### PR TITLE
docs: record shipped features in the changelog and log the run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Streaming conversational AI coach that uses your training context.
 - `demo` LLM provider with canned responses (no API key) plus demo media for the
   AI flows, so the app and live demo work without a real key.
+- Demo credentials shown on the login screen when demo mode is enabled, so the
+  live demo is one click to try.
+- Expanded the default exercise catalog with common machine, cable, dumbbell, and
+  accessory movements, including coverage for the forearms and lower-back groups.
 - Test pyramid (unit, integration, E2E) with CI running lint, typecheck, unit,
   integration, build, and E2E on every pull request.
 - Docker and Docker Compose setup for local development and production.
@@ -30,9 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Migrated the entire codebase (UI, comments, prompts, docs) from French to
   English.
-- Bootstrapped the autonomous-loop maintenance infrastructure: the green-gate
-  (`scripts/verify.sh`), the `implement-issue` skill, and the loop playbook in
-  `docs/loops/`.
+- Grew the autonomous-loop maintenance infrastructure into a full self-maintenance
+  pipeline: the green-gate (`scripts/verify.sh`); the `implement-issue`, `triage`,
+  `ship-pr`, and `write-up` skills; an autonomy charter with guardrails; and the
+  loop playbook in `docs/loops/`.
 
 ### Fixed
 

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -6,6 +6,29 @@ by the charter in [`07-autonomy.md`](07-autonomy.md).
 
 ---
 
+## 2026-06-08 - First product run (catalog + content)
+
+**Context.** Maintainer loop running unsupervised under the charter. Goal: drain ready PRs,
+then improve the product, challenging each non-trivial change with a subagent.
+
+**Decided / shipped.**
+- Shipped #11 (Closes #4): expanded the seed exercise catalog by 25 movements and filled the
+  two muscle groups that had zero coverage (FOREARMS, LOWER_BACK); strengthened the catalog
+  test to assert valid enum membership and full-group coverage.
+- Content loop (this PR): recorded the now-merged demo-credentials (#6) and catalog (#4)
+  features in CHANGELOG, updated the loop-infra line, and logged this run.
+
+**Challenged.** An independent skeptic subagent reviewed the #4 diff and caught a real
+mis-classification (Hammer curl tagged FOREARMS; brachialis/biceps are the prime movers).
+Fixed to BICEPS before push, then re-verified. The author did not grade its own homework.
+
+**Deferred to human.** None.
+
+**Next.** #5 (polish empty states) with subagent review; then scope #1 (imperial units,
+larger, additive only). Triage if the backlog empties.
+
+---
+
 ## 2026-06-08 - Bootstrap autonomy
 
 **Context.** Operator switched the repo to a full-autonomy experiment: improve the product


### PR DESCRIPTION
Content-loop pass after #4/#6 shipped.

- CHANGELOG: add the demo-credentials login feature (#6) and the expanded exercise catalog (#4) under Unreleased > Added; update the loop-infrastructure line to reflect the full self-maintenance pipeline (triage/ship-pr/write-up skills + autonomy charter).
- `docs/loops/autonomy-log.md`: append the run entry (what shipped, the subagent finding on the catalog, what is next).

Every claim checked against merged code. Docs only.

## How I tested
- `bash scripts/verify.sh` -> GREEN-GATE PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)