### PR TITLE
feat: apply the kg/lb unit preference to the progress charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Friendly empty states with a clear call to action on the progress and history
   pages when there is no data yet.
 - Weight-unit preference: choose kilograms or pounds for displaying and entering
-  weights across logging and history. Data is always stored in kg.
+  weights everywhere (logging, history, summaries, and progress charts). Data is
+  always stored in kg.
 - Test pyramid (unit, integration, E2E) with CI running lint, typecheck, unit,
   integration, build, and E2E on every pull request.
 - Docker and Docker Compose setup for local development and production.

--- a/app/(app)/progress/page.tsx
+++ b/app/(app)/progress/page.tsx
@@ -46,10 +46,11 @@ export default async function ProgressPage({
     }),
     db.user.findUnique({
       where: { id: auth.userId },
-      select: { bodyweight: true },
+      select: { bodyweight: true, unit: true },
     }),
   ]);
   const bodyweight = user?.bodyweight ?? null;
+  const unit = user?.unit ?? 'KG';
   const usesBodyweightById = new Map(
     exercisesWithSets.map((e) => [e.id, e.usesBodyweight]),
   );
@@ -211,6 +212,7 @@ export default async function ProgressPage({
               total: w.total,
             }))}
             recap={recap}
+            unit={unit}
           />
         )}
       </div>

--- a/components/progress/progress-dashboard.tsx
+++ b/components/progress/progress-dashboard.tsx
@@ -22,7 +22,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import type { WeightUnit } from '@prisma/client';
 import type { ExerciseChartPoint } from '@/lib/stats';
+import { roundWeight, toDisplayWeight, unitLabel } from '@/lib/units';
 
 interface RecapRow {
   exerciseId: string;
@@ -52,6 +54,7 @@ interface Props {
   exercisePoints: ExerciseChartPoint[];
   weeklyPoints: SerializedWeeklyPoint[];
   recap: RecapRow[];
+  unit: WeightUnit;
 }
 
 // Stable palette for muscle groups (distinct HSL, accessible LCH).
@@ -87,10 +90,18 @@ export function ProgressDashboard({
   exercisePoints,
   weeklyPoints,
   recap,
+  unit,
 }: Props) {
   const router = useRouter();
   const search = useSearchParams();
   const [isPending, startTransition] = useTransition();
+
+  // Convert a kg value to the display unit. KG returns the raw value unchanged
+  // (so kg output stays byte-identical); LB rounds the conversion for clean
+  // axes, tooltips, and table cells.
+  const unitSuffix = unitLabel(unit);
+  const toDisplay = (kg: number) =>
+    unit === 'KG' ? kg : roundWeight(toDisplayWeight(kg, unit), 1);
 
   function selectExercise(id: string) {
     const params = new URLSearchParams(search.toString());
@@ -111,18 +122,28 @@ export function ProgressDashboard({
     return [...groups];
   }, [weeklyPoints]);
 
-  // Flatten the weekly points for Recharts (key = weekKey, value per group).
+  // Flatten the weekly points for Recharts (key = weekKey, value per group),
+  // converting each group volume to the display unit.
   const weeklyChartData = useMemo(() => {
-    return weeklyPoints.map((p) => ({
-      weekKey: p.weekKey,
-      label: shortLabelFromWeekKey(p.weekKey),
-      ...p.byMuscleGroup,
-    }));
-  }, [weeklyPoints]);
+    return weeklyPoints.map((p) => {
+      const converted: Record<string, number> = {};
+      for (const [group, value] of Object.entries(p.byMuscleGroup)) {
+        converted[group] = toDisplay(value);
+      }
+      return {
+        weekKey: p.weekKey,
+        label: shortLabelFromWeekKey(p.weekKey),
+        ...converted,
+      };
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [weeklyPoints, unit]);
 
   const exerciseChartData = exercisePoints.map((p) => ({
-    label: shortDate(p.sessionStartedAt.toString()),
     ...p,
+    label: shortDate(p.sessionStartedAt.toString()),
+    maxWeight: toDisplay(p.maxWeight),
+    estimated1RM: toDisplay(p.estimated1RM),
   }));
 
   return (
@@ -179,7 +200,7 @@ export function ProgressDashboard({
                   <Line
                     type="monotone"
                     dataKey="maxWeight"
-                    name="Max load (kg)"
+                    name={`Max load (${unitSuffix})`}
                     stroke="hsl(var(--primary))"
                     strokeWidth={2}
                     dot={{ r: 3 }}
@@ -187,7 +208,7 @@ export function ProgressDashboard({
                   <Line
                     type="monotone"
                     dataKey="estimated1RM"
-                    name="Estimated 1RM (kg)"
+                    name={`Estimated 1RM (${unitSuffix})`}
                     stroke="#a855f7"
                     strokeDasharray="4 4"
                     strokeWidth={2}
@@ -278,13 +299,13 @@ export function ProgressDashboard({
                       </td>
                       <td className="py-2">{r.sessions}</td>
                       <td className="py-2">
-                        {r.firstWeight} → {r.lastWeight} kg
+                        {toDisplay(r.firstWeight)} → {toDisplay(r.lastWeight)} {unitSuffix}
                       </td>
                       <td className={`py-2 font-medium ${deltaClass(r.weightDelta)}`}>
-                        {formatDelta(r.weightDelta)} kg
+                        {formatDelta(toDisplay(r.weightDelta))} {unitSuffix}
                       </td>
                       <td className={`py-2 ${deltaClass(r.e1rmDelta)}`}>
-                        {formatDelta(r.e1rmDelta)} kg
+                        {formatDelta(toDisplay(r.e1rmDelta))} {unitSuffix}
                       </td>
                     </tr>
                   ))}


### PR DESCRIPTION
**Final part of imperial-unit support (issue #1).** The progress page was the last surface still hardcoded to kg; now it honors the user's unit like the rest of the app.

- Converts the **plotted data** to the display unit (not just labels): max load + estimated 1RM line chart, and the weekly volume-per-muscle-group bars.
- Chart series labels use the unit ("Max load (lb)" / "Estimated 1RM (lb)").
- Recap table (load start -> end, delta load, delta 1RM) converts via the same helper.
- Threads `unit` from the progress page into `ProgressDashboard`.
- kg output stays **byte-identical** for existing users: the `toDisplay` helper returns the raw kg value unchanged when unit is KG.

With this, the unit preference applies everywhere a weight is shown or entered, satisfying the issue's "all weight displays" criterion. (The AI coach intentionally stays in kg, matching its own prompt/prose.)

Closes #1

## How I tested
- `bash scripts/verify.sh` -> GREEN-GATE PASSED.
- Independent skeptic subagent review: READY (verified kg byte-parity, no double-conversion, no mixed units, correct spread order and memo deps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)