### PR TITLE
feat: show demo credentials on the login screen in demo mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,14 @@ JWT_SECRET=replace-me-with-openssl-rand-base64-48
 USER_EMAIL=you@example.com
 USER_PASSWORD=change-me-immediately
 
+# Public demo mode: when "true", the login page shows the demo credentials below
+# with a one-click "Log in as demo" button. Leave unset for normal instances.
+# These are NEXT_PUBLIC_* (exposed to the browser) so only use them on a public
+# demo instance with throwaway credentials.
+NEXT_PUBLIC_DEMO_MODE=false
+NEXT_PUBLIC_DEMO_EMAIL=demo@gymcoach.app
+NEXT_PUBLIC_DEMO_PASSWORD=gymcoachdemo
+
 # --- AI coach ---
 # Choose the LLM provider: "anthropic" (default), "openrouter", or "demo".
 # "demo" returns canned responses with no API key, handy to try the AI screens.

--- a/components/auth/login-form.test.tsx
+++ b/components/auth/login-form.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// The router is irrelevant to these assertions; stub it so the component mounts.
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn(), refresh: vi.fn() }),
+}));
+
+// The demo flag/credentials are read at module load, so re-import after stubbing.
+async function renderForm() {
+  vi.resetModules();
+  const { LoginForm } = await import('./login-form');
+  return render(<LoginForm />);
+}
+
+describe('LoginForm demo banner', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('does not render the demo banner when NEXT_PUBLIC_DEMO_MODE is unset', async () => {
+    await renderForm();
+    expect(screen.queryByText('Demo account')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /log in as demo/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the demo credentials and logs in with one click when demo mode is on', async () => {
+    vi.stubEnv('NEXT_PUBLIC_DEMO_MODE', 'true');
+    vi.stubEnv('NEXT_PUBLIC_DEMO_EMAIL', 'demo@gymcoach.app');
+    vi.stubEnv('NEXT_PUBLIC_DEMO_PASSWORD', 'gymcoachdemo');
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({}) });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await renderForm();
+
+    expect(screen.getByText('Demo account')).toBeInTheDocument();
+    expect(
+      screen.getByText('demo@gymcoach.app / gymcoachdemo'),
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /log in as demo/i }),
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/auth/login',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          email: 'demo@gymcoach.app',
+          password: 'gymcoachdemo',
+        }),
+      }),
+    );
+  });
+});

--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -24,6 +24,13 @@ const schema = z.object({
 
 type FormValues = z.infer<typeof schema>;
 
+// Public demo flag and credentials, inlined at build time. When the flag is on
+// (e.g. on a public demo instance) the login page surfaces a one-click sign in.
+const demoMode = process.env.NEXT_PUBLIC_DEMO_MODE === 'true';
+const demoEmail = process.env.NEXT_PUBLIC_DEMO_EMAIL ?? '';
+const demoPassword = process.env.NEXT_PUBLIC_DEMO_PASSWORD ?? '';
+const showDemo = demoMode && demoEmail !== '' && demoPassword !== '';
+
 export function LoginForm() {
   const router = useRouter();
   const [serverError, setServerError] = useState<string | null>(null);
@@ -31,11 +38,19 @@ export function LoginForm() {
   const {
     register,
     handleSubmit,
+    setValue,
     formState: { errors, isSubmitting },
   } = useForm<FormValues>({
     resolver: zodResolver(schema),
     defaultValues: { email: '', password: '' },
   });
+
+  async function loginAsDemo() {
+    // Prefill the fields for visible feedback, then submit the demo credentials.
+    setValue('email', demoEmail);
+    setValue('password', demoPassword);
+    await onSubmit({ email: demoEmail, password: demoPassword });
+  }
 
   async function onSubmit(values: FormValues) {
     setServerError(null);
@@ -62,6 +77,23 @@ export function LoginForm() {
         <CardDescription>Access your training log.</CardDescription>
       </CardHeader>
       <CardContent>
+        {showDemo && (
+          <div className="mb-4 space-y-2 rounded-md border border-dashed bg-muted/50 p-3">
+            <p className="text-sm font-medium">Demo account</p>
+            <p className="text-sm text-muted-foreground">
+              {demoEmail} / {demoPassword}
+            </p>
+            <Button
+              type="button"
+              variant="secondary"
+              className="min-h-tap w-full"
+              onClick={loginAsDemo}
+              disabled={isSubmitting}
+            >
+              {isSubmitting ? 'Signing in...' : 'Log in as demo'}
+            </Button>
+          </div>
+        )}
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
           <div className="space-y-2">
             <Label htmlFor="email">Email</Label>


### PR DESCRIPTION
When NEXT_PUBLIC_DEMO_MODE is true and demo credentials are configured, the login page renders a banner with the demo email/password and a one-click "Log in as demo" button. No effect when the flag is unset.

Closes #2

## Summary

<!-- What does this change and why? -->

## How was it tested?

<!-- Commands run, scenarios covered. -->

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test`
- [ ] `npm run build`
- [ ] Integration / E2E if relevant

## Notes

<!-- Anything reviewers should pay attention to. -->
