### PR TITLE
test: add unit tests for lib/preferences.ts

### DIFF
--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -6,6 +6,38 @@ by the charter in [`07-autonomy.md`](07-autonomy.md).
 
 ---
 
+## 2026-06-08 - Backlog cleared (tests + polish)
+
+**Context.** Drain the triaged batch (#18/#19/#20) and keep the pipeline honest.
+
+**Decided / shipped.**
+- #19 (Closes): unit-agnostic set-note placeholder. Trivial copy change, so no subagent
+  review per the charter's non-trivial threshold - documented that judgment in the PR.
+- #18 (Closes): validation tests for the six untested `lib/schemas` Zod schemas (40 cases).
+- #20 (Closes): integration tests for `getLastPerformances`, run against the real test
+  Postgres locally (full integration suite 7/7) before shipping, not just typechecked.
+- Subagent reviews on #18 and #20 returned READY; the #18 review prompted documenting a
+  real `z.coerce.boolean()` footgun ("false" coerces to true).
+
+**Challenged / process guardrails that fired.**
+- **Commit on a RED gate, caught and reverted.** A `verify.sh | tail && git commit` chain
+  let the pipe mask verify.sh's non-zero exit, so a commit landed while typecheck was red.
+  Caught it immediately, fixed the test, re-verified by capturing the exit code to a file.
+  Lesson recorded in the loop prompts: never pipe the gate through `tail` in a commit chain.
+- **Mixed-scope branch, untangled.** The #18 test commit had been stacked on the #19
+  branch; recovered by cherry-picking it onto a clean branch so each PR holds one scope.
+- **Non-fast-forward after an amend, reconciled without force.** Amending an already-pushed
+  commit broke the push; resolved with `reset --soft` + a new commit (force-push stays
+  denied by the charter), never rewriting pushed history.
+
+**Deferred to human.** None.
+
+**Next.** Backlog empty -> triage to refill (uncovered lib modules / small polish), then
+implement with subagent review. The big roadmap item (in-session AI suggestions) is left
+for a human to scope.
+
+---
+
 ## 2026-06-08 - Imperial units complete + backlog refilled
 
 **Context.** Close out issue #1 and keep the pipeline fed.

--- a/lib/preferences.test.ts
+++ b/lib/preferences.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  DEFAULT_PREFERENCES,
+  loadPreferences,
+  savePreferences,
+  isVibrationEnabled,
+  isRestTimerSoundEnabled,
+} from './preferences';
+
+const STORAGE_KEY = 'gymcoach.prefs.v1';
+
+describe('preferences', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('returns the defaults when nothing is stored', () => {
+    expect(loadPreferences()).toEqual(DEFAULT_PREFERENCES);
+  });
+
+  it('merges a partial stored object over the defaults', () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ restTimerSound: true }));
+    expect(loadPreferences()).toEqual({
+      vibration: DEFAULT_PREFERENCES.vibration,
+      restTimerSound: true,
+    });
+  });
+
+  it('falls back to the defaults on corrupt JSON without throwing', () => {
+    window.localStorage.setItem(STORAGE_KEY, '{not valid json');
+    expect(loadPreferences()).toEqual(DEFAULT_PREFERENCES);
+  });
+
+  it('round-trips through savePreferences', () => {
+    const prefs = { vibration: false, restTimerSound: true };
+    savePreferences(prefs);
+    expect(loadPreferences()).toEqual(prefs);
+  });
+
+  it('exposes targeted helpers that reflect stored values', () => {
+    savePreferences({ vibration: false, restTimerSound: true });
+    expect(isVibrationEnabled()).toBe(false);
+    expect(isRestTimerSoundEnabled()).toBe(true);
+  });
+});


### PR DESCRIPTION
Adds colocated unit tests for `lib/preferences.ts` (local user preferences in localStorage): defaults when empty, partial-merge over defaults, corrupt-JSON fallback (no throw), save/load round-trip, and the `isVibrationEnabled` / `isRestTimerSoundEnabled` helpers.

Closes #26

## How I tested
- `npx vitest run lib/preferences.test.ts` -> 5 passed.
- `bash scripts/verify.sh` -> GREEN-GATE PASSED (exit 0).
- Independent skeptic subagent review: READY (assertions match behavior, non-vacuous, isolated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)