### PR TITLE
test: integration coverage for getLastPerformances

### DIFF
--- a/tests/integration/last-performance.test.ts
+++ b/tests/integration/last-performance.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { db } from '@/lib/db';
+import { getLastPerformances } from '@/lib/last-performance';
+
+async function makeUser(email: string) {
+  return db.user.create({ data: { email, passwordHash: 'x' } });
+}
+
+async function makeExercise(userId: string, name = 'Bench') {
+  return db.exercise.create({
+    data: { userId, name, muscleGroup: 'CHEST', category: 'COMPOUND' },
+  });
+}
+
+// A set's date controls both "most recent session" ordering and seeding.
+function at(daysAgo: number): Date {
+  return new Date(Date.UTC(2026, 0, 30 - daysAgo, 12, 0, 0));
+}
+
+describe('getLastPerformances', () => {
+  it('returns the most recent session with its max load and reps at that load', async () => {
+    const user = await makeUser('lp-recent@test.dev');
+    const exo = await makeExercise(user.id);
+
+    // Older session: should be ignored once a newer one exists.
+    const older = await db.session.create({
+      data: { userId: user.id, startedAt: at(7) },
+    });
+    await db.set.create({
+      data: { sessionId: older.id, exerciseId: exo.id, setNumber: 1, weight: 80, reps: 8, completedAt: at(7) },
+    });
+
+    // Newer session: a warmup (excluded), then working sets. Top load 100,
+    // reached for 5 then 6 reps -> repsAtMaxWeight must be the higher (6).
+    const newer = await db.session.create({
+      data: { userId: user.id, startedAt: at(1) },
+    });
+    await db.set.createMany({
+      data: [
+        { sessionId: newer.id, exerciseId: exo.id, setNumber: 1, weight: 60, reps: 12, isWarmup: true, completedAt: at(1) },
+        { sessionId: newer.id, exerciseId: exo.id, setNumber: 2, weight: 90, reps: 8, completedAt: at(1) },
+        { sessionId: newer.id, exerciseId: exo.id, setNumber: 3, weight: 100, reps: 5, completedAt: at(1) },
+        { sessionId: newer.id, exerciseId: exo.id, setNumber: 4, weight: 100, reps: 6, completedAt: at(1) },
+      ],
+    });
+
+    const map = await getLastPerformances(user.id, [exo.id], null);
+    const perf = map.get(exo.id);
+
+    expect(perf).toBeDefined();
+    expect(perf!.sessionStartedAt.getTime()).toBe(at(1).getTime());
+    expect(perf!.maxWeight).toBe(100);
+    expect(perf!.repsAtMaxWeight).toBe(6);
+    // Warmup excluded: 3 working sets only.
+    expect(perf!.sets).toHaveLength(3);
+    expect(perf!.sets.some((s) => s.weight === 60)).toBe(false);
+  });
+
+  it('excludes the current session via excludeSessionId', async () => {
+    const user = await makeUser('lp-exclude@test.dev');
+    const exo = await makeExercise(user.id);
+
+    const previous = await db.session.create({ data: { userId: user.id, startedAt: at(5) } });
+    await db.set.create({
+      data: { sessionId: previous.id, exerciseId: exo.id, setNumber: 1, weight: 70, reps: 10, completedAt: at(5) },
+    });
+    const current = await db.session.create({ data: { userId: user.id, startedAt: at(0) } });
+    await db.set.create({
+      data: { sessionId: current.id, exerciseId: exo.id, setNumber: 1, weight: 110, reps: 3, completedAt: at(0) },
+    });
+
+    // Excluding the current session, the last performance is the previous one.
+    const map = await getLastPerformances(user.id, [exo.id], current.id);
+    expect(map.get(exo.id)?.maxWeight).toBe(70);
+
+    // With no exclusion, the current session wins.
+    const all = await getLastPerformances(user.id, [exo.id], null);
+    expect(all.get(exo.id)?.maxWeight).toBe(110);
+  });
+
+  it("does not leak another user's sets", async () => {
+    const owner = await makeUser('lp-owner@test.dev');
+    const exo = await makeExercise(owner.id);
+    const session = await db.session.create({ data: { userId: owner.id, startedAt: at(2) } });
+    await db.set.create({
+      data: { sessionId: session.id, exerciseId: exo.id, setNumber: 1, weight: 120, reps: 5, completedAt: at(2) },
+    });
+
+    const stranger = await makeUser('lp-stranger@test.dev');
+    // The stranger asks for the owner's exercise id: ownership is enforced on
+    // the session, so nothing is returned.
+    const map = await getLastPerformances(stranger.id, [exo.id], null);
+    expect(map.has(exo.id)).toBe(false);
+  });
+
+  it('returns an empty map when there is no history', async () => {
+    const user = await makeUser('lp-empty@test.dev');
+    const exo = await makeExercise(user.id);
+    const map = await getLastPerformances(user.id, [exo.id], null);
+    expect(map.size).toBe(0);
+  });
+});


### PR DESCRIPTION
Adds integration coverage for `lib/last-performance.ts` (`getLastPerformances`), the helper that pre-fills the session logger's suggestions. Runs against the test Postgres (integration tier).

Asserts:
- picks the most recent session per exercise (by `completedAt`);
- `maxWeight` and `repsAtMaxWeight` (the higher rep count at the top load);
- warmup sets are excluded;
- `excludeSessionId` skips the current session;
- no cross-user leakage (ownership enforced via the session relation);
- empty map when there is no history.

Closes #20

## How I tested
- Brought up `docker-compose.test.yml`, `prisma migrate deploy`, then ran the integration suite: `tests/integration/last-performance.test.ts` 4/4 pass, full integration suite 7/7 pass.
- `bash scripts/verify.sh` (default gate, incl. `tsc`) -> GREEN-GATE PASSED.
- CI runs this in the integration job.
- Independent skeptic subagent review: READY (assertions match query semantics, deterministic, non-vacuous).

🤖 Generated with [Claude Code](https://claude.com/claude-code)