### PR TITLE
feat: weight-unit foundation (kg/lb preference plumbing)

### DIFF
--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
-import { Sex, TrainingGoal } from '@prisma/client';
+import { Sex, TrainingGoal, WeightUnit } from '@prisma/client';
 import { db } from '@/lib/db';
 import { handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
 
@@ -14,6 +14,8 @@ const profileUpdateSchema = z.object({
   heightCm: z.number().int().min(100).max(250).nullable().optional(),
   goal: z.nativeEnum(TrainingGoal).nullable().optional(),
   weeklyFrequency: z.number().int().min(1).max(14).nullable().optional(),
+  // Preferred weight unit (display + input only; data stays in kg).
+  unit: z.nativeEnum(WeightUnit).optional(),
 });
 
 const PROFILE_SELECT = {
@@ -24,6 +26,7 @@ const PROFILE_SELECT = {
   heightCm: true,
   goal: true,
   weeklyFrequency: true,
+  unit: true,
 } as const;
 
 export async function GET() {
@@ -54,6 +57,7 @@ export async function PATCH(req: Request) {
         ...(data.weeklyFrequency !== undefined
           ? { weeklyFrequency: data.weeklyFrequency }
           : {}),
+        ...(data.unit !== undefined ? { unit: data.unit } : {}),
       },
       select: PROFILE_SELECT,
     });

--- a/lib/units.test.ts
+++ b/lib/units.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import {
+  KG_PER_LB,
+  kgToLb,
+  lbToKg,
+  toDisplayWeight,
+  fromDisplayWeight,
+  unitLabel,
+  roundWeight,
+  formatWeight,
+  displayIncrement,
+} from './units';
+
+describe('units', () => {
+  it('converts kg <-> lb with the exact factor', () => {
+    expect(kgToLb(KG_PER_LB)).toBeCloseTo(1, 10);
+    expect(lbToKg(1)).toBeCloseTo(KG_PER_LB, 10);
+    expect(kgToLb(100)).toBeCloseTo(220.462, 3);
+    expect(lbToKg(100)).toBeCloseTo(45.359, 3);
+  });
+
+  it('round-trips a value through lb and back to kg', () => {
+    const kg = 82.5;
+    expect(lbToKg(kgToLb(kg))).toBeCloseTo(kg, 10);
+  });
+
+  it('toDisplayWeight / fromDisplayWeight are identity for KG and inverse for LB', () => {
+    expect(toDisplayWeight(70, 'KG')).toBe(70);
+    expect(fromDisplayWeight(70, 'KG')).toBe(70);
+    expect(toDisplayWeight(70, 'LB')).toBeCloseTo(154.324, 3);
+    expect(fromDisplayWeight(toDisplayWeight(70, 'LB'), 'LB')).toBeCloseTo(70, 10);
+  });
+
+  it('labels the unit', () => {
+    expect(unitLabel('KG')).toBe('kg');
+    expect(unitLabel('LB')).toBe('lb');
+  });
+
+  it('rounds to the requested precision', () => {
+    expect(roundWeight(154.3239, 1)).toBe(154.3);
+    expect(roundWeight(1234.6, 0)).toBe(1235);
+  });
+
+  it('formats stored kg in the user unit', () => {
+    expect(formatWeight(70, 'KG')).toBe('70 kg');
+    expect(formatWeight(70, 'LB')).toBe('154.3 lb');
+    expect(formatWeight(1234.5, 'KG', { decimals: 0 })).toBe('1,235 kg');
+    expect(formatWeight(70, 'KG', { withUnit: false })).toBe('70');
+  });
+
+  it('uses clean plate jumps for the lb increment', () => {
+    expect(displayIncrement(2.5, 'KG')).toBe(2.5);
+    expect(displayIncrement(1, 'KG')).toBe(1);
+    expect(displayIncrement(2.5, 'LB')).toBe(5);
+    expect(displayIncrement(1, 'LB')).toBe(2.5);
+  });
+});

--- a/lib/units.ts
+++ b/lib/units.ts
@@ -1,0 +1,65 @@
+import { WeightUnit } from '@prisma/client';
+
+// Weight is always stored in kilograms. These helpers convert at the edges only
+// (display and form input) so a user can work in pounds without any data
+// migration. See issue #1.
+
+// Exact pounds <-> kilograms factor.
+export const KG_PER_LB = 0.45359237;
+
+export function kgToLb(kg: number): number {
+  return kg / KG_PER_LB;
+}
+
+export function lbToKg(lb: number): number {
+  return lb * KG_PER_LB;
+}
+
+// A stored kg value -> a number in the user's display unit.
+export function toDisplayWeight(kg: number, unit: WeightUnit): number {
+  return unit === 'LB' ? kgToLb(kg) : kg;
+}
+
+// A number entered in the user's display unit -> kg for storage.
+export function fromDisplayWeight(value: number, unit: WeightUnit): number {
+  return unit === 'LB' ? lbToKg(value) : value;
+}
+
+// Short label for the unit ("kg" / "lb").
+export function unitLabel(unit: WeightUnit): string {
+  return unit === 'LB' ? 'lb' : 'kg';
+}
+
+// Round to a fixed number of decimals (default 1), dropping floating-point noise.
+export function roundWeight(value: number, decimals = 1): number {
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}
+
+interface FormatOptions {
+  // Decimal places for the converted value (default 1).
+  decimals?: number;
+  // Append the unit label (default true).
+  withUnit?: boolean;
+}
+
+// Format a stored kg value for display in the user's unit, e.g. "70 kg" or
+// "154.3 lb". Thousands are grouped; trailing zeros are dropped.
+export function formatWeight(
+  kg: number,
+  unit: WeightUnit,
+  opts: FormatOptions = {},
+): string {
+  const { decimals = 1, withUnit = true } = opts;
+  const display = roundWeight(toDisplayWeight(kg, unit), decimals);
+  const str = display.toLocaleString('en-US', { maximumFractionDigits: decimals });
+  return withUnit ? `${str} ${unitLabel(unit)}` : str;
+}
+
+// The set-logger increment in the user's display unit. Internally the app uses
+// kg steps (2.5 kg compound / 1 kg isolation); in pounds we use clean plate
+// jumps (5 lb / 2.5 lb) rather than awkward converted values.
+export function displayIncrement(kgIncrement: number, unit: WeightUnit): number {
+  if (unit === 'KG') return kgIncrement;
+  return kgIncrement >= 2.5 ? 5 : 2.5;
+}

--- a/prisma/migrations/20260608000000_add_weight_unit/migration.sql
+++ b/prisma/migrations/20260608000000_add_weight_unit/migration.sql
@@ -1,0 +1,6 @@
+-- CreateEnum
+CREATE TYPE "WeightUnit" AS ENUM ('KG', 'LB');
+
+-- AlterTable
+ALTER TABLE "User"
+  ADD COLUMN "unit" "WeightUnit" NOT NULL DEFAULT 'KG';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,6 +25,9 @@ model User {
   heightCm        Int?
   goal            TrainingGoal?
   weeklyFrequency Int?
+  // Preferred weight unit for display and input. Data is always stored in kg;
+  // this only affects the presentation layer. Default keeps existing users on kg.
+  unit            WeightUnit @default(KG)
   createdAt    DateTime   @default(now())
   programs      Program[]
   sessions      Session[]
@@ -36,6 +39,11 @@ enum Sex {
   MALE
   FEMALE
   OTHER
+}
+
+enum WeightUnit {
+  KG
+  LB
 }
 
 enum TrainingGoal {


### PR DESCRIPTION
**PR 1 of 2** for imperial-unit support (issue #1). This is the safe, tested plumbing with **no UX change**; the settings toggle and display/input wiring follow in PR 2 (kept separate so the larger, regression-prone presentation change gets its own focused review).

- `WeightUnit` enum (KG | LB) and a `unit` column on `User` (default KG). **Additive migration**: a skeptic subagent confirmed `ADD COLUMN ... NOT NULL DEFAULT 'KG'` backfills existing rows in one metadata-only statement on PG 11+ (no rewrite, no data loss). Data stays in kg; no data migration.
- `lib/units.ts`: exact kg<->lb conversion, display formatting (`formatWeight`), and clean plate-jump increments, with full unit tests (7 cases).
- Profile API accepts and persists the `unit` preference, Zod-validated (`z.nativeEnum(WeightUnit)`), added to the profile select.

Why split: converting every display surface (history, progress charts, summaries, coach) plus the input path while preserving exact kg formatting is large and regression-prone. Landing the additive migration + tested conversion lib independently keeps each PR small and reviewable per the repo's autonomy charter (`docs/loops/07-autonomy.md`).

Refs #1 (closed by PR 2)

## How I tested
- `bash scripts/verify.sh` -> GREEN-GATE PASSED (prisma generate + lint + typecheck + unit + build).
- `npx vitest run lib/units.test.ts` -> 7 passed.
- Independent skeptic subagent review: READY, migration verified production-safe, no defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)