### PR TITLE
test: cover the API error handling in lib/api.ts

### DIFF
--- a/lib/api.test.ts
+++ b/lib/api.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+import { z } from 'zod';
+import { Prisma } from '@prisma/client';
+import { ApiError, handleApiError, parseJsonBody } from './api';
+
+function jsonRequest(body: string): Request {
+  return new Request('http://test.local/api', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+  });
+}
+
+describe('handleApiError', () => {
+  it('maps an ApiError to its own status and message', async () => {
+    const res = handleApiError(new ApiError(401, 'Unauthorized'));
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({ error: 'Unauthorized' });
+  });
+
+  it('maps a Prisma P2002 unique-constraint error to 409', async () => {
+    const err = new Prisma.PrismaClientKnownRequestError('dup', {
+      code: 'P2002',
+      clientVersion: 'test',
+    });
+    const res = handleApiError(err);
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toEqual({
+      error: 'Conflict: an entry with this value already exists.',
+    });
+  });
+
+  it('maps a Prisma P2025 record-not-found error to 404', async () => {
+    const err = new Prisma.PrismaClientKnownRequestError('missing', {
+      code: 'P2025',
+      clientVersion: 'test',
+    });
+    const res = handleApiError(err);
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({ error: 'Not found.' });
+  });
+
+  it('maps any other error to a generic 500 without leaking details', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const res = handleApiError(new Error('database password is hunter2'));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Server error.' });
+    expect(JSON.stringify(body)).not.toContain('hunter2');
+    spy.mockRestore();
+  });
+
+  it('treats an unknown Prisma code as a 500 (not 409/404)', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const err = new Prisma.PrismaClientKnownRequestError('boom', {
+      code: 'P2003',
+      clientVersion: 'test',
+    });
+    const res = handleApiError(err);
+    expect(res.status).toBe(500);
+    spy.mockRestore();
+  });
+});
+
+describe('parseJsonBody', () => {
+  const schema = z.object({ name: z.string().min(1) });
+
+  it('returns the parsed data for a valid payload', async () => {
+    const data = await parseJsonBody(jsonRequest(JSON.stringify({ name: 'ok' })), schema);
+    expect(data).toEqual({ name: 'ok' });
+  });
+
+  it('throws a 400 ApiError on invalid JSON', async () => {
+    await expect(parseJsonBody(jsonRequest('not json{'), schema)).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+
+  it('throws a 400 ApiError when the payload fails schema validation', async () => {
+    await expect(
+      parseJsonBody(jsonRequest(JSON.stringify({ name: '' })), schema),
+    ).rejects.toBeInstanceOf(ApiError);
+    await expect(
+      parseJsonBody(jsonRequest(JSON.stringify({ name: '' })), schema),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});


### PR DESCRIPTION
Adds `lib/api.test.ts` for the centralized API error handling every route relies on.

- `handleApiError`: ApiError -> its own status/message; Prisma `P2002` -> 409; `P2025` -> 404; an unknown Prisma code and any other error -> generic 500 (asserts the original message, e.g. a secret, does not leak into the body).
- `parseJsonBody`: returns parsed data on success; throws a 400 `ApiError` on invalid JSON and on Zod-invalid payloads.

Console noise on the 500 path is suppressed and restored per test.

Closes #27

## How I tested
- `npx vitest run lib/api.test.ts` -> 8 passed.
- `bash scripts/verify.sh` -> GREEN-GATE PASSED (exit 0).
- Independent skeptic subagent review: READY (verified the Prisma `instanceof` actually matches, so the 409/404 branches are exercised, not vacuous).

🤖 Generated with [Claude Code](https://claude.com/claude-code)