### PR TITLE
feat(loops): triage, ship, and content loops for end-to-end autonomy

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,6 +29,8 @@
       "Bash(git push origin *)",
       "Bash(gh pr *)",
       "Bash(gh issue *)",
+      "Bash(gh run *)",
+      "Bash(gh search *)",
       "Bash(ls *)",
       "Bash(cat *)",
       "Bash(find *)",

--- a/.claude/skills/ship-pr/SKILL.md
+++ b/.claude/skills/ship-pr/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: ship-pr
+description: Drive one open PR to merged. Wait for CI, fix red checks (bounded retries), self-review the diff, and auto-merge (squash) once CI is green and review is clean. Use when asked to "ship PR N", "merge the green PRs", or as the unit the shipping loop calls. Never merges on a red gate.
+---
+
+# ship-pr
+
+The shipping half of the pipeline. `implement-issue` opens PRs; this skill takes **one**
+open PR from "opened" to "merged", autonomously. It is the reusable unit behind the
+CI-watch and auto-merge loops. Read `CLAUDE.md` first.
+
+**Autonomy boundary (decided):** auto-merge is allowed **only** when CI is green and the
+self-review is clean. The green CI is the trust boundary - never merge around it, never
+merge on a red or pending gate, never merge a PR a human has marked as draft or requested
+changes on.
+
+## Input
+
+- A PR number, OR "ship the ready PRs" (then operate on each open, non-draft PR that
+  targets `main` and is authored by the loop).
+
+## Procedure (per PR)
+
+1. **Load state.**
+   `gh pr view <n> --json number,title,headRefName,isDraft,mergeable,reviewDecision,state`.
+   Skip immediately if: draft, `state != OPEN`, `reviewDecision == CHANGES_REQUESTED`,
+   or not targeting `main`. Report why it was skipped.
+
+2. **Watch CI.** `gh pr checks <n> --watch` (blocks until checks settle), or poll
+   `gh pr checks <n>`. Three outcomes:
+   - **All green** -> go to step 4 (review).
+   - **Some red** -> step 3 (fix).
+   - **Stuck pending** for an unreasonable time -> stop, report; do not merge.
+
+3. **Fix a red gate (bounded).** Reproduce locally with the matching green-gate tier:
+   `bash scripts/verify.sh` for lint/type/unit/build, `--full` for integration/E2E.
+   - `gh run view --log-failed` on the failing run to see the real error.
+   - Check out the PR branch (`gh pr checkout <n>`), fix the **cause**, re-run the gate,
+     commit (Conventional Commit, e.g. `fix(ci): ...`), and push.
+   - **At most 3 fix attempts.** If still red after 3: do not merge. Leave a comment
+     summarizing the blocker (`gh pr comment <n> --body ...`), mark the PR draft if
+     appropriate, and STOP. A human looks.
+
+4. **Self-review the diff.** Run the `code-review` skill (or review `gh pr diff <n>`
+   directly) for correctness and convention bugs. If it surfaces a real defect, treat it
+   like a red gate: fix on the branch (counts against the 3 attempts), re-verify, push.
+   Cosmetic-only nits do not block a merge.
+
+5. **Merge.** Only if CI is green AND review is clean:
+   `gh pr merge <n> --squash --delete-branch`. Confirm it merged
+   (`gh pr view <n> --json state,mergedAt`).
+
+6. **Report.** PR -> merged (with the merge commit), or skipped/blocked with the reason.
+
+## Guardrails
+
+- Never `gh pr merge` while any required check is red or pending.
+- Never merge a draft, a `CHANGES_REQUESTED` PR, or one not targeting `main`.
+- At most 3 fix attempts per PR; then stop and hand off.
+- Per run, ship at most the PRs you were given (or cap "ship the ready PRs" at a small
+  batch so a bad change cannot cascade). One merge at a time; re-check the next PR's CI
+  after each merge in case `main` moved.
+- Inherited deny-list still applies (no force-push, no hard reset).
+
+## What success looks like
+
+Open PRs that are genuinely ready (green CI, clean review) become squash-merged commits
+on `main` with their branch deleted - with no human click. Anything uncertain stops and
+asks. The green gate, not optimism, decides.

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: triage
+description: Keep the backlog fed. Survey the repo for real, actionable work (code TODOs, coverage gaps, roadmap items, small bugs, stale deps) and file well-scoped GitHub issues so the Issue -> PR loop never starves. Use when asked to "triage", "refill the backlog", or when no actionable issue is left.
+---
+
+# triage
+
+The Issue -> PR loop stops when there is "no actionable issue left". Triage is the
+loop that **prevents that** by manufacturing well-scoped work from the state of the
+repo. It is the head of the pipeline. Read `CLAUDE.md` first for conventions.
+
+The output is **issues, not code.** One run files a small batch of focused issues a
+later `implement-issue` run can pick up unattended.
+
+## Guardrails (so it does not spam the tracker)
+
+- File **at most 3 issues** per run.
+- Before filing, list open issues (`gh issue list --state open --limit 50 --json number,title`)
+  and **do not duplicate** an existing one (match on intent, not exact title).
+- Every issue must be **small, self-contained, and verifiable** by the green-gate -
+  the kind `implement-issue` can finish in one PR. No epics, no vague "improve X".
+- If you cannot find 3 genuinely useful, non-duplicate items, file fewer. Filing
+  nothing is a valid, good outcome - say so. Never invent busywork.
+
+## Where real work comes from (sweep these, in order)
+
+1. **Code markers** - `grep -rn "TODO\|FIXME\|HACK\|XXX" app lib components --include=*.ts --include=*.tsx`.
+   Each concrete marker is a candidate.
+2. **Roadmap gaps** - the unchecked items in the README "Roadmap" section.
+3. **Test coverage holes** - modules in `lib/` with logic but no colocated `*.test.ts`,
+   or API routes with no integration test in `tests/`.
+4. **Small UX/polish** - empty states, error states, loading states that are missing
+   (only file if concrete and locatable).
+5. **Dependency hygiene** - `npm outdated` for clearly safe minor/patch bumps, or a
+   flagged advisory from `npm audit`. One issue per coherent group, not per package.
+
+Prefer the source that yields the most concrete, lowest-ambiguity item. A good triage
+issue names the file(s) and the acceptance check.
+
+## Procedure
+
+1. **Start clean** on `main` (`git switch main && git pull --ff-only`). Triage reads;
+   it does not branch or edit code.
+2. **Sweep** the sources above until you have up to 3 strong candidates.
+3. **De-dupe** against open issues and against each other.
+4. **Write each issue** with this shape:
+   - Title: imperative, conventional-ish (e.g. "Add coverage for `lib/progression.ts`").
+   - Body: **Context** (what/where, with file paths), **Acceptance criteria** (a
+     bulleted, checkable list the green-gate or a reviewer can confirm), and the
+     label `good first issue` when it genuinely is one.
+   - File it: `gh issue create --title "..." --body "..." --label "good first issue"`.
+5. **Report** the new issue numbers + one line each, and what you deliberately skipped
+   (e.g. "3 TODOs found but all need a product decision -> left for human").
+
+## Stop conditions
+
+- Nothing actionable and non-duplicate found -> file nothing, report "backlog healthy".
+- An item needs a product/design decision -> do NOT file a half-baked issue; report it
+  for a human to scope.
+- Already 3 issues filed this run -> stop.
+
+## What success looks like
+
+A handful of crisp, non-duplicate, single-PR-sized issues that a later `implement-issue`
+run can pick up with zero extra context. Triage feeds the machine; it never merges or
+writes product code.

--- a/.claude/skills/write-up/SKILL.md
+++ b/.claude/skills/write-up/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: write-up
+description: Turn shipped work into the public story. After PRs merge, update the CHANGELOG and the docs/loops playbook so the "this repo maintains itself" narrative stays current and reproducible. Use when asked to "write up the démarche", "update the changelog", or as the unit the content loop calls.
+---
+
+# write-up
+
+The tail of the pipeline and the actual growth engine. The product is the gym app; the
+**story** - "this repo maintains itself with documented loops" - is what earns stars.
+This skill keeps that story current and truthful after work ships. Read `CLAUDE.md`.
+
+It writes **docs only** (CHANGELOG, `docs/loops/*`, README touch-ups). It never touches
+product code. Output is one focused docs PR via `implement-issue` conventions, or a
+commit on an existing docs branch.
+
+## Inputs
+
+- A set of recently merged PRs / closed issues (default: since the last CHANGELOG entry).
+  Find them: `gh pr list --state merged --limit 20 --json number,title,mergedAt` and
+  `git log --oneline origin/main` since the last documented change.
+
+## What to keep current
+
+1. **CHANGELOG.md** - move shipped, user-facing changes into the right `Unreleased`
+   group (Added / Changed / Fixed). One terse line per change, no marketing. Skip
+   internal-only churn unless it is itself the story (loop infra often is).
+2. **docs/loops/** - when a *new loop or skill* shipped, add or update its numbered
+   playbook entry so anyone can reproduce it. The playbook is the content; keep it
+   honest (document what actually runs, including failure modes you hit).
+3. **README** - only when a user-facing capability or the loop narrative changed enough
+   to matter (features list, roadmap checkboxes). Keep edits minimal.
+
+## Procedure
+
+1. **Start clean** on `main` (`git switch main && git pull --ff-only`), branch
+   `docs/<slug>`.
+2. **Gather** the merged work since the last write-up. Map each item to a CHANGELOG
+   group and decide if it warrants a playbook/README change. **Verify each claim against
+   the code or the merged diff** - never document a feature that is not actually there
+   (this skill exists partly because a changelog drifts otherwise).
+3. **Write** the smallest accurate edits. English only, regular hyphens (no em/en-dash),
+   Keep a Changelog format.
+4. **Green-gate** (`bash scripts/verify.sh`) - docs-only, but the working agreement is
+   the working agreement.
+5. **Commit, push, PR** with `Closes #<n>` if a content issue exists, else a plain docs
+   PR. The shipping loop (`ship-pr`) will merge it once CI is green.
+6. **Report** what was documented and what was intentionally left out.
+
+## Guardrails
+
+- Truth over hype: every changelog/README claim is checked against merged code.
+- Docs only - no product code, no merges (let `ship-pr` merge it).
+- Do not document unmerged work as shipped (it belongs in the PR, not `main`'s story).
+
+## What success looks like
+
+The CHANGELOG and the `docs/loops/` playbook always reflect what actually shipped, so the
+public démarche is current, reproducible, and trustworthy - the thing that compounds into
+stars while the loops do the typing.

--- a/docs/loops/03-triage-loop.md
+++ b/docs/loops/03-triage-loop.md
@@ -1,0 +1,44 @@
+# 03 — The triage loop (keep the backlog fed)
+
+The Issue -> PR loop has a fatal flaw on its own: it stops when there is "no actionable
+issue left". A self-maintaining repo cannot wait for a human to write issues. The triage
+loop is the **head of the pipeline** - it manufactures well-scoped work from the state of
+the repo so the machine never starves.
+
+## The body is one sentence
+
+> survey the repo for real, actionable work -> file up to 3 focused issues -> stop.
+
+The discipline lives in the `triage` skill (`.claude/skills/triage/`): where to look
+(code TODOs, roadmap gaps, coverage holes, small UX/polish, dep hygiene), how to scope
+(small, self-contained, green-gate-verifiable), and how not to spam (de-dupe against open
+issues, cap at 3, file nothing rather than invent busywork).
+
+## Running it
+
+```
+/loop Run the triage skill. Find real, non-duplicate, single-PR-sized work and file at
+most 3 issues. If the backlog is already healthy, file nothing and say so. STOP after
+one triage pass.
+```
+
+## The three hard stops
+
+1. **Max output** - at most 3 issues per run.
+2. **No-progress / no-invention** - nothing actionable and non-duplicate found means file
+   nothing. Triage must be allowed to do nothing; that is the guardrail against a tracker
+   full of make-work.
+3. **Budget ceiling** - a token target on the turn, like every loop.
+
+## Why issues, not code
+
+Triage deliberately stops at the issue. Separating *deciding what to do* from *doing it*
+keeps each loop sharp and each unit tested: the triage loop's output (a crisp issue) is
+exactly the Issue -> PR loop's input. Two simple loops that compose beat one loop that
+tries to do both and does neither well.
+
+## How it chains
+
+`triage` (this) -> `implement-issue` (`02`) -> `ship-pr` (`04`) -> `write-up` (`05`). The
+orchestration loop (`06`) runs triage only when the backlog is low, so the tracker stays
+useful instead of flooded.

--- a/docs/loops/04-ship-loop.md
+++ b/docs/loops/04-ship-loop.md
@@ -1,0 +1,55 @@
+# 04 — The ship loop (CI-watch + auto-merge)
+
+`implement-issue` opens a PR and then, by design, stops: "never merge - a human reviews".
+That human is the last manual step in the pipeline. The ship loop removes it **safely**:
+it watches the PR's CI, fixes a red gate within bounds, self-reviews the diff, and
+**auto-merges on green**. This is the shipping half - the CI-watch and merge stages of the
+pipeline, in one reusable skill (`.claude/skills/ship-pr/`).
+
+## The autonomy boundary (the decision that defines this loop)
+
+Auto-merge is allowed **only** when CI is green and the self-review is clean. The green CI
+is the trust boundary. The loop never merges around it:
+
+- never merge while a required check is **red or pending**;
+- never merge a **draft**, a `CHANGES_REQUESTED` PR, or one not targeting `main`;
+- PRs only - nothing ever lands on `main` directly;
+- the inherited deny-list (no force-push, no hard reset) still holds.
+
+This is why local-only verification is not enough: `scripts/verify.sh` covers
+lint/type/unit/build, but integration + E2E run **only in CI**. The ship loop is where the
+full gate actually gates a merge.
+
+## The body is one sentence
+
+> for each ready PR: watch CI -> if red, fix (<=3 tries) -> self-review -> merge on green.
+
+## Running it
+
+```
+/loop Run the ship-pr skill on the open, non-draft PRs that target main. Watch CI, fix a
+red gate up to 3 times, self-review, and squash-merge any PR that is green and clean.
+STOP when there are no ready PRs, or a PR is still red after 3 fix attempts (leave a
+comment and move on). Never merge on a red or pending gate.
+```
+
+## The three hard stops
+
+1. **Max fix attempts** - 3 per PR, then comment the blocker and stop. No thrashing on a
+   genuinely broken change.
+2. **No-progress detection** - a stuck-pending CI or a PR that fails the skip checks is
+   reported, not forced through.
+3. **Budget ceiling** - token target on the turn.
+
+## Fixing a red gate
+
+Reproduce locally with the matching gate tier (`bash scripts/verify.sh`, or `--full` for
+integration/E2E), read the real error with `gh run view --log-failed`, fix the **cause**
+on the PR branch, re-verify, push. Each fix counts against the 3-attempt budget so a
+flaky-looking failure cannot loop forever.
+
+## How it chains
+
+`implement-issue` (`02`) and `write-up` (`05`) both produce PRs; the ship loop merges
+both. After each merge it re-checks the next PR's CI, because `main` just moved. Merged
+work then becomes the raw material for the content loop (`05`).

--- a/docs/loops/05-content-loop.md
+++ b/docs/loops/05-content-loop.md
@@ -1,0 +1,48 @@
+# 05 — The content loop (publish the démarche)
+
+The product is the gym app. The **growth engine** is the meta-story: *this repo maintains
+itself with documented loops.* That story only compounds into stars if it stays current
+and true. The content loop is the tail of the pipeline: after work ships, it updates the
+CHANGELOG and the `docs/loops/` playbook so the démarche keeps pace with reality. The unit
+is the `write-up` skill (`.claude/skills/write-up/`).
+
+## The body is one sentence
+
+> gather what merged since the last write-up -> update CHANGELOG + playbook (truthfully)
+> -> open a docs PR.
+
+## Running it
+
+```
+/loop Run the write-up skill. Look at what merged to main since the last CHANGELOG entry,
+move the user-facing changes into the right Unreleased group, and update docs/loops if a
+new loop or skill shipped. Verify every claim against the merged code. Open one docs PR.
+STOP after one write-up.
+```
+
+## Truth is the only feature
+
+A changelog that drifts is worse than none - it makes the whole "self-maintaining"
+narrative look fake. So the one rule that overrides everything: **every claim is checked
+against merged code or the merged diff before it is written.** No documenting unmerged
+work as shipped; no marketing adjectives; skip internal churn unless the infrastructure
+*is* the story (here, it often is).
+
+## The three hard stops
+
+1. **Max output** - one docs PR per run.
+2. **No-progress detection** - nothing user-facing merged since the last write-up means
+   write nothing and say so.
+3. **Budget ceiling** - token target on the turn.
+
+## Docs only, and it does not merge itself
+
+The content loop writes only docs (CHANGELOG, `docs/loops/*`, minimal README touch-ups)
+and opens a PR like any other change. The ship loop (`04`) merges it once CI is green.
+Same discipline as everything else: one small, verified change; the gate decides.
+
+## How it chains
+
+It reads the output of `ship-pr` (`04`) - the merged commits - and feeds the public story.
+Closing the circle: triage finds work, implement does it, ship merges it, write-up tells
+the world, and the telling brings the contributors who file the next issues.

--- a/docs/loops/06-orchestration.md
+++ b/docs/loops/06-orchestration.md
@@ -1,0 +1,76 @@
+# 06 — Orchestration (the self-maintaining repo)
+
+The first five files built the **stages**: triage finds work, implement does it, ship
+merges it, write-up tells the story. Each is a small loop calling a tested skill. This
+file ties them into one **maintainer loop** that runs the whole pipeline end to end - the
+thing that lets the repo maintain itself while you sleep.
+
+```
+        +-----------------------------------------------------------+
+        |                    maintainer loop                        |
+        |                                                           |
+        v                                                           |
+  triage (03) --> implement-issue (02) --> ship-pr (04) --> write-up (05)
+   refill if          one issue              merge every        tell the
+   backlog low        -> one PR              green PR           story
+        ^                                                           |
+        +-----------------------------------------------------------+
+                 git + GitHub hold the state between ticks
+```
+
+## The decision-maker in the body
+
+A cron job runs a fixed script; a loop runs a model that **looks at current state and
+decides what to do next**. The maintainer loop's decision each tick:
+
+1. **Are there ready PRs?** (green or fixable CI) -> ship them first. Shipping finishes
+   started work and moves `main` forward; always drain this before starting new work.
+2. **Is the backlog low** (no actionable, unclaimed issue)? -> run triage to refill.
+3. **Is there an actionable issue?** -> implement the next one (-> a PR, which next tick's
+   step 1 will ship).
+4. **Did things merge since the last write-up?** -> run the content loop.
+5. **Nothing to do on any of the above?** -> stop. A clean idle is success, not failure.
+
+Order matters: finish before you start (ship before implement), and only manufacture work
+(triage) when genuinely starved, so the tracker and the PR queue never flood.
+
+## Running it
+
+Phase 1 - watched, locally:
+
+```
+/loop You are the maintainer of this repo. Each tick: (1) ship any ready PR with ship-pr;
+(2) if the backlog is low, run triage; (3) implement the next actionable issue with
+implement-issue; (4) if work merged since the last write-up, run write-up. Respect every
+skill's own guardrails. STOP when there is nothing to ship, no actionable issue, and
+nothing to document - or after 3 merges this run. Auto-merge only on green CI; never on
+main directly.
+```
+
+Phase 2 - unattended, on infrastructure:
+
+- Flip `.claude/settings.json` to `bypassPermissions` for the cron run (it cannot pause to
+  ask). Keep the **deny-list** - it still blocks the destructive ops.
+- `/schedule` the same prompt nightly. State lives in git (one branch per task) and on
+  GitHub (issues + PRs), so a crash mid-run loses nothing; the next tick re-reads reality
+  and continues.
+
+## The four rules, at the orchestration level
+
+1. **Feedback** - every stage self-verifies (green-gate locally, **CI before merge**).
+   Nothing lands on optimism.
+2. **Skills, not prompts** - the maintainer loop is thin glue; all discipline lives in the
+   four tested skills. Tighten a skill when you see a failure mode; every loop benefits.
+3. **It must halt** - each stage caps its output (3 issues, 1 issue->PR, 3 fix attempts, 1
+   docs PR) and the maintainer caps merges per run and stops on a clean idle. Three layers
+   of stop.
+4. **Durability** - the only state that matters is in git and on GitHub. The session is
+   disposable; the pipeline is resumable.
+
+## What "autonomous end to end" actually means here
+
+A human still owns *what the project is for* - the vision, the hard product calls, the
+occasional "this PR needs a human". Everything mechanical between "there is work" and "it
+is shipped and documented" runs without a click. The job moved up an altitude: from
+writing the code to **authoring the loops that write it** - and this file is the loop that
+runs the loops.

--- a/docs/loops/README.md
+++ b/docs/loops/README.md
@@ -13,21 +13,37 @@ This folder is the reproducible playbook. Read in order:
   (`.claude/settings.json`), and a reusable skill.
 - [`02-issue-to-pr-loop.md`](02-issue-to-pr-loop.md) - the flagship loop that turns
   open issues into pull requests, its guardrails, and how it graduates to the cloud.
+- [`03-triage-loop.md`](03-triage-loop.md) - the head of the pipeline: manufacture
+  well-scoped issues so the Issue -> PR loop never starves.
+- [`04-ship-loop.md`](04-ship-loop.md) - the shipping half: watch CI, fix a red gate,
+  self-review, and auto-merge on green. Where the full gate actually gates a merge.
+- [`05-content-loop.md`](05-content-loop.md) - the tail: keep the CHANGELOG and this
+  playbook true to what shipped. The growth engine.
+- [`06-orchestration.md`](06-orchestration.md) - the maintainer loop that runs all the
+  stages end to end, and how it graduates to a nightly cron.
 
 ## The system at a glance
 
 ```
-/loop (cron + decision-maker)
-   |
-   v
-implement-issue  (the reusable skill: branch -> code -> test -> PR)
-   |
-   v
-scripts/verify.sh  (the green-gate: lint + typecheck + unit + build)   <- feedback
-   |
-   v
-green PR that closes an issue   ->   a human reviews and merges
+            maintainer loop (06): cron + a decision-maker each tick
+                                  |
+   +----------------+------------+------------+-----------------+
+   v                v                         v                 v
+ triage (03)   implement-issue (02)      ship-pr (04)      write-up (05)
+ refill the    one issue -> one PR       watch CI, fix     CHANGELOG +
+ backlog       (branch->code->test)      red, self-review, playbook stay
+ when low                                auto-merge GREEN  true to reality
+   |                |                         |                 |
+   +----------------+------------+------------+-----------------+
+                                  |
+                    scripts/verify.sh + CI = the feedback gate
+                    (nothing merges on a red or pending gate)
+                                  |
+                    state lives in git + GitHub, not the session
 ```
+
+The pipeline is **generate work -> do work -> verify in CI -> ship -> tell the story**.
+Each stage is a small loop calling one tested skill; `06` is the loop that runs them.
 
 ## The four rules we never break
 


### PR DESCRIPTION
Completes the self-maintenance pipeline. The repo had the foundations + one loop (Issue -> PR); this adds the missing stages on both ends so it maintains itself end to end:

```
generate work -> do work -> verify in CI -> ship -> tell the story
  (triage)      (issue->PR)  (ci-watch)   (merge)  (demarche)
```

**New skills** (`.claude/skills/`)
- `triage` - survey the repo (TODOs, coverage gaps, roadmap, dep hygiene) and file up to 3 well-scoped issues so the pipeline never starves. Files nothing rather than invent busywork.
- `ship-pr` - drive one open PR to merged: watch CI, fix a red gate (<=3 attempts), self-review, and **auto-merge (squash) on green**.
- `write-up` - keep the CHANGELOG and `docs/loops/` playbook true to what shipped (the growth engine).

**New playbook docs** (`docs/loops/`)
- `03-triage-loop`, `04-ship-loop`, `05-content-loop`, and `06-orchestration` (the maintainer loop that runs every stage), plus an updated README/diagram.

**Autonomy boundary (decided):** auto-merge **only** on green CI; PRs only (never `main` directly); never merge a red/pending/draft/changes-requested PR; deny-list still blocks force-push and hard reset. CI is the trust boundary - and since integration + E2E run only in CI, the ship loop is where the full gate actually gates a merge.

Closes #8

## How I tested
- `bash scripts/verify.sh` -> GREEN-GATE PASSED (prisma generate + lint + typecheck + unit + build).
- `.claude/settings.json` validated as JSON; allow-list extended with `gh run *` / `gh search *`.
- Skills load (visible in the skill registry as `triage`, `ship-pr`, `write-up`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)