### PR TITLE
feat: in-workout plate-loading calculator

### DIFF
--- a/components/session/plate-calculator.tsx
+++ b/components/session/plate-calculator.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Calculator } from 'lucide-react';
+import type { WeightUnit } from '@prisma/client';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { computePlateLoad } from '@/lib/plates';
+import { plateConfigForUnit } from '@/lib/preferences';
+import { roundWeight, toDisplayWeight, unitLabel } from '@/lib/units';
+
+interface Props {
+  // The current target load, stored in kg (the app's storage unit).
+  weightKg: number;
+  unit: WeightUnit;
+}
+
+// In-workout plate-loading calculator (issue #39). Reads the user's per-unit
+// bar weight + plate inventory from preferences and shows the plates to load
+// per side for the current target weight. Display-only; never mutates the set.
+export function PlateCalculator({ weightKg, unit }: Props) {
+  const [open, setOpen] = useState(false);
+
+  // Compute lazily when the dialog opens so localStorage is only read on the
+  // client (and only when the user actually wants the calculator).
+  const result = useMemo(() => {
+    if (!open) return null;
+    const { barWeight, plates } = plateConfigForUnit(unit);
+    const target = roundWeight(toDisplayWeight(weightKg, unit), 2);
+    return { target, ...computePlateLoad(target, barWeight, plates) };
+  }, [open, weightKg, unit]);
+
+  const label = unitLabel(unit);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1 px-2 text-xs text-muted-foreground"
+          aria-label="Open the plate calculator"
+        >
+          <Calculator className="size-4" />
+          Plates
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Plate calculator</DialogTitle>
+          <DialogDescription>
+            Plates to load per side for{' '}
+            {result ? `${result.target} ${label}` : `the current weight`} on a{' '}
+            {result ? `${result.barWeight} ${label}` : ''} bar.
+          </DialogDescription>
+        </DialogHeader>
+
+        {result && (
+          <div className="space-y-4">
+            {result.perSide.length > 0 ? (
+              <div className="flex flex-wrap gap-2" aria-label="Plates per side">
+                {result.perSide.map((g) => (
+                  <Badge
+                    key={g.plate}
+                    variant="secondary"
+                    className="text-base font-semibold"
+                  >
+                    {g.count} x {g.plate} {label}
+                  </Badge>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                Just the bar - no plates needed.
+              </p>
+            )}
+
+            <p className="text-sm text-muted-foreground">
+              Loads to {result.achievedWeight} {label} (bar {result.barWeight} {label}).
+            </p>
+
+            {!result.exact && result.remainder > 0 && (
+              <p className="text-sm text-amber-600 dark:text-amber-500">
+                {result.remainder} {label} cannot be loaded with your available
+                plates. Adjust the target or your plate inventory in settings.
+              </p>
+            )}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/session/set-input.tsx
+++ b/components/session/set-input.tsx
@@ -17,6 +17,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { suggestNextWeight, weightIncrement } from '@/lib/progression';
+import { PlateCalculator } from '@/components/session/plate-calculator';
 import type { PendingSet } from '@/lib/indexeddb';
 import type { SerializedLastPerformance } from './session-runner';
 
@@ -98,9 +99,12 @@ export function SetInput({ programExercise, existingSets, lastPerformance, unit,
       <CardContent className="flex flex-col gap-4 pt-6">
         {/* Load */}
         <div className="space-y-2">
-          <Label className="text-xs uppercase tracking-wide text-muted-foreground">
-            Load ({unitLabel(unit)})
-          </Label>
+          <div className="flex items-center justify-between">
+            <Label className="text-xs uppercase tracking-wide text-muted-foreground">
+              Load ({unitLabel(unit)})
+            </Label>
+            <PlateCalculator weightKg={form.weight} unit={unit} />
+          </div>
           <div className="flex items-center gap-2">
             <Button
               type="button"

--- a/components/settings/settings-client.tsx
+++ b/components/settings/settings-client.tsx
@@ -6,6 +6,8 @@ import { Moon, Smartphone, Sun, Volume2, Monitor } from 'lucide-react';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import {
   DEFAULT_PREFERENCES,
   loadPreferences,
@@ -92,8 +94,105 @@ export function SettingsClient() {
         </CardContent>
       </Card>
 
+      <Card>
+        <CardHeader className="pb-3">
+          <h2 className="text-base font-semibold">Plate calculator</h2>
+          <p className="text-xs text-muted-foreground">
+            Bar weight and available plates per side, used by the in-workout
+            plate calculator. Set the values for the unit you train in.
+          </p>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <BarPlatesRow
+            unitLabel="kg"
+            barWeight={prefs.barWeightKg}
+            plates={prefs.platesKg}
+            onBarChange={(v) => update('barWeightKg', v)}
+            onPlatesChange={(v) => update('platesKg', v)}
+            disabled={!hydrated}
+          />
+          <BarPlatesRow
+            unitLabel="lb"
+            barWeight={prefs.barWeightLb}
+            plates={prefs.platesLb}
+            onBarChange={(v) => update('barWeightLb', v)}
+            onPlatesChange={(v) => update('platesLb', v)}
+            disabled={!hydrated}
+          />
+        </CardContent>
+      </Card>
+
       <BackupSection />
     </>
+  );
+}
+
+function BarPlatesRow({
+  unitLabel,
+  barWeight,
+  plates,
+  onBarChange,
+  onPlatesChange,
+  disabled,
+}: {
+  unitLabel: string;
+  barWeight: number;
+  plates: number[];
+  onBarChange: (v: number) => void;
+  onPlatesChange: (v: number[]) => void;
+  disabled?: boolean;
+}) {
+  // Edit plates as comma-separated text; commit a cleaned, descending list on
+  // change. Empty / invalid entries are dropped so the calculator stays sane.
+  function commitPlates(raw: string) {
+    const parsed = raw
+      .split(',')
+      .map((s) => parseFloat(s.trim()))
+      .filter((n) => Number.isFinite(n) && n > 0)
+      .sort((a, b) => b - a);
+    onPlatesChange(parsed);
+  }
+
+  return (
+    <div className="rounded-md border border-border/40 p-3">
+      <p className="mb-2 text-sm font-medium">Equipment ({unitLabel})</p>
+      <div className="flex flex-col gap-3">
+        <div className="space-y-1">
+          <Label
+            htmlFor={`bar-${unitLabel}`}
+            className="text-xs uppercase tracking-wide text-muted-foreground"
+          >
+            Bar weight ({unitLabel})
+          </Label>
+          <Input
+            id={`bar-${unitLabel}`}
+            type="number"
+            inputMode="decimal"
+            step="0.5"
+            value={barWeight}
+            disabled={disabled}
+            onChange={(e) => onBarChange(parseFloat(e.target.value) || 0)}
+          />
+        </div>
+        <div className="space-y-1">
+          <Label
+            htmlFor={`plates-${unitLabel}`}
+            className="text-xs uppercase tracking-wide text-muted-foreground"
+          >
+            Plates per side ({unitLabel})
+          </Label>
+          <Input
+            id={`plates-${unitLabel}`}
+            type="text"
+            inputMode="decimal"
+            defaultValue={plates.join(', ')}
+            disabled={disabled}
+            onBlur={(e) => commitPlates(e.target.value)}
+            placeholder="e.g. 25, 20, 15, 10, 5, 2.5, 1.25"
+          />
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/lib/plates.test.ts
+++ b/lib/plates.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computePlateLoad,
+  DEFAULT_BAR_WEIGHT,
+  DEFAULT_PLATES,
+} from './plates';
+
+describe('computePlateLoad', () => {
+  const KG = DEFAULT_PLATES.KG;
+  const LB = DEFAULT_PLATES.LB;
+
+  it('loads a clean kg target exactly (100 kg on a 20 kg bar)', () => {
+    const load = computePlateLoad(100, 20, KG);
+    // 40 kg per side -> 1x25 + 1x15, or 2x20? greedy: 25, then 15.
+    expect(load.exact).toBe(true);
+    expect(load.remainder).toBe(0);
+    expect(load.achievedWeight).toBe(100);
+    expect(load.perSide).toEqual([
+      { plate: 25, count: 1 },
+      { plate: 15, count: 1 },
+    ]);
+  });
+
+  it('uses multiple plates of the same denomination', () => {
+    // 140 kg, 20 bar -> 60 per side -> 2x25 + 1x10
+    const load = computePlateLoad(140, 20, KG);
+    expect(load.exact).toBe(true);
+    expect(load.perSide).toEqual([
+      { plate: 25, count: 2 },
+      { plate: 10, count: 1 },
+    ]);
+  });
+
+  it('loads a clean lb target exactly (135 lb on a 45 lb bar)', () => {
+    const load = computePlateLoad(135, 45, LB);
+    // 45 per side -> 1x45
+    expect(load.exact).toBe(true);
+    expect(load.achievedWeight).toBe(135);
+    expect(load.perSide).toEqual([{ plate: 45, count: 1 }]);
+  });
+
+  it('loads 225 lb (a classic plate-math case)', () => {
+    const load = computePlateLoad(225, 45, LB);
+    // 90 per side -> 2x45
+    expect(load.exact).toBe(true);
+    expect(load.perSide).toEqual([{ plate: 45, count: 2 }]);
+  });
+
+  it('reports a remainder when the target is not exactly loadable', () => {
+    // 101 kg, 20 bar -> 40.5 per side; smallest plate is 1.25.
+    // greedy: 25 + 15 = 40, leaving 0.5 unloadable.
+    const load = computePlateLoad(101, 20, KG);
+    expect(load.exact).toBe(false);
+    expect(load.achievedWeight).toBe(100);
+    expect(load.remainder).toBe(1); // 0.5 per side -> 1 total
+  });
+
+  it('returns just the bar when the target equals the bar', () => {
+    const load = computePlateLoad(20, 20, KG);
+    expect(load.exact).toBe(true);
+    expect(load.perSide).toEqual([]);
+    expect(load.remainder).toBe(0);
+  });
+
+  it('handles a target below the bar gracefully', () => {
+    const load = computePlateLoad(15, 20, KG);
+    expect(load.exact).toBe(false);
+    expect(load.perSide).toEqual([]);
+    expect(load.achievedWeight).toBe(20);
+    // remainder is clamped to 0 below the bar (you cannot remove bar weight).
+    expect(load.remainder).toBe(0);
+  });
+
+  it('handles a non-finite target without throwing', () => {
+    const load = computePlateLoad(NaN, 20, KG);
+    expect(load.perSide).toEqual([]);
+    expect(load.exact).toBe(false);
+  });
+
+  it('ignores non-positive plate denominations', () => {
+    const load = computePlateLoad(100, 20, [25, 0, -5, 15]);
+    expect(load.perSide).toEqual([
+      { plate: 25, count: 1 },
+      { plate: 15, count: 1 },
+    ]);
+  });
+
+  it('does not accumulate floating-point noise across 2.5/1.25 plates', () => {
+    // 47.5 kg, 20 bar -> 13.75 per side -> 10 + 2.5 + 1.25
+    const load = computePlateLoad(47.5, 20, KG);
+    expect(load.exact).toBe(true);
+    expect(load.remainder).toBe(0);
+    expect(load.perSide).toEqual([
+      { plate: 10, count: 1 },
+      { plate: 2.5, count: 1 },
+      { plate: 1.25, count: 1 },
+    ]);
+  });
+
+  it('exposes sensible defaults per unit', () => {
+    expect(DEFAULT_BAR_WEIGHT.KG).toBe(20);
+    expect(DEFAULT_BAR_WEIGHT.LB).toBe(45);
+    expect(DEFAULT_PLATES.KG[0]).toBeGreaterThan(DEFAULT_PLATES.KG.at(-1)!);
+  });
+});

--- a/lib/plates.ts
+++ b/lib/plates.ts
@@ -1,0 +1,107 @@
+// Pure plate-loading math for the in-workout calculator (issue #39).
+//
+// The calculator works entirely in the user's *display* unit (kg or lb),
+// because plate inventories are unit-specific: a kg gym stocks 20/15/10/... kg
+// plates, a lb gym stocks 45/35/25/... lb plates. The session UI converts the
+// kg-stored target weight to the display unit before calling in here.
+
+import { WeightUnit } from '@prisma/client';
+
+// Standard bar weights per unit (the empty Olympic barbell).
+export const DEFAULT_BAR_WEIGHT: Record<WeightUnit, number> = {
+  KG: 20,
+  LB: 45,
+};
+
+// Standard plate inventories per unit, one plate denomination each. These are
+// the plates available *per side*; the calculator assumes a symmetric load.
+export const DEFAULT_PLATES: Record<WeightUnit, number[]> = {
+  KG: [25, 20, 15, 10, 5, 2.5, 1.25],
+  LB: [45, 35, 25, 10, 5, 2.5],
+};
+
+export interface PlateGroup {
+  // The plate denomination (in the display unit).
+  plate: number;
+  // How many of this plate go on each side.
+  count: number;
+}
+
+export interface PlateLoad {
+  // The bar weight used in the computation.
+  barWeight: number;
+  // The plates to load on each side, heaviest first.
+  perSide: PlateGroup[];
+  // The exact weight the plates + bar produce (may be below the target when
+  // the remainder cannot be made from the available plates).
+  achievedWeight: number;
+  // Target minus achieved, in the display unit. 0 when the target is loadable
+  // exactly. Positive means some weight could not be loaded.
+  remainder: number;
+  // True when the target is below the bar, or no full pair of any plate fits.
+  // The UI uses this to show "cannot load this exactly".
+  exact: boolean;
+}
+
+// Round to a small number of decimals to kill floating-point noise from the
+// repeated subtraction (e.g. 2.5 + 1.25 sums).
+function clean(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}
+
+// Greedy plate decomposition. Given a target weight (display unit), a bar
+// weight, and an available plate set (per side), return the plates to load on
+// each side. For the standard kg/lb inventories the denominations are regular
+// enough that greedy yields the minimal, gym-intuitive loading. Any weight that
+// cannot be made from the available plates is reported as a remainder, so the
+// user is never misled into thinking an unloadable target is loadable.
+export function computePlateLoad(
+  targetWeight: number,
+  barWeight: number,
+  availablePlates: number[],
+): PlateLoad {
+  // Plates usable per side: positive, sorted heaviest first.
+  const plates = availablePlates
+    .filter((p) => p > 0)
+    .slice()
+    .sort((a, b) => b - a);
+
+  // A non-positive or sub-bar target cannot be loaded with plates.
+  if (!Number.isFinite(targetWeight) || targetWeight <= barWeight) {
+    const remainder = Number.isFinite(targetWeight)
+      ? clean(Math.max(0, targetWeight - barWeight))
+      : 0;
+    return {
+      barWeight,
+      perSide: [],
+      achievedWeight: barWeight,
+      remainder,
+      exact: clean(targetWeight) === clean(barWeight),
+    };
+  }
+
+  // Weight to distribute across both sides.
+  let perSideRemaining = clean((targetWeight - barWeight) / 2);
+  const perSide: PlateGroup[] = [];
+
+  for (const plate of plates) {
+    if (perSideRemaining < plate) continue;
+    const count = Math.floor(clean(perSideRemaining / plate));
+    if (count > 0) {
+      perSide.push({ plate, count });
+      perSideRemaining = clean(perSideRemaining - plate * count);
+    }
+  }
+
+  const loadedPerSide = perSide.reduce((sum, g) => clean(sum + g.plate * g.count), 0);
+  const achievedWeight = clean(barWeight + loadedPerSide * 2);
+  const remainder = clean(targetWeight - achievedWeight);
+
+  return {
+    barWeight,
+    perSide,
+    achievedWeight,
+    remainder,
+    exact: remainder === 0,
+  };
+}

--- a/lib/preferences.test.ts
+++ b/lib/preferences.test.ts
@@ -5,6 +5,7 @@ import {
   savePreferences,
   isVibrationEnabled,
   isRestTimerSoundEnabled,
+  plateConfigForUnit,
 } from './preferences';
 
 const STORAGE_KEY = 'gymcoach.prefs.v1';
@@ -21,7 +22,7 @@ describe('preferences', () => {
   it('merges a partial stored object over the defaults', () => {
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ restTimerSound: true }));
     expect(loadPreferences()).toEqual({
-      vibration: DEFAULT_PREFERENCES.vibration,
+      ...DEFAULT_PREFERENCES,
       restTimerSound: true,
     });
   });
@@ -32,14 +33,30 @@ describe('preferences', () => {
   });
 
   it('round-trips through savePreferences', () => {
-    const prefs = { vibration: false, restTimerSound: true };
+    const prefs = { ...DEFAULT_PREFERENCES, vibration: false, restTimerSound: true };
     savePreferences(prefs);
     expect(loadPreferences()).toEqual(prefs);
   });
 
   it('exposes targeted helpers that reflect stored values', () => {
-    savePreferences({ vibration: false, restTimerSound: true });
+    savePreferences({ ...DEFAULT_PREFERENCES, vibration: false, restTimerSound: true });
     expect(isVibrationEnabled()).toBe(false);
     expect(isRestTimerSoundEnabled()).toBe(true);
+  });
+
+  it('returns the plate config for the active unit', () => {
+    expect(plateConfigForUnit('KG')).toEqual({
+      barWeight: DEFAULT_PREFERENCES.barWeightKg,
+      plates: DEFAULT_PREFERENCES.platesKg,
+    });
+    expect(plateConfigForUnit('LB')).toEqual({
+      barWeight: DEFAULT_PREFERENCES.barWeightLb,
+      plates: DEFAULT_PREFERENCES.platesLb,
+    });
+  });
+
+  it('reflects a customized plate config', () => {
+    savePreferences({ ...DEFAULT_PREFERENCES, barWeightKg: 15, platesKg: [20, 10] });
+    expect(plateConfigForUnit('KG')).toEqual({ barWeight: 15, plates: [20, 10] });
   });
 });

--- a/lib/preferences.ts
+++ b/lib/preferences.ts
@@ -1,16 +1,29 @@
 // User preferences stored locally (not in the DB).
 // Everything is single-user, so localStorage is enough. SSR-safe reads.
 
+import { WeightUnit } from '@prisma/client';
+
 const STORAGE_KEY = 'gymcoach.prefs.v1';
 
 export interface UserPreferences {
   vibration: boolean;
   restTimerSound: boolean;
+  // Plate-loading calculator (issue #39). Bar weight and available plate
+  // denominations are stored per unit, since a kg gym and a lb gym stock
+  // different plates. Values are in the matching display unit.
+  barWeightKg: number;
+  barWeightLb: number;
+  platesKg: number[];
+  platesLb: number[];
 }
 
 export const DEFAULT_PREFERENCES: UserPreferences = {
   vibration: true,
   restTimerSound: false,
+  barWeightKg: 20,
+  barWeightLb: 45,
+  platesKg: [25, 20, 15, 10, 5, 2.5, 1.25],
+  platesLb: [45, 35, 25, 10, 5, 2.5],
 };
 
 export function loadPreferences(): UserPreferences {
@@ -41,4 +54,15 @@ export function isVibrationEnabled(): boolean {
 
 export function isRestTimerSoundEnabled(): boolean {
   return loadPreferences().restTimerSound;
+}
+
+// The plate-loading config (bar weight + available plates) for the active unit.
+export function plateConfigForUnit(unit: WeightUnit): {
+  barWeight: number;
+  plates: number[];
+} {
+  const prefs = loadPreferences();
+  return unit === 'LB'
+    ? { barWeight: prefs.barWeightLb, plates: prefs.platesLb }
+    : { barWeight: prefs.barWeightKg, plates: prefs.platesKg };
 }


### PR DESCRIPTION
Closes #39

## What

Adds an in-workout plate-loading calculator.

- `lib/plates.ts`: pure greedy per-side plate decomposition. Works in the user's display unit (kg/lb), uses configurable bar weight + plate inventory, and honestly reports any weight that cannot be loaded (`remainder` / `exact`) instead of silently rounding. Defaults: 20 kg / 45 lb bar, standard kg and lb plate sets.
- `components/session/plate-calculator.tsx`: a Dialog surfaced from the Load field in the set logger. Display-only, never mutates the set; reads the per-unit config from preferences lazily on open.
- `lib/preferences.ts`: per-unit `barWeight*` / `plates*` preferences + `plateConfigForUnit()` helper (localStorage, single-user).
- `components/settings/settings-client.tsx`: a "Plate calculator" settings card to configure bar weight and plates per unit.

## Notes

- Greedy decomposition is optimal for the standard kg/lb inventories; for unusual custom plate sets it may leave a remainder that a different combination could load. That case is documented and surfaced honestly to the user rather than hidden.

## How I tested

- `lib/plates.test.ts`: clean kg/lb targets, repeated plates, 225 lb, remainder/unloadable, sub-bar, NaN, non-positive plate filtering, floating-point accumulation.
- `lib/preferences.test.ts`: extended for the new per-unit config + `plateConfigForUnit`.
- `bash scripts/verify.sh` is green (prisma generate + lint + typecheck + unit + build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)