### PR TITLE
test: add validation tests for the lib/schemas Zod schemas

### DIFF
--- a/lib/schemas/exercise.test.ts
+++ b/lib/schemas/exercise.test.ts
@@ -20,10 +20,18 @@ describe('exerciseInputSchema', () => {
     expect(exerciseInputSchema.safeParse({ ...valid, category: 'CARDIO' }).success).toBe(false);
   });
 
-  it('coerces usesBodyweight and enforces the rest-time range', () => {
-    expect(exerciseInputSchema.parse({ ...valid, usesBodyweight: 'true' }).usesBodyweight).toBe(
+  it('coerces usesBodyweight with JS Boolean semantics (any non-empty string is true)', () => {
+    // z.coerce.boolean() is Boolean(value): an empty string is false, and ANY
+    // non-empty string (even "false") is true. Documented here so the footgun
+    // is explicit; callers should send real booleans, not string flags.
+    expect(exerciseInputSchema.parse({ ...valid, usesBodyweight: true }).usesBodyweight).toBe(true);
+    expect(exerciseInputSchema.parse({ ...valid, usesBodyweight: '' }).usesBodyweight).toBe(false);
+    expect(exerciseInputSchema.parse({ ...valid, usesBodyweight: 'false' }).usesBodyweight).toBe(
       true,
     );
+  });
+
+  it('enforces the default-rest-time range', () => {
     expect(exerciseInputSchema.safeParse({ ...valid, defaultRestSec: 5 }).success).toBe(false);
     expect(exerciseInputSchema.safeParse({ ...valid, defaultRestSec: 601 }).success).toBe(false);
   });

--- a/lib/schemas/exercise.test.ts
+++ b/lib/schemas/exercise.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { exerciseInputSchema } from './exercise';
+
+describe('exerciseInputSchema', () => {
+  const valid = { name: 'Bench press', muscleGroup: 'CHEST', category: 'COMPOUND' };
+
+  it('accepts a valid exercise and applies defaults', () => {
+    const parsed = exerciseInputSchema.parse(valid);
+    expect(parsed.defaultRestSec).toBe(90);
+    expect(parsed.usesBodyweight).toBe(false);
+  });
+
+  it('trims the name and rejects an empty one', () => {
+    expect(exerciseInputSchema.parse({ ...valid, name: '  Squat  ' }).name).toBe('Squat');
+    expect(exerciseInputSchema.safeParse({ ...valid, name: '  ' }).success).toBe(false);
+  });
+
+  it('rejects an unknown muscle group or category', () => {
+    expect(exerciseInputSchema.safeParse({ ...valid, muscleGroup: 'NECK' }).success).toBe(false);
+    expect(exerciseInputSchema.safeParse({ ...valid, category: 'CARDIO' }).success).toBe(false);
+  });
+
+  it('coerces usesBodyweight and enforces the rest-time range', () => {
+    expect(exerciseInputSchema.parse({ ...valid, usesBodyweight: 'true' }).usesBodyweight).toBe(
+      true,
+    );
+    expect(exerciseInputSchema.safeParse({ ...valid, defaultRestSec: 5 }).success).toBe(false);
+    expect(exerciseInputSchema.safeParse({ ...valid, defaultRestSec: 601 }).success).toBe(false);
+  });
+});

--- a/lib/schemas/program-exercise.test.ts
+++ b/lib/schemas/program-exercise.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { programExerciseInputSchema } from './program-exercise';
+
+describe('programExerciseInputSchema', () => {
+  const valid = {
+    exerciseId: 'ex1',
+    targetSets: 3,
+    targetRepsMin: 8,
+    targetRepsMax: 12,
+    targetRIR: 2,
+    restSec: 120,
+  };
+
+  it('accepts a valid program exercise and coerces numeric strings', () => {
+    const parsed = programExerciseInputSchema.parse({ ...valid, targetSets: '4' });
+    expect(parsed.targetSets).toBe(4);
+  });
+
+  it('allows an equal rep range (min === max)', () => {
+    expect(
+      programExerciseInputSchema.safeParse({ ...valid, targetRepsMin: 10, targetRepsMax: 10 })
+        .success,
+    ).toBe(true);
+  });
+
+  it('rejects targetRepsMax below targetRepsMin (cross-field refine)', () => {
+    const res = programExerciseInputSchema.safeParse({
+      ...valid,
+      targetRepsMin: 12,
+      targetRepsMax: 8,
+    });
+    expect(res.success).toBe(false);
+    if (!res.success) {
+      expect(res.error.issues.some((i) => i.path.includes('targetRepsMax'))).toBe(true);
+    }
+  });
+
+  it('enforces bounds on sets, RIR, and rest', () => {
+    expect(programExerciseInputSchema.safeParse({ ...valid, targetSets: 21 }).success).toBe(false);
+    expect(programExerciseInputSchema.safeParse({ ...valid, targetRIR: 6 }).success).toBe(false);
+    expect(programExerciseInputSchema.safeParse({ ...valid, restSec: 14 }).success).toBe(false);
+  });
+});

--- a/lib/schemas/program.test.ts
+++ b/lib/schemas/program.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { programInputSchema } from './program';
+
+describe('programInputSchema', () => {
+  it('accepts a valid program and trims fields', () => {
+    const parsed = programInputSchema.parse({
+      name: '  Upper/Lower  ',
+      phase: '  Hypertrophy  ',
+      description: '  4-week block  ',
+    });
+    expect(parsed.name).toBe('Upper/Lower');
+    expect(parsed.phase).toBe('Hypertrophy');
+    expect(parsed.description).toBe('4-week block');
+  });
+
+  it('treats description as optional', () => {
+    expect(programInputSchema.safeParse({ name: 'PPL', phase: 'Base' }).success).toBe(true);
+  });
+
+  it('requires name and phase', () => {
+    expect(programInputSchema.safeParse({ name: '', phase: 'Base' }).success).toBe(false);
+    expect(programInputSchema.safeParse({ name: 'PPL', phase: '' }).success).toBe(false);
+  });
+
+  it('rejects an over-long name', () => {
+    expect(programInputSchema.safeParse({ name: 'x'.repeat(121), phase: 'Base' }).success).toBe(
+      false,
+    );
+  });
+});

--- a/lib/schemas/session.test.ts
+++ b/lib/schemas/session.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { sessionStartSchema, sessionUpdateSchema } from './session';
+
+describe('sessionStartSchema', () => {
+  it('requires a non-empty workoutId', () => {
+    expect(sessionStartSchema.parse({ workoutId: 'w1' }).workoutId).toBe('w1');
+    expect(sessionStartSchema.safeParse({ workoutId: '' }).success).toBe(false);
+    expect(sessionStartSchema.safeParse({}).success).toBe(false);
+  });
+});
+
+describe('sessionUpdateSchema', () => {
+  it('accepts an empty object (all fields optional)', () => {
+    expect(sessionUpdateSchema.safeParse({}).success).toBe(true);
+  });
+
+  it('trims notes and accepts a finish flag', () => {
+    const parsed = sessionUpdateSchema.parse({ notes: '  good session  ', finish: true });
+    expect(parsed.notes).toBe('good session');
+    expect(parsed.finish).toBe(true);
+  });
+
+  it('rejects notes longer than 2000 characters', () => {
+    expect(sessionUpdateSchema.safeParse({ notes: 'x'.repeat(2001) }).success).toBe(false);
+  });
+});

--- a/lib/schemas/set.test.ts
+++ b/lib/schemas/set.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { setInputSchema } from './set';
+
+describe('setInputSchema', () => {
+  const valid = { exerciseId: 'ex1', setNumber: 1, weight: 60, reps: 10 };
+
+  it('accepts a minimal valid set and applies boolean defaults', () => {
+    const parsed = setInputSchema.parse(valid);
+    expect(parsed.isWarmup).toBe(false);
+    expect(parsed.isDropSet).toBe(false);
+  });
+
+  it('coerces numeric strings', () => {
+    const parsed = setInputSchema.parse({
+      exerciseId: 'ex1',
+      setNumber: '2',
+      weight: '82.5',
+      reps: '8',
+    });
+    expect(parsed.setNumber).toBe(2);
+    expect(parsed.weight).toBe(82.5);
+    expect(parsed.reps).toBe(8);
+  });
+
+  it('allows weight 0 (bodyweight) and a null rir', () => {
+    expect(setInputSchema.parse({ ...valid, weight: 0, rir: null }).rir).toBeNull();
+  });
+
+  it('rejects an empty exerciseId', () => {
+    expect(setInputSchema.safeParse({ ...valid, exerciseId: '' }).success).toBe(false);
+  });
+
+  it('rejects out-of-range weight, reps, setNumber, and rir', () => {
+    expect(setInputSchema.safeParse({ ...valid, weight: 501 }).success).toBe(false);
+    expect(setInputSchema.safeParse({ ...valid, weight: -1 }).success).toBe(false);
+    expect(setInputSchema.safeParse({ ...valid, reps: 101 }).success).toBe(false);
+    expect(setInputSchema.safeParse({ ...valid, setNumber: 0 }).success).toBe(false);
+    expect(setInputSchema.safeParse({ ...valid, rir: 6 }).success).toBe(false);
+  });
+
+  it('rejects non-integer reps and setNumber', () => {
+    expect(setInputSchema.safeParse({ ...valid, reps: 8.5 }).success).toBe(false);
+    expect(setInputSchema.safeParse({ ...valid, setNumber: 1.5 }).success).toBe(false);
+  });
+});

--- a/lib/schemas/workout.test.ts
+++ b/lib/schemas/workout.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { workoutInputSchema } from './workout';
+
+describe('workoutInputSchema', () => {
+  it('accepts a name with a valid day of week', () => {
+    const parsed = workoutInputSchema.parse({ name: 'Push', dayOfWeek: 1 });
+    expect(parsed).toEqual({ name: 'Push', dayOfWeek: 1 });
+  });
+
+  it('trims the name and rejects an empty one', () => {
+    expect(workoutInputSchema.parse({ name: '  Pull  ' }).name).toBe('Pull');
+    expect(workoutInputSchema.safeParse({ name: '   ' }).success).toBe(false);
+  });
+
+  it('normalizes an empty-string day of week to null', () => {
+    expect(workoutInputSchema.parse({ name: 'Legs', dayOfWeek: '' }).dayOfWeek).toBeNull();
+  });
+
+  it('coerces a numeric-string day and rejects out-of-range days', () => {
+    expect(workoutInputSchema.parse({ name: 'Legs', dayOfWeek: '3' }).dayOfWeek).toBe(3);
+    expect(workoutInputSchema.safeParse({ name: 'Legs', dayOfWeek: 8 }).success).toBe(false);
+    expect(workoutInputSchema.safeParse({ name: 'Legs', dayOfWeek: 0 }).success).toBe(false);
+  });
+});


### PR DESCRIPTION
Adds colocated Vitest tests for the six API-input schemas that lacked coverage: `set`, `session`, `workout`, `program`, `program-exercise`, `exercise`. Validating API input with Zod is a core repo convention, so these lock in the accept/reject behavior.

Covers: valid payloads, numeric-string coercion, defaults (e.g. `isWarmup`/`isDropSet` false, `defaultRestSec` 90), boundary rejection (out-of-range weights/reps/sets/RIR/rest), the workout `dayOfWeek` transform, and the program-exercise `repsMax >= repsMin` refine. Per the skeptic review, the `usesBodyweight` test now documents the real `z.coerce.boolean()` footgun (any non-empty string is true).

Closes #18

## How I tested
- `npx vitest run lib/schemas/` -> all pass (8 files).
- `bash scripts/verify.sh` -> GREEN-GATE PASSED.
- Independent skeptic subagent review: READY (every assertion verified against the schema source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)