### PR TITLE
docs: add CHANGELOG.md and link it from the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Multi-user accounts: registration, profiles, per-user data isolation, and
+  rate limiting.
+- Workout logging with sets, reps, RIR, warmups, and drop sets.
+- Progress charts and estimated 1RM tracking.
+- Pluggable LLM provider: Anthropic SDK or any OpenRouter model, switchable via
+  the `LLM_PROVIDER` environment variable.
+- AI program generation from a natural-language goal, with Zod-validated output.
+- Streaming conversational AI coach that uses your training context.
+- `demo` LLM provider with canned responses (no API key) plus demo media for the
+  AI flows, so the app and live demo work without a real key.
+- Test pyramid (unit, integration, E2E) with CI running lint, typecheck, unit,
+  integration, build, and E2E on every pull request.
+- Docker and Docker Compose setup for local development and production.
+
+### Changed
+
+- Migrated the entire codebase (UI, comments, prompts, docs) from French to
+  English.
+- Bootstrapped the autonomous-loop maintenance infrastructure: the green-gate
+  (`scripts/verify.sh`), the `implement-issue` skill, and the loop playbook in
+  `docs/loops/`.
+
+### Fixed
+
+- Mapped the popover color token so dropdown menus render opaque instead of
+  transparent.
+- Used a literal `DATABASE_URL` in the E2E CI job environment.
+
+[Unreleased]: https://github.com/Julien-Au/gymcoach/commits/main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multi-user accounts: registration, profiles, per-user data isolation, and
   rate limiting.
 - Workout logging with sets, reps, RIR, warmups, and drop sets.
-- Progress charts and estimated 1RM tracking.
+- Progress charts, estimated 1RM (Epley) tracking, and bodyweight-aware tonnage
+  for movements like pull-ups and dips.
+- Installable PWA with offline-first session logging (IndexedDB + background
+  sync) and a screen wake lock during sessions.
 - Pluggable LLM provider: Anthropic SDK or any OpenRouter model, switchable via
   the `LLM_PROVIDER` environment variable.
 - AI program generation from a natural-language goal, with Zod-validated output.

--- a/README.md
+++ b/README.md
@@ -214,7 +214,8 @@ docker compose -f docker-compose.prod.yml exec app npx prisma migrate deploy
 ## Contributing
 
 Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup,
-conventions and the test commands.
+conventions and the test commands. Notable changes are tracked in the
+[CHANGELOG](CHANGELOG.md).
 
 ## License
 


### PR DESCRIPTION
Adds a `CHANGELOG.md` in [Keep a Changelog](https://keepachangelog.com) format, backfilled from the git history into an `Unreleased` section grouped Added / Changed / Fixed (no release tags exist yet, so everything is unreleased). The README's Contributing section now links to it.

Closes #3

## How I tested
- `bash scripts/verify.sh` -> GREEN-GATE PASSED (prisma generate + lint + typecheck + unit + build).
- Verified the README link target resolves to `CHANGELOG.md` at the repo root.
- Confirmed the bodyweight-tonnage and offline-PWA entries against the code (`lib/stats.ts`, `lib/indexeddb.ts`, `lib/wake-lock.ts`, `public/manifest.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)