### PR TITLE
docs: README self-maintaining story, changelog, and run log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   live demo is one click to try.
 - Expanded the default exercise catalog with common machine, cable, dumbbell, and
   accessory movements, including coverage for the forearms and lower-back groups.
+- Friendly empty states with a clear call to action on the progress and history
+  pages when there is no data yet.
+- Weight-unit preference: choose kilograms or pounds for displaying and entering
+  weights across logging and history. Data is always stored in kg.
 - Test pyramid (unit, integration, E2E) with CI running lint, typecheck, unit,
   integration, build, and E2E on every pull request.
 - Docker and Docker Compose setup for local development and production.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ Open source, self hosted hypertrophy training tracker with a built in AI coach. 
 > OpenRouter), with a unit / integration / E2E test suite and deep AI
 > integration.
 
+## This repo largely maintains itself
+
+GymCoach is also an experiment in autonomous software maintenance: most of its
+ongoing changes are made by Claude Code running in **documented loops**, not by a
+human typing each one. An agent picks an open issue, writes the change to the repo
+conventions, makes it pass a green-gate (lint + typecheck + tests + build), has an
+independent agent adversarially review the diff, opens a pull request, and
+auto-merges it once CI is green. A human still owns the vision and the hard calls.
+
+The whole playbook is open and reproducible in [`docs/loops/`](docs/loops/): the
+pipeline (triage -> implement -> ship -> write-up), the guardrails, and the
+[autonomy charter](docs/loops/07-autonomy.md) the agent runs inside. If you care
+more about *how a repo can maintain itself* than about the gym app, start there.
+
 ## Features
 
 - Multi-user accounts: sign up, profiles, per-user data isolation
@@ -43,6 +57,7 @@ Open source, self hosted hypertrophy training tracker with a built in AI coach. 
 - Conversational AI coach: streaming chat grounded in your training data
 - AI program generation from a natural-language goal, editable before saving
 - Pluggable LLM provider: Anthropic SDK or any OpenRouter model
+- Train in kilograms or pounds, a per-user preference (data is always stored in kg)
 - Installable PWA with offline session logging
 
 ## Stack

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -6,6 +6,37 @@ by the charter in [`07-autonomy.md`](07-autonomy.md).
 
 ---
 
+## 2026-06-08 - Empty states + imperial units (split delivery)
+
+**Context.** Continuing the maintainer loop through the backlog (#5, #1).
+
+**Decided / shipped.**
+- Shipped #5 (empty states): a reusable `EmptyState` primitive + friendly empty states
+  with a CTA on the progress and history pages. Subagent review: READY.
+- Issue #1 (imperial units) was deliberately **split** - the full conversion across every
+  surface plus input was too large/regression-prone for one safe PR (charter: split when
+  too large). PR #14 (foundation: WeightUnit enum, additive migration, `lib/units.ts`,
+  profile API) merged. PR #15 (UX: settings toggle + logging/history conversion) opened.
+  Progress charts follow in a third PR that closes #1; the AI coach stays in kg to match
+  its own prompt/prose.
+- Content/README pass (this PR): added a "this repo largely maintains itself" section to
+  the README (the démarche is the growth engine), recorded empty states + the unit
+  preference in the CHANGELOG, and logged this run.
+
+**Challenged.** Subagents reviewed every product change. On #1 PR #15 the skeptic caught a
+**real silent regression**: rendering raw stored weights via `decimals:1` would have
+rounded `82.25 kg -> 82.3 kg` for existing kg users. Fixed to `{decimals:2, group:false}`
+(byte-identical to the old raw render) and verified by a second review pass. This is the
+adversarial loop earning its keep.
+
+**Deferred to human.** None. Progress-chart conversion and a possible coach localization
+are tracked as follow-up work, not blockers.
+
+**Next.** Merge #15 on green, then PR #3-of-#1 (progress charts) to close #1; triage to
+refill the backlog once empty.
+
+---
+
 ## 2026-06-08 - First product run (catalog + content)
 
 **Context.** Maintainer loop running unsupervised under the charter. Goal: drain ready PRs,


### PR DESCRIPTION
Content / démarche pass. The meta-story (a repo that maintains and improves itself with documented loops) is the project's growth engine, so it deserves to be front and center.

- **README**: new "This repo largely maintains itself" section pointing to `docs/loops/` (pipeline, guardrails, autonomy charter), plus a kg/lb entry in Features.
- **CHANGELOG**: empty states (#5) and the weight-unit preference under Unreleased > Added.
- **docs/loops/autonomy-log.md**: dated entry for this run, including the subagent-caught kg regression on #1.

Docs only. Should merge after #15 so the kg/lb claims are live on main.

## How I tested
- `bash scripts/verify.sh` -> GREEN-GATE PASSED.
- No em/en-dashes (repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)