### PR TITLE
test: add unit coverage for lib/llm/index.ts provider resolution

### DIFF
--- a/lib/llm/index.test.ts
+++ b/lib/llm/index.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getLlmProvider, resolveProviderId } from './index';
+
+// resolveProviderId() and getLlmProvider() select the AI provider from the
+// LLM_PROVIDER env var. We save/restore the var around every test so this
+// suite never leaks state into the others.
+describe('lib/llm provider resolution', () => {
+  let originalValue: string | undefined;
+
+  beforeEach(() => {
+    originalValue = process.env.LLM_PROVIDER;
+  });
+
+  afterEach(() => {
+    if (originalValue === undefined) {
+      delete process.env.LLM_PROVIDER;
+    } else {
+      process.env.LLM_PROVIDER = originalValue;
+    }
+  });
+
+  describe('resolveProviderId', () => {
+    it('defaults to anthropic when LLM_PROVIDER is unset', () => {
+      delete process.env.LLM_PROVIDER;
+      expect(resolveProviderId()).toBe('anthropic');
+    });
+
+    it('resolves the exact known values', () => {
+      process.env.LLM_PROVIDER = 'anthropic';
+      expect(resolveProviderId()).toBe('anthropic');
+      process.env.LLM_PROVIDER = 'openrouter';
+      expect(resolveProviderId()).toBe('openrouter');
+      process.env.LLM_PROVIDER = 'demo';
+      expect(resolveProviderId()).toBe('demo');
+    });
+
+    it('is case-insensitive', () => {
+      process.env.LLM_PROVIDER = 'Demo';
+      expect(resolveProviderId()).toBe('demo');
+      process.env.LLM_PROVIDER = 'OPENROUTER';
+      expect(resolveProviderId()).toBe('openrouter');
+      process.env.LLM_PROVIDER = 'AnThRoPiC';
+      expect(resolveProviderId()).toBe('anthropic');
+    });
+
+    it('trims surrounding whitespace', () => {
+      process.env.LLM_PROVIDER = '  demo  ';
+      expect(resolveProviderId()).toBe('demo');
+      process.env.LLM_PROVIDER = '\topenrouter\n';
+      expect(resolveProviderId()).toBe('openrouter');
+    });
+
+    it('falls back to anthropic for an unknown value', () => {
+      process.env.LLM_PROVIDER = 'foo';
+      expect(resolveProviderId()).toBe('anthropic');
+    });
+
+    it('falls back to anthropic for an empty string', () => {
+      process.env.LLM_PROVIDER = '';
+      expect(resolveProviderId()).toBe('anthropic');
+    });
+  });
+
+  describe('getLlmProvider', () => {
+    it('returns a provider whose id matches the resolved id', () => {
+      process.env.LLM_PROVIDER = 'anthropic';
+      expect(getLlmProvider().id).toBe('anthropic');
+      process.env.LLM_PROVIDER = 'openrouter';
+      expect(getLlmProvider().id).toBe('openrouter');
+      process.env.LLM_PROVIDER = 'demo';
+      expect(getLlmProvider().id).toBe('demo');
+    });
+
+    it('returns the anthropic provider by default', () => {
+      delete process.env.LLM_PROVIDER;
+      expect(getLlmProvider().id).toBe('anthropic');
+    });
+  });
+});


### PR DESCRIPTION
Adds the missing colocated unit test for `lib/llm/index.ts`, the provider-selection seam for the whole AI layer.

- `resolveProviderId()`: default (unset) -> `anthropic`; exact `anthropic`/`openrouter`/`demo`; case-insensitivity; whitespace trimming; unknown and empty -> `anthropic` fallback.
- `getLlmProvider()`: returned instance `.id` matches the resolved id for all three providers; default is anthropic.

Tests only - no change to `lib/llm/index.ts` behavior, no new dependencies. The test saves/restores `process.env.LLM_PROVIDER` so it does not leak state into other suites.

Closes #34

## How I tested
- `bash scripts/verify.sh` -> GREEN-GATE PASSED (prisma generate + lint + typecheck + unit + build).
- `npx vitest run lib/llm/index.test.ts` -> 8 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)