### PR TITLE
feat: friendly empty states on the progress and history pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/media/raw/
 
 # Claude Code local (machine-specific) overrides
 .claude/settings.local.json
+# Claude Code runtime state (locks, scheduled tasks) - never commit
+.claude/scheduled_tasks.lock
+.claude/*.lock

--- a/app/(app)/history/page.tsx
+++ b/app/(app)/history/page.tsx
@@ -3,6 +3,7 @@ import { Calendar, ChevronRight, History as HistoryIcon } from 'lucide-react';
 import { db } from '@/lib/db';
 import { requireSession } from '@/lib/auth';
 import { Card, CardContent } from '@/components/ui/card';
+import { EmptyState } from '@/components/ui/empty-state';
 import { Badge } from '@/components/ui/badge';
 import { applyBodyweight, totalVolume } from '@/lib/stats';
 import { HistoryFilters } from '@/components/history/history-filters';
@@ -18,6 +19,8 @@ export default async function HistoryPage({
   searchParams: SearchParams;
 }) {
   const session = await requireSession();
+
+  const hasActiveFilters = Boolean(searchParams.programId || searchParams.month);
 
   // Filters: program and month (YYYY-MM).
   const programFilter = searchParams.programId
@@ -86,11 +89,20 @@ export default async function HistoryPage({
         />
 
         {sessions.length === 0 ? (
-          <Card>
-            <CardContent className="py-8 text-center text-sm text-muted-foreground">
-              No finished session matches these filters.
-            </CardContent>
-          </Card>
+          hasActiveFilters ? (
+            <Card>
+              <CardContent className="py-8 text-center text-sm text-muted-foreground">
+                No finished session matches these filters.
+              </CardContent>
+            </Card>
+          ) : (
+            <EmptyState
+              icon={HistoryIcon}
+              title="No sessions logged yet"
+              description="Finish your first workout and it will show up here with its volume, sets, and duration."
+              action={{ label: 'Log your first session', href: '/session/new' }}
+            />
+          )
         ) : (
           <ul className="flex flex-col gap-2">
             {sessions.map((s) => {

--- a/app/(app)/progress/page.tsx
+++ b/app/(app)/progress/page.tsx
@@ -1,7 +1,7 @@
 import { TrendingUp } from 'lucide-react';
 import { db } from '@/lib/db';
 import { requireSession } from '@/lib/auth';
-import { Card, CardContent } from '@/components/ui/card';
+import { EmptyState } from '@/components/ui/empty-state';
 import { MUSCLE_GROUP_LABELS } from '@/lib/schemas/exercise';
 import {
   applyBodyweight,
@@ -189,11 +189,12 @@ export default async function ProgressPage({
         </div>
 
         {exercisesWithSets.length === 0 ? (
-          <Card>
-            <CardContent className="py-8 text-center text-sm text-muted-foreground">
-              No sets recorded yet over the last {RECENT_WEEKS} weeks.
-            </CardContent>
-          </Card>
+          <EmptyState
+            icon={TrendingUp}
+            title="No progress to show yet"
+            description={`Log a few sessions and your charts and PRs will appear here, tracking the last ${RECENT_WEEKS} weeks.`}
+            action={{ label: 'Log your first session', href: '/session/new' }}
+          />
         ) : (
           <ProgressDashboard
             exercises={exercisesWithSets.map((e) => ({

--- a/components/ui/empty-state.test.tsx
+++ b/components/ui/empty-state.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Dumbbell } from 'lucide-react';
+import { EmptyState } from './empty-state';
+
+describe('EmptyState', () => {
+  it('renders the title and description', () => {
+    render(
+      <EmptyState title="No sessions logged yet" description="Log one to begin." />,
+    );
+    expect(screen.getByText('No sessions logged yet')).toBeInTheDocument();
+    expect(screen.getByText('Log one to begin.')).toBeInTheDocument();
+  });
+
+  it('renders the call-to-action as a link to the given href', () => {
+    render(
+      <EmptyState
+        icon={Dumbbell}
+        title="Nothing here"
+        action={{ label: 'Log your first session', href: '/session/new' }}
+      />,
+    );
+    const cta = screen.getByRole('link', { name: 'Log your first session' });
+    expect(cta).toBeInTheDocument();
+    expect(cta).toHaveAttribute('href', '/session/new');
+  });
+
+  it('renders no link when there is no action', () => {
+    render(<EmptyState title="Nothing here" />);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+});

--- a/components/ui/empty-state.tsx
+++ b/components/ui/empty-state.tsx
@@ -1,0 +1,48 @@
+import Link from 'next/link';
+import type { LucideIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
+interface EmptyStateProps {
+  icon?: LucideIcon;
+  title: string;
+  description?: string;
+  action?: { label: string; href: string };
+  className?: string;
+}
+
+// Friendly placeholder shown when a page has no data yet. Keeps the Shadcn Card
+// look and offers an optional call-to-action.
+export function EmptyState({
+  icon: Icon,
+  title,
+  description,
+  action,
+  className,
+}: EmptyStateProps) {
+  return (
+    <Card className={cn(className)}>
+      <CardContent className="flex flex-col items-center gap-3 py-12 text-center">
+        {Icon && (
+          <div className="rounded-full bg-muted p-3 text-muted-foreground">
+            <Icon className="size-6" />
+          </div>
+        )}
+        <div className="flex flex-col gap-1">
+          <p className="text-base font-medium">{title}</p>
+          {description && (
+            <p className="mx-auto max-w-sm text-sm text-muted-foreground">
+              {description}
+            </p>
+          )}
+        </div>
+        {action && (
+          <Button asChild className="min-h-tap mt-1">
+            <Link href={action.href}>{action.label}</Link>
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
A brand-new user with no data saw bare progress/history pages. This adds welcoming empty states with a clear call to action.

- New reusable `components/ui/empty-state.tsx` primitive (icon + title + description + optional CTA), built from the existing Shadcn `Card`/`Button` and the repo's `Button asChild` + `next/link` convention.
- **Progress**: when there are no logged sets, shows "No progress to show yet" + "Log your first session" instead of a bare placeholder card.
- **History**: when there are no sessions *and no active filters*, shows "No sessions logged yet" + CTA. The existing "No finished session matches these filters." copy is kept for the filtered-but-empty case (so behavior with filters/data is unchanged).
- Colocated component test (`empty-state.test.tsx`) covering title/description, the CTA link + href, and the no-action case.
- Also gitignores Claude Code runtime lock files.

Reviewed by an independent skeptic subagent (no blocking findings): confirmed no dead imports, the history branch logic, the `/session/new` CTA route, and unchanged data paths.

Closes #5

## How I tested
- `bash scripts/verify.sh` -> GREEN-GATE PASSED (prisma generate + lint + typecheck + unit + build).
- `npx vitest run components/ui/empty-state.test.tsx` -> 3 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)