### PR TITLE
fix: make the set-logger quick-note placeholder unit-agnostic

### DIFF
--- a/components/session/set-input.tsx
+++ b/components/session/set-input.tsx
@@ -224,7 +224,7 @@ export function SetInput({ programExercise, existingSets, lastPerformance, unit,
             rows={2}
             value={form.notes}
             onChange={(e) => setForm((f) => ({ ...f, notes: e.target.value }))}
-            placeholder="e.g. wrist pain, drop set 22.5 then 18kg, etc."
+            placeholder="e.g. wrist pain, dropped the weight mid-set, felt easy, etc."
           />
         </div>
 


### PR DESCRIPTION
The set logger's quick-note placeholder hardcoded a kg example ("...then 18kg..."), which read wrong for pounds users now that the unit is configurable (#1). Replaced with a unit-free example.

Closes #19

## How I tested
- \`bash scripts/verify.sh\` -> GREEN-GATE PASSED.

Trivial copy-only change (no logic), so no separate subagent review per the autonomy charter's non-trivial threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)