### PR TITLE
feat: apply the kg/lb unit preference across logging and history

### DIFF
--- a/app/(app)/history/[id]/page.tsx
+++ b/app/(app)/history/[id]/page.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { MUSCLE_GROUP_LABELS } from '@/lib/schemas/exercise';
 import { applyBodyweight, best1RM, totalVolume } from '@/lib/stats';
+import { formatWeight } from '@/lib/units';
 import { DeleteSessionButton } from '@/components/history/delete-session-button';
 
 interface Params {
@@ -40,7 +41,7 @@ export default async function HistorySessionPage({ params }: Params) {
     }),
     db.user.findUnique({
       where: { id: auth.userId },
-      select: { bodyweight: true },
+      select: { bodyweight: true, unit: true },
     }),
   ]);
 
@@ -48,6 +49,7 @@ export default async function HistorySessionPage({ params }: Params) {
     notFound();
   }
   const bodyweight = user?.bodyweight ?? null;
+  const unit = user?.unit ?? 'KG';
 
   // Group sets by exercise (keeping the order of the first set per exercise).
   const exerciseOrder: string[] = [];
@@ -132,7 +134,7 @@ export default async function HistorySessionPage({ params }: Params) {
             <Stat label="Exercises" value={String(setsByExercise.size)} />
             <Stat
               label="Total volume"
-              value={`${Math.round(volume).toLocaleString('en-US')} kg`}
+              value={formatWeight(volume, unit, { decimals: 0 })}
             />
           </CardContent>
         </Card>
@@ -181,8 +183,22 @@ export default async function HistorySessionPage({ params }: Params) {
                         </Badge>
                       </div>
                       <div className="mt-1 flex gap-3 text-xs text-muted-foreground">
-                        <span>Volume: {Math.round(exoVolume)} kg</span>
-                        {e1rm > 0 && <span>Est. 1RM: {e1rm.toFixed(1)} kg</span>}
+                        <span>
+                          Volume:{' '}
+                          {formatWeight(exoVolume, unit, {
+                            decimals: 0,
+                            group: false,
+                          })}
+                        </span>
+                        {e1rm > 0 && (
+                          <span>
+                            Est. 1RM:{' '}
+                            {formatWeight(e1rm, unit, {
+                              decimals: 1,
+                              fixed: true,
+                            })}
+                          </span>
+                        )}
                       </div>
                     </CardHeader>
                     <CardContent className="pt-0">
@@ -213,16 +229,20 @@ export default async function HistorySessionPage({ params }: Params) {
                                 <td className="py-1.5">
                                   {isBw ? (
                                     <span>
-                                      {effective} kg
+                                      {formatWeight(effective, unit, { decimals: 1 })}
                                       <span className="ml-1 text-xs text-muted-foreground">
                                         ({s.weight >= 0 ? '+' : ''}
-                                        {s.weight} ext)
+                                        {formatWeight(s.weight, unit, {
+                                          decimals: 1,
+                                          withUnit: false,
+                                        })}{' '}
+                                        ext)
                                       </span>
                                     </span>
                                   ) : effective === 0 ? (
                                     'BW'
                                   ) : (
-                                    `${effective} kg`
+                                    formatWeight(effective, unit, { decimals: 1 })
                                   )}
                                 </td>
                                 <td className="py-1.5">{s.reps}</td>

--- a/app/(app)/history/[id]/page.tsx
+++ b/app/(app)/history/[id]/page.tsx
@@ -196,6 +196,7 @@ export default async function HistorySessionPage({ params }: Params) {
                             {formatWeight(e1rm, unit, {
                               decimals: 1,
                               fixed: true,
+                              group: false,
                             })}
                           </span>
                         )}
@@ -229,12 +230,16 @@ export default async function HistorySessionPage({ params }: Params) {
                                 <td className="py-1.5">
                                   {isBw ? (
                                     <span>
-                                      {formatWeight(effective, unit, { decimals: 1 })}
+                                      {formatWeight(effective, unit, {
+                                        decimals: 2,
+                                        group: false,
+                                      })}
                                       <span className="ml-1 text-xs text-muted-foreground">
                                         ({s.weight >= 0 ? '+' : ''}
                                         {formatWeight(s.weight, unit, {
-                                          decimals: 1,
+                                          decimals: 2,
                                           withUnit: false,
+                                          group: false,
                                         })}{' '}
                                         ext)
                                       </span>
@@ -242,7 +247,10 @@ export default async function HistorySessionPage({ params }: Params) {
                                   ) : effective === 0 ? (
                                     'BW'
                                   ) : (
-                                    formatWeight(effective, unit, { decimals: 1 })
+                                    formatWeight(effective, unit, {
+                                      decimals: 2,
+                                      group: false,
+                                    })
                                   )}
                                 </td>
                                 <td className="py-1.5">{s.reps}</td>

--- a/app/(app)/history/page.tsx
+++ b/app/(app)/history/page.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { EmptyState } from '@/components/ui/empty-state';
 import { Badge } from '@/components/ui/badge';
 import { applyBodyweight, totalVolume } from '@/lib/stats';
+import { formatWeight } from '@/lib/units';
 import { HistoryFilters } from '@/components/history/history-filters';
 
 interface SearchParams {
@@ -70,9 +71,10 @@ export default async function HistoryPage({
     }),
     db.user.findUnique({
       where: { id: session.userId },
-      select: { bodyweight: true },
+      select: { bodyweight: true, unit: true },
     }),
   ]);
+  const unit = user?.unit ?? 'KG';
 
   return (
     <main className="flex-1 px-4 py-6">
@@ -148,7 +150,7 @@ export default async function HistoryPage({
                               {workingSets} set{workingSets > 1 ? 's' : ''}
                             </Badge>
                             <Badge variant="outline">
-                              {Math.round(volume).toLocaleString('en-US')} kg vol.
+                              {formatWeight(volume, unit, { decimals: 0 })} vol.
                             </Badge>
                             {durationMin != null && (
                               <Badge variant="outline">{durationMin} min</Badge>

--- a/app/(app)/session/[id]/page.tsx
+++ b/app/(app)/session/[id]/page.tsx
@@ -36,14 +36,23 @@ export default async function SessionRunPage({ params }: Props) {
   if (!session.workout) notFound();
 
   const exerciseIds = session.workout.exercises.map((pe) => pe.exerciseId);
-  const lastPerformances = await getLastPerformances(auth.userId, exerciseIds, session.id);
+  const [lastPerformances, user] = await Promise.all([
+    getLastPerformances(auth.userId, exerciseIds, session.id),
+    db.user.findUnique({ where: { id: auth.userId }, select: { unit: true } }),
+  ]);
 
   const lastPerfRecord: Record<string, SerializedLastPerformance> = {};
   for (const [k, v] of lastPerformances) {
     lastPerfRecord[k] = serializePerf(v);
   }
 
-  return <SessionRunner session={session} lastPerformances={lastPerfRecord} />;
+  return (
+    <SessionRunner
+      session={session}
+      lastPerformances={lastPerfRecord}
+      unit={user?.unit ?? 'KG'}
+    />
+  );
 }
 
 function serializePerf(p: LastPerformance): SerializedLastPerformance {

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -16,6 +16,7 @@ export default async function SettingsPage() {
       heightCm: true,
       goal: true,
       weeklyFrequency: true,
+      unit: true,
     },
   });
 
@@ -47,6 +48,7 @@ export default async function SettingsPage() {
             heightCm: user?.heightCm ?? null,
             goal: user?.goal ?? null,
             weeklyFrequency: user?.weeklyFrequency ?? null,
+            unit: user?.unit ?? 'KG',
           }}
         />
 

--- a/components/session/exercise-card.tsx
+++ b/components/session/exercise-card.tsx
@@ -2,20 +2,22 @@
 
 import { useState } from 'react';
 import { ChevronDown, ChevronUp, HelpCircle, Lightbulb, TrendingUp } from 'lucide-react';
-import type { Exercise, ProgramExercise } from '@prisma/client';
+import type { Exercise, ProgramExercise, WeightUnit } from '@prisma/client';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { MUSCLE_GROUP_LABELS, CATEGORY_LABELS } from '@/lib/schemas/exercise';
 import { suggestNextWeight } from '@/lib/progression';
+import { formatWeight } from '@/lib/units';
 import type { SerializedLastPerformance } from './session-runner';
 
 interface Props {
   programExercise: ProgramExercise & { exercise: Exercise };
   lastPerformance: SerializedLastPerformance | undefined;
+  unit: WeightUnit;
 }
 
-export function ExerciseCard({ programExercise, lastPerformance }: Props) {
+export function ExerciseCard({ programExercise, lastPerformance, unit }: Props) {
   const [notesOpen, setNotesOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
   const exo = programExercise.exercise;
@@ -57,7 +59,7 @@ export function ExerciseCard({ programExercise, lastPerformance }: Props) {
             <p className="font-medium">
               {lastPerformance.maxWeight === 0
                 ? `${lastPerformance.repsAtMaxWeight} reps bodyweight`
-                : `${lastPerformance.maxWeight} kg × ${lastPerformance.repsAtMaxWeight} reps`}
+                : `${formatWeight(lastPerformance.maxWeight, unit, { decimals: 1 })} × ${lastPerformance.repsAtMaxWeight} reps`}
             </p>
           </div>
         )}
@@ -75,11 +77,11 @@ export function ExerciseCard({ programExercise, lastPerformance }: Props) {
                 <span className="font-medium">
                   {suggestion.weight === 0
                     ? 'bodyweight'
-                    : `${suggestion.weight} kg`}
+                    : formatWeight(suggestion.weight, unit, { decimals: 1 })}
                 </span>
                 {suggestion.reason === 'progression' && suggestion.delta && (
                   <span className="ml-1 text-xs text-primary">
-                    (+{suggestion.delta} kg)
+                    (+{formatWeight(suggestion.delta, unit, { decimals: 1 })})
                   </span>
                 )}
               </span>
@@ -96,7 +98,7 @@ export function ExerciseCard({ programExercise, lastPerformance }: Props) {
             {helpOpen && (
               <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
                 {suggestion.reason === 'progression'
-                  ? `All working sets reached ${suggestion.targetRepsMax} reps at ${suggestion.workingWeight} kg: load goes up by ${suggestion.delta} kg to drop back to the bottom of the rep range (double progression).`
+                  ? `All working sets reached ${suggestion.targetRepsMax} reps at ${formatWeight(suggestion.workingWeight ?? 0, unit, { decimals: 1 })}: load goes up by ${formatWeight(suggestion.delta ?? 0, unit, { decimals: 1 })} to drop back to the bottom of the rep range (double progression).`
                   : `Keep the same load and try to beat your reps. Progression unlocks once all working sets reach ${suggestion.targetRepsMax} reps.`}
               </p>
             )}

--- a/components/session/exercise-card.tsx
+++ b/components/session/exercise-card.tsx
@@ -59,7 +59,7 @@ export function ExerciseCard({ programExercise, lastPerformance, unit }: Props) 
             <p className="font-medium">
               {lastPerformance.maxWeight === 0
                 ? `${lastPerformance.repsAtMaxWeight} reps bodyweight`
-                : `${formatWeight(lastPerformance.maxWeight, unit, { decimals: 1 })} × ${lastPerformance.repsAtMaxWeight} reps`}
+                : `${formatWeight(lastPerformance.maxWeight, unit, { decimals: 2, group: false })} × ${lastPerformance.repsAtMaxWeight} reps`}
             </p>
           </div>
         )}
@@ -77,11 +77,11 @@ export function ExerciseCard({ programExercise, lastPerformance, unit }: Props) 
                 <span className="font-medium">
                   {suggestion.weight === 0
                     ? 'bodyweight'
-                    : formatWeight(suggestion.weight, unit, { decimals: 1 })}
+                    : formatWeight(suggestion.weight, unit, { decimals: 2, group: false })}
                 </span>
                 {suggestion.reason === 'progression' && suggestion.delta && (
                   <span className="ml-1 text-xs text-primary">
-                    (+{formatWeight(suggestion.delta, unit, { decimals: 1 })})
+                    (+{formatWeight(suggestion.delta, unit, { decimals: 2, group: false })})
                   </span>
                 )}
               </span>
@@ -98,7 +98,7 @@ export function ExerciseCard({ programExercise, lastPerformance, unit }: Props) 
             {helpOpen && (
               <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
                 {suggestion.reason === 'progression'
-                  ? `All working sets reached ${suggestion.targetRepsMax} reps at ${formatWeight(suggestion.workingWeight ?? 0, unit, { decimals: 1 })}: load goes up by ${formatWeight(suggestion.delta ?? 0, unit, { decimals: 1 })} to drop back to the bottom of the rep range (double progression).`
+                  ? `All working sets reached ${suggestion.targetRepsMax} reps at ${formatWeight(suggestion.workingWeight ?? 0, unit, { decimals: 2, group: false })}: load goes up by ${formatWeight(suggestion.delta ?? 0, unit, { decimals: 2, group: false })} to drop back to the bottom of the rep range (double progression).`
                   : `Keep the same load and try to beat your reps. Progression unlocks once all working sets reach ${suggestion.targetRepsMax} reps.`}
               </p>
             )}

--- a/components/session/session-runner.tsx
+++ b/components/session/session-runner.tsx
@@ -10,6 +10,7 @@ import type {
   ProgramExercise,
   Session,
   Set as PrismaSet,
+  WeightUnit,
   Workout,
 } from '@prisma/client';
 import { useLiveQuery } from 'dexie-react-hooks';
@@ -51,6 +52,7 @@ type SessionRunnerProps = {
     sets: PrismaSet[];
   };
   lastPerformances: Record<string, SerializedLastPerformance>;
+  unit: WeightUnit;
 };
 
 type Mode =
@@ -58,7 +60,7 @@ type Mode =
   | { kind: 'rest'; endsAt: number; totalSec: number; nextExerciseIdx: number | null }
   | { kind: 'summary' };
 
-export function SessionRunner({ session, lastPerformances }: SessionRunnerProps) {
+export function SessionRunner({ session, lastPerformances, unit }: SessionRunnerProps) {
   const router = useRouter();
   const workout = session.workout!;
   const programExercises = workout.exercises;
@@ -248,6 +250,7 @@ export function SessionRunner({ session, lastPerformances }: SessionRunnerProps)
         session={session}
         sets={liveSets}
         programExercises={programExercises}
+        unit={unit}
         onBack={() => setMode({ kind: 'input' })}
         onFinish={handleFinishSession}
         finishing={closing}
@@ -293,7 +296,7 @@ export function SessionRunner({ session, lastPerformances }: SessionRunnerProps)
       </div>
 
       <div className="mx-auto flex w-full max-w-2xl flex-col gap-4 px-4 py-4">
-        <ExerciseCard programExercise={currentPE} lastPerformance={lastPerf} />
+        <ExerciseCard programExercise={currentPE} lastPerformance={lastPerf} unit={unit} />
 
         <SetsList
           programExercise={currentPE}
@@ -307,6 +310,7 @@ export function SessionRunner({ session, lastPerformances }: SessionRunnerProps)
             programExercise={currentPE}
             existingSets={currentSets}
             lastPerformance={lastPerf}
+            unit={unit}
             onSubmit={handleValidate}
           />
         ) : (

--- a/components/session/session-summary.tsx
+++ b/components/session/session-summary.tsx
@@ -101,7 +101,7 @@ export function SessionSummary({ session, sets, programExercises, unit, onBack, 
                   <span className="flex-shrink-0 text-xs text-muted-foreground">
                     {s.doneSets}/{s.targetSets} sets
                     {s.maxWeight > 0
-                      ? ` · max ${formatWeight(s.maxWeight, unit, { decimals: 1 })}`
+                      ? ` · max ${formatWeight(s.maxWeight, unit, { decimals: 2, group: false })}`
                       : ''}
                   </span>
                 </li>

--- a/components/session/session-summary.tsx
+++ b/components/session/session-summary.tsx
@@ -2,24 +2,26 @@
 
 import { useState } from 'react';
 import { ChevronLeft, Check } from 'lucide-react';
-import type { Exercise, ProgramExercise, Session } from '@prisma/client';
+import type { Exercise, ProgramExercise, Session, WeightUnit } from '@prisma/client';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 import { toast } from 'sonner';
 import type { PendingSet } from '@/lib/indexeddb';
+import { formatWeight } from '@/lib/units';
 
 interface Props {
   session: Session;
   sets: PendingSet[];
   programExercises: (ProgramExercise & { exercise: Exercise })[];
+  unit: WeightUnit;
   onBack: () => void;
   onFinish: () => Promise<void> | void;
   finishing: boolean;
 }
 
-export function SessionSummary({ session, sets, programExercises, onBack, onFinish, finishing }: Props) {
+export function SessionSummary({ session, sets, programExercises, unit, onBack, onFinish, finishing }: Props) {
   const [notes, setNotes] = useState(session.notes ?? '');
 
   const durationMin = Math.round(
@@ -70,7 +72,7 @@ export function SessionSummary({ session, sets, programExercises, onBack, onFini
         <div className="grid grid-cols-3 gap-3">
           <Stat label="Duration" value={`${durationMin} min`} />
           <Stat label="Sets" value={totalSets} />
-          <Stat label="Volume" value={`${Math.round(totalVolume).toLocaleString('en-US')} kg`} />
+          <Stat label="Volume" value={formatWeight(totalVolume, unit, { decimals: 0 })} />
         </div>
         <p className="text-xs text-muted-foreground">
           Volume = Σ (load × reps), {totalReps} reps total.
@@ -98,7 +100,9 @@ export function SessionSummary({ session, sets, programExercises, onBack, onFini
                   </div>
                   <span className="flex-shrink-0 text-xs text-muted-foreground">
                     {s.doneSets}/{s.targetSets} sets
-                    {s.maxWeight > 0 ? ` · max ${s.maxWeight} kg` : ''}
+                    {s.maxWeight > 0
+                      ? ` · max ${formatWeight(s.maxWeight, unit, { decimals: 1 })}`
+                      : ''}
                   </span>
                 </li>
               ))}

--- a/components/session/set-input.tsx
+++ b/components/session/set-input.tsx
@@ -2,7 +2,14 @@
 
 import { useEffect, useState } from 'react';
 import { Check, Minus, Plus } from 'lucide-react';
-import type { Exercise, ProgramExercise } from '@prisma/client';
+import type { Exercise, ProgramExercise, WeightUnit } from '@prisma/client';
+import {
+  displayIncrement,
+  fromDisplayWeight,
+  roundWeight,
+  toDisplayWeight,
+  unitLabel,
+} from '@/lib/units';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -17,6 +24,7 @@ interface Props {
   programExercise: ProgramExercise & { exercise: Exercise };
   existingSets: PendingSet[];
   lastPerformance: SerializedLastPerformance | undefined;
+  unit: WeightUnit;
   onSubmit: (values: {
     weight: number;
     reps: number;
@@ -38,7 +46,7 @@ interface FormState {
 
 const RIR_OPTIONS = [0, 1, 2, 3];
 
-export function SetInput({ programExercise, existingSets, lastPerformance, onSubmit }: Props) {
+export function SetInput({ programExercise, existingSets, lastPerformance, unit, onSubmit }: Props) {
   // Pre-fill: last set of this exercise in the current session,
   // otherwise the last performance, otherwise defaults.
   const initial = computeInitial(programExercise, existingSets, lastPerformance);
@@ -52,6 +60,14 @@ export function SetInput({ programExercise, existingSets, lastPerformance, onSub
   }, [programExercise.id, existingSets.length]);
 
   const incrementKg = weightIncrement(programExercise.exercise.category);
+  // Increment shown in the user's unit (clean plate jumps), applied to the
+  // kg-stored weight. The form value stays in kg; only display/input convert.
+  const stepDisplay = displayIncrement(incrementKg, unit);
+  const stepKg = fromDisplayWeight(stepDisplay, unit);
+  // Show the kg-stored weight in the user's unit. KG renders the raw value
+  // (unchanged behavior); LB shows a rounded conversion.
+  const displayWeight =
+    unit === 'LB' ? roundWeight(toDisplayWeight(form.weight, unit), 1) : form.weight;
 
   function adjustWeight(delta: number) {
     setForm((f) => ({ ...f, weight: Math.max(0, +(f.weight + delta).toFixed(2)) }));
@@ -83,16 +99,16 @@ export function SetInput({ programExercise, existingSets, lastPerformance, onSub
         {/* Load */}
         <div className="space-y-2">
           <Label className="text-xs uppercase tracking-wide text-muted-foreground">
-            Load (kg)
+            Load ({unitLabel(unit)})
           </Label>
           <div className="flex items-center gap-2">
             <Button
               type="button"
               variant="outline"
               size="icon"
-              onClick={() => adjustWeight(-incrementKg)}
+              onClick={() => adjustWeight(-stepKg)}
               className="min-h-tap min-w-tap"
-              aria-label={`-${incrementKg} kg`}
+              aria-label={`-${stepDisplay} ${unitLabel(unit)}`}
             >
               <Minus className="size-5" />
             </Button>
@@ -100,9 +116,12 @@ export function SetInput({ programExercise, existingSets, lastPerformance, onSub
               type="number"
               inputMode="decimal"
               step="0.1"
-              value={form.weight}
+              value={displayWeight}
               onChange={(e) =>
-                setForm((f) => ({ ...f, weight: parseFloat(e.target.value) || 0 }))
+                setForm((f) => ({
+                  ...f,
+                  weight: fromDisplayWeight(parseFloat(e.target.value) || 0, unit),
+                }))
               }
               className="h-14 text-center text-2xl font-semibold"
             />
@@ -110,9 +129,9 @@ export function SetInput({ programExercise, existingSets, lastPerformance, onSub
               type="button"
               variant="outline"
               size="icon"
-              onClick={() => adjustWeight(incrementKg)}
+              onClick={() => adjustWeight(stepKg)}
               className="min-h-tap min-w-tap"
-              aria-label={`+${incrementKg} kg`}
+              aria-label={`+${stepDisplay} ${unitLabel(unit)}`}
             >
               <Plus className="size-5" />
             </Button>

--- a/components/settings/profile-section.tsx
+++ b/components/settings/profile-section.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { Loader2, Save, User } from 'lucide-react';
 import { toast } from 'sonner';
-import type { Sex, TrainingGoal } from '@prisma/client';
+import type { Sex, TrainingGoal, WeightUnit } from '@prisma/client';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -23,6 +23,7 @@ export interface ProfileData {
   heightCm: number | null;
   goal: TrainingGoal | null;
   weeklyFrequency: number | null;
+  unit: WeightUnit;
 }
 
 interface Props {
@@ -43,6 +44,11 @@ const GOAL_OPTIONS: { value: TrainingGoal; label: string }[] = [
   { value: 'GENERAL_FITNESS', label: 'General fitness' },
 ];
 
+const UNIT_OPTIONS: { value: WeightUnit; label: string }[] = [
+  { value: 'KG', label: 'Kilograms (kg)' },
+  { value: 'LB', label: 'Pounds (lb)' },
+];
+
 function numOrEmpty(n: number | null): string {
   return n != null ? String(n) : '';
 }
@@ -58,6 +64,7 @@ export function ProfileSection({ initial }: Props) {
   const [goal, setGoal] = useState<TrainingGoal | undefined>(
     initial.goal ?? undefined,
   );
+  const [unit, setUnit] = useState<WeightUnit>(initial.unit);
   const [pending, setPending] = useState(false);
 
   function rangeOk(value: string, min: number, max: number): boolean {
@@ -86,6 +93,7 @@ export function ProfileSection({ initial }: Props) {
       };
       if (sex) body.sex = sex;
       if (goal) body.goal = goal;
+      body.unit = unit;
 
       const res = await fetch('/api/profile', {
         method: 'PATCH',
@@ -220,6 +228,26 @@ export function ProfileSection({ initial }: Props) {
               ))}
             </SelectContent>
           </Select>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label className="text-sm">Weight unit</Label>
+          <Select value={unit} onValueChange={(v) => setUnit(v as WeightUnit)}>
+            <SelectTrigger className="max-w-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {UNIT_OPTIONS.map((o) => (
+                <SelectItem key={o.value} value={o.value}>
+                  {o.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            Changes how weights are shown and entered. Your data is always stored
+            in kg, so switching never alters past sessions.
+          </p>
         </div>
 
         <div>

--- a/lib/units.test.ts
+++ b/lib/units.test.ts
@@ -48,6 +48,15 @@ describe('units', () => {
     expect(formatWeight(70, 'KG', { withUnit: false })).toBe('70');
   });
 
+  it('honors fixed decimals and grouping options (kg parity with toFixed / no-group)', () => {
+    // fixed keeps trailing zeros, matching the old `e1rm.toFixed(1)` look.
+    expect(formatWeight(100, 'KG', { decimals: 1, fixed: true })).toBe('100.0 kg');
+    // group:false matches the old `Math.round(volume)` (no separators).
+    expect(formatWeight(1234, 'KG', { decimals: 0, group: false })).toBe('1234 kg');
+    // signed external load, no unit label.
+    expect(formatWeight(20, 'KG', { decimals: 1, withUnit: false })).toBe('20');
+  });
+
   it('uses clean plate jumps for the lb increment', () => {
     expect(displayIncrement(2.5, 'KG')).toBe(2.5);
     expect(displayIncrement(1, 'KG')).toBe(1);

--- a/lib/units.ts
+++ b/lib/units.ts
@@ -41,18 +41,27 @@ interface FormatOptions {
   decimals?: number;
   // Append the unit label (default true).
   withUnit?: boolean;
+  // Always show exactly `decimals` digits, keeping trailing zeros (like
+  // toFixed). Default false: trailing zeros are dropped.
+  fixed?: boolean;
+  // Group thousands with separators (default true).
+  group?: boolean;
 }
 
 // Format a stored kg value for display in the user's unit, e.g. "70 kg" or
-// "154.3 lb". Thousands are grouped; trailing zeros are dropped.
+// "154.3 lb". Options preserve the exact look of each call site.
 export function formatWeight(
   kg: number,
   unit: WeightUnit,
   opts: FormatOptions = {},
 ): string {
-  const { decimals = 1, withUnit = true } = opts;
+  const { decimals = 1, withUnit = true, fixed = false, group = true } = opts;
   const display = roundWeight(toDisplayWeight(kg, unit), decimals);
-  const str = display.toLocaleString('en-US', { maximumFractionDigits: decimals });
+  const str = display.toLocaleString('en-US', {
+    minimumFractionDigits: fixed ? decimals : 0,
+    maximumFractionDigits: decimals,
+    useGrouping: group,
+  });
   return withUnit ? `${str} ${unitLabel(unit)}` : str;
 }
 


### PR DESCRIPTION
**PR 2 of imperial-unit support (issue #1).** Threads the user's `unit` preference (added in #14) through the logging and review surfaces, converting at the edges only - weight is always stored in kg.

- **Settings**: a weight-unit toggle (Kilograms / Pounds) persisted via the profile API.
- **Set input**: label, value, and increment buttons in the chosen unit; the form state and the offline (IndexedDB) `PendingSet`/submit value stay in kg, so the offline logging path is unchanged.
- **Session summary, exercise card, history list, history detail**: weights shown in the chosen unit.
- `formatWeight` gains `fixed`/`group` options so KG output stays **byte-identical** for existing users.

**Scope**: progress charts are converted in a follow-up PR (which closes #1). The AI coach stays in kg, matching its own prompt and prose.

### Subagent review caught a real bug
An independent skeptic review flagged that several sites render the *raw* stored weight (which can carry 2 decimals), and my initial `decimals:1` would have silently rounded `82.25 kg -> 82.3 kg` for existing kg users. Fixed to `{decimals:2, group:false}` (byte-identical to the old raw render) and verified by a second review pass: KG output is now identical for every reachable value.

Refs #1

## How I tested
- `bash scripts/verify.sh` -> GREEN-GATE PASSED.
- `npx vitest run lib/units.test.ts` -> 8 passed.
- Two independent skeptic subagent reviews (found + verified the kg-regression fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)