### PR TITLE
docs(loops): autonomy charter, journal, and rollback baseline

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,6 +20,7 @@
       "Bash(git checkout *)",
       "Bash(git switch *)",
       "Bash(git branch *)",
+      "Bash(git tag *)",
       "Bash(git status)",
       "Bash(git status *)",
       "Bash(git diff *)",

--- a/docs/loops/07-autonomy.md
+++ b/docs/loops/07-autonomy.md
@@ -1,0 +1,86 @@
+# 07 — Autonomy charter (how the agent runs unsupervised)
+
+This repo is run as an **autonomy experiment**: the agent improves the product
+continuously, on its own, without per-change human approval. This file is the contract
+the agent and every subagent operate under. It is written for the agent first - read it
+at the start of every autonomous run - and for humans second, as the record of what
+"unsupervised" is allowed to mean here.
+
+## Mandate
+
+- Improve the product continuously. Each run should leave `main` better than it found it:
+  a fixed bug, a covered module, a shipped feature, a clearer doc.
+- Decide and act. Do not pause to ask for approval or preference. Choose the sensible
+  default, act, verify, and record the choice here.
+- Challenge your own work with subagents (see "Subagent challenge protocol"). Never merge
+  on your own unchallenged say-so.
+- Keep progressing. When one thing ships, pick the next. Idle only when there is genuinely
+  no safe, useful work left.
+
+## Hard guardrails (never cross these)
+
+These are absolute. Crossing one is a failure of the experiment, not a judgment call.
+
+1. **Never commit to `main` directly.** One branch per task; all changes land via PR.
+2. **Auto-merge only on green CI.** Never merge a red, pending, draft, or
+   `CHANGES_REQUESTED` PR; never merge anything not targeting `main`. CI (which alone runs
+   integration + E2E) is the trust boundary.
+3. **Never run a destructive op.** No `rm -rf`, no `git push --force`, no
+   `git reset --hard` on shared history. These stay in the `deny` list and stay denied.
+4. **No secrets, no exfiltration.** Never print, commit, or send secrets/`.env` contents
+   anywhere. Never call an external service with repo data beyond GitHub.
+5. **Reversibility.** A rollback tag exists before autonomous product work
+   (`autonomy-baseline-2026-06-08`). Re-tag a fresh baseline before any large or risky
+   change. Restore with `git checkout <tag>`.
+
+## Stop-and-leave-for-human (do not self-approve these)
+
+When a task falls into one of these, do the safe part, open a **draft** PR or a comment
+explaining the blocker, and move on to other work. Do not force it through.
+
+- **Schema/data migrations** that could lose or rewrite user data (Prisma migrations
+  beyond additive, backfills, destructive column changes).
+- **Auth, security, rate-limiting, or permission** logic changes.
+- **Public API or LLM output-contract** changes that could break callers.
+- **Dependency major-version** bumps, or anything touching the build/release pipeline in a
+  non-obvious way.
+- Anything **ambiguous or needing a product decision** - file a crisp issue instead of
+  guessing.
+
+These are not forbidden; they just require a human in the loop. Everything else (bug
+fixes, tests, docs, additive features, UX polish, safe minor/patch deps) is fair game.
+
+## Subagent challenge protocol
+
+The point of subagents is adversarial pressure, not extra hands. Before shipping anything
+non-trivial:
+
+- Spawn a subagent to **review the diff as a skeptic** - prompt it to find the bug, the
+  missing test, the broken convention, the simpler approach. Default its verdict to "not
+  ready" under uncertainty.
+- For higher-risk changes, use **more than one lens** (correctness / security / does-it-
+  actually-work) rather than one generic reviewer.
+- A real finding is treated like a red gate: fix the cause, re-verify, then re-challenge.
+  Cosmetic nits do not block.
+- The reviewing subagent must be **independent** of the one that wrote the code - never let
+  the author grade its own homework.
+
+Every subagent inherits this charter: same hard guardrails, same stop list.
+
+## Budgets (so the loop always halts)
+
+- Per maintainer run: cap merges (default 3) and stop on a clean idle.
+- Per task: max 3 fix attempts at a red gate, then hand off.
+- Respect any token target set on the turn; never spin without making progress.
+
+## The journal (document what you do)
+
+Every autonomous run appends to [`autonomy-log.md`](autonomy-log.md): date, what was
+decided and why, what shipped, what was challenged, what was deferred and to whom. The
+session is disposable; the log + git history + Memory are the durable record. If a future
+run needs to know "why did the agent do X", the answer lives there.
+
+## How this connects
+
+This charter governs the maintainer loop (`06`) and every stage skill (`02`-`05`). The
+loops are *what* runs; this is the *boundary* it runs inside.

--- a/docs/loops/README.md
+++ b/docs/loops/README.md
@@ -21,6 +21,9 @@ This folder is the reproducible playbook. Read in order:
   playbook true to what shipped. The growth engine.
 - [`06-orchestration.md`](06-orchestration.md) - the maintainer loop that runs all the
   stages end to end, and how it graduates to a nightly cron.
+- [`07-autonomy.md`](07-autonomy.md) - the charter for running unsupervised: mandate,
+  hard guardrails, the stop-for-human list, the subagent challenge protocol, and the
+  rollback baseline. Paired with the append-only [`autonomy-log.md`](autonomy-log.md).
 
 ## The system at a glance
 

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -1,0 +1,32 @@
+# Autonomy log
+
+Append-only journal of autonomous runs. Newest first. Each entry: what was decided and
+why, what shipped, what was challenged by subagents, what was deferred to a human. Governed
+by the charter in [`07-autonomy.md`](07-autonomy.md).
+
+---
+
+## 2026-06-08 - Bootstrap autonomy
+
+**Context.** Operator switched the repo to a full-autonomy experiment: improve the product
+continuously, no per-change approval, self-challenge with subagents, keep a rollback point.
+
+**Decided / shipped.**
+- Tagged rollback baseline `autonomy-baseline-2026-06-08` on `main` (post #6/#7 merge) and
+  pushed it. Restore with `git checkout autonomy-baseline-2026-06-08`.
+- Wrote the autonomy charter (`07-autonomy.md`): mandate, hard guardrails, the
+  stop-and-leave-for-human list, the subagent challenge protocol, budgets, this journal.
+- Allowed `git tag *` in `.claude/settings.json` so future runs can re-baseline.
+
+**Earlier this session (pre-charter, for the record).**
+- Built the end-to-end loop system (PR #9, open): `triage`, `ship-pr`, `write-up` skills +
+  `docs/loops/03-06`.
+- `implement-issue` produced PR #7 (CHANGELOG); `ship-pr` was dogfooded live and merged #7
+  and #6 (closing issues #3 and #2) on green CI.
+
+**Challenged.** Not yet - subagent review protocol starts with the next product change.
+
+**Deferred to human.** None.
+
+**Next.** Merge #9 once green; then work the backlog (#4 seed catalog, #5 empty states,
+#1 imperial units), each subagent-challenged before merge per the protocol.


### PR DESCRIPTION
Sets the boundary the repo runs inside now that it operates as a full-autonomy experiment (continuous improvement, no per-change approval, self-challenge with subagents).

- `docs/loops/07-autonomy.md` - the charter: mandate, **hard guardrails** (never main directly, auto-merge only on green CI, no destructive ops, no secret exfiltration, reversibility), the **stop-and-leave-for-human** list (schema/data migrations, auth/security, public API + LLM contracts, major dep bumps, ambiguity), the **subagent challenge protocol** (independent skeptic review before merge), and budgets.
- `docs/loops/autonomy-log.md` - append-only journal of autonomous runs (what was decided/why, shipped, challenged, deferred).
- Rollback baseline tagged + pushed: `autonomy-baseline-2026-06-08` (restore with `git checkout <tag>`).
- `.claude/settings.json`: allow `git tag *` so future runs can re-baseline before risky work.

Docs + config only; no product code.

## How I tested
- `bash scripts/verify.sh` -> GREEN-GATE PASSED.
- `.claude/settings.json` validated as JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)