### PR TITLE
feat: built-in templates for established programs

### DIFF
--- a/app/(app)/programs/new/page.tsx
+++ b/app/(app)/programs/new/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
-import { ChevronLeft } from 'lucide-react';
+import { ChevronLeft, LayoutTemplate } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
 import { ProgramCreateForm } from '@/components/programs/program-create-form';
 
 export default function NewProgramPage() {
@@ -14,6 +15,25 @@ export default function NewProgramPage() {
           </Link>
         </Button>
         <h1 className="text-2xl font-bold tracking-tight">New program</h1>
+
+        <Card>
+          <CardContent className="flex items-center justify-between gap-3 pt-6">
+            <div className="flex min-w-0 items-start gap-3">
+              <LayoutTemplate className="mt-0.5 size-5 shrink-0 text-muted-foreground" />
+              <div className="min-w-0">
+                <p className="text-sm font-medium">Start from a template</p>
+                <p className="text-xs text-muted-foreground">
+                  Run an established program (5/3/1, GZCLP, nSuns, PPL, Upper/Lower)
+                  as written.
+                </p>
+              </div>
+            </div>
+            <Button asChild variant="outline" className="min-h-tap shrink-0">
+              <Link href="/programs/new/template">Browse</Link>
+            </Button>
+          </CardContent>
+        </Card>
+
         <ProgramCreateForm />
       </div>
     </main>

--- a/app/(app)/programs/new/template/page.tsx
+++ b/app/(app)/programs/new/template/page.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link';
+import { ChevronLeft } from 'lucide-react';
+import { requireSession } from '@/lib/auth';
+import { Button } from '@/components/ui/button';
+import { TemplatePicker } from '@/components/programs/template-picker';
+import { programTemplates } from '@/lib/programs/templates';
+
+export default async function TemplateProgramPage() {
+  await requireSession();
+
+  return (
+    <main className="flex-1 px-4 py-6">
+      <div className="mx-auto flex max-w-2xl flex-col gap-4">
+        <Button asChild variant="ghost" size="sm" className="self-start">
+          <Link href="/programs/new">
+            <ChevronLeft className="size-4" />
+            <span className="ml-1">Back</span>
+          </Link>
+        </Button>
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Start from a template</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Instantiate a well-known program as written. The AI coach advises
+            within it - it will not silently restructure your program.
+          </p>
+        </div>
+        <TemplatePicker templates={programTemplates} />
+      </div>
+    </main>
+  );
+}

--- a/components/programs/template-picker.tsx
+++ b/components/programs/template-picker.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import type { ProgramTemplate } from '@/lib/programs/templates';
+
+interface Props {
+  templates: ProgramTemplate[];
+}
+
+// "Start from a template" picker. Materializes the selected template into a
+// real Program through the same /api/programs/build route the AI generator
+// uses, so the structure is persisted exactly as written and the coach treats
+// it like any user-authored program.
+export function TemplatePicker({ templates }: Props) {
+  const router = useRouter();
+  const [creatingSlug, setCreatingSlug] = useState<string | null>(null);
+
+  async function instantiate(template: ProgramTemplate) {
+    setCreatingSlug(template.slug);
+    try {
+      const res = await fetch('/api/programs/build', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(template.program),
+      });
+      if (!res.ok) {
+        const j = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(j.error ?? `Error ${res.status}`);
+      }
+      const j = (await res.json()) as { id: string };
+      toast.success('Program created from template.');
+      router.push(`/programs/${j.id}`);
+      router.refresh();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Could not create the program.');
+      setCreatingSlug(null);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {templates.map((template) => {
+        const dayCount = template.program.workouts.length;
+        return (
+          <Card key={template.slug}>
+            <CardHeader className="pb-2">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <h2 className="text-base font-semibold">{template.name}</h2>
+                  <p className="mt-1 text-sm text-muted-foreground">{template.summary}</p>
+                </div>
+                <Badge variant="secondary" className="shrink-0">
+                  {dayCount} {dayCount === 1 ? 'day' : 'days'}
+                </Badge>
+              </div>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-3">
+              <p className="text-xs text-muted-foreground">{template.attribution}</p>
+              <div className="flex justify-end">
+                <Button
+                  type="button"
+                  className="min-h-tap"
+                  disabled={creatingSlug !== null}
+                  onClick={() => instantiate(template)}
+                >
+                  {creatingSlug === template.slug ? 'Creating...' : 'Use this template'}
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/lib/programs/templates.test.ts
+++ b/lib/programs/templates.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import {
+  programTemplates,
+  getTemplateBySlug,
+} from './templates';
+import { generatedProgramSchema } from '@/lib/schemas/program-generation';
+
+describe('program templates', () => {
+  it('ships at least the four required established programs', () => {
+    // Issue #37 asks for 5/3/1, GZCLP, a PPL split and an Upper/Lower split.
+    expect(programTemplates.length).toBeGreaterThanOrEqual(4);
+    const slugs = programTemplates.map((t) => t.slug);
+    expect(slugs).toContain('531-bbb-4day');
+    expect(slugs).toContain('gzclp-3day');
+    expect(slugs).toContain('ppl-6day');
+    expect(slugs).toContain('upper-lower-4day');
+  });
+
+  it('has unique slugs', () => {
+    const slugs = programTemplates.map((t) => t.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it('every template program validates against the build schema', () => {
+    for (const t of programTemplates) {
+      const result = generatedProgramSchema.safeParse(t.program);
+      expect(result.success, `${t.slug} should be valid`).toBe(true);
+    }
+  });
+
+  it('every template has display metadata', () => {
+    for (const t of programTemplates) {
+      expect(t.name.length).toBeGreaterThan(0);
+      expect(t.summary.length).toBeGreaterThan(0);
+      expect(t.attribution.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every workout has at least one exercise with a valid rep range', () => {
+    for (const t of programTemplates) {
+      for (const w of t.program.workouts) {
+        expect(w.exercises.length).toBeGreaterThan(0);
+        for (const ex of w.exercises) {
+          expect(ex.targetRepsMax).toBeGreaterThanOrEqual(ex.targetRepsMin);
+        }
+      }
+    }
+  });
+
+  it('looks up a template by slug and returns undefined for an unknown slug', () => {
+    expect(getTemplateBySlug('ppl-6day')?.name).toBe('Push / Pull / Legs (6-day)');
+    expect(getTemplateBySlug('does-not-exist')).toBeUndefined();
+  });
+});

--- a/lib/programs/templates.ts
+++ b/lib/programs/templates.ts
@@ -1,0 +1,569 @@
+// Built-in program templates for established routines (issue #37).
+//
+// A template is just a curated `GeneratedProgram`: the exact same structured
+// shape the AI program generator produces and the existing `/api/programs/build`
+// route persists. This means templates materialize into a real `Program`
+// through the same validated path, and the AI coach treats a template-derived
+// program like any other user-authored program (it advises within it, it does
+// not silently restructure it).
+//
+// Loading schemes (5/3/1 percentages, GZCLP stages, nSuns waves) are expressed
+// here as set/rep/RIR targets plus explanatory notes, since GymCoach tracks
+// sets/reps/RIR rather than a built-in percentage engine. The notes carry the
+// "as written" intent so the user can run the program faithfully.
+
+import {
+  generatedProgramSchema,
+  type GeneratedProgram,
+} from '@/lib/schemas/program-generation';
+
+export interface ProgramTemplate {
+  // Stable slug used in URLs and the picker (e.g. "ppl-6day").
+  slug: string;
+  // Short display name.
+  name: string;
+  // One-line summary for the picker card.
+  summary: string;
+  // Attribution / how to run it as written.
+  attribution: string;
+  // The structured program, ready to POST to /api/programs/build.
+  program: GeneratedProgram;
+}
+
+// 5/3/1 - basic 4-day (Wendler). Main lift per day at a working top set, plus
+// Boring But Big style accessories. RIR/rep targets approximate the as-written
+// intent; notes carry the percentage scheme.
+const FIVE_THREE_ONE: ProgramTemplate = {
+  slug: '531-bbb-4day',
+  name: '5/3/1 (Boring But Big, 4-day)',
+  summary: 'Wendler 5/3/1 main lifts with 5x10 BBB supplemental work, 4 days.',
+  attribution:
+    'Jim Wendler 5/3/1. Run the main lift off your training max (90% of 1RM): wave 5s/3s/1s week to week, last set AMRAP. Supplemental is 5x10 at ~50-60% TM.',
+  program: {
+    name: '5/3/1 Boring But Big',
+    description:
+      'Wendler 5/3/1 with Boring But Big supplemental volume. Set your training max to 90% of your 1RM and progress the TM, not the day-to-day load.',
+    phase: 'Strength',
+    workouts: [
+      {
+        name: 'Day 1 - Overhead Press',
+        dayOfWeek: 1,
+        exercises: [
+          {
+            name: 'Overhead Press',
+            muscleGroup: 'SHOULDERS_FRONT',
+            category: 'COMPOUND',
+            targetSets: 3,
+            targetRepsMin: 1,
+            targetRepsMax: 5,
+            targetRIR: 1,
+            restSec: 180,
+            notes: 'Main lift. 5/3/1 wave off training max; last set AMRAP.',
+          },
+          {
+            name: 'Overhead Press',
+            muscleGroup: 'SHOULDERS_FRONT',
+            category: 'COMPOUND',
+            targetSets: 5,
+            targetRepsMin: 10,
+            targetRepsMax: 10,
+            targetRIR: 3,
+            restSec: 90,
+            notes: 'Boring But Big supplemental: 5x10 at ~50-60% TM.',
+          },
+          {
+            name: 'Chin-up',
+            muscleGroup: 'BACK_WIDTH',
+            category: 'COMPOUND',
+            targetSets: 5,
+            targetRepsMin: 8,
+            targetRepsMax: 12,
+            targetRIR: 2,
+            restSec: 90,
+            notes: 'Pulling accessory to balance the pressing volume.',
+          },
+        ],
+      },
+      {
+        name: 'Day 2 - Deadlift',
+        dayOfWeek: 3,
+        exercises: [
+          {
+            name: 'Deadlift',
+            muscleGroup: 'BACK_THICKNESS',
+            category: 'COMPOUND',
+            targetSets: 3,
+            targetRepsMin: 1,
+            targetRepsMax: 5,
+            targetRIR: 1,
+            restSec: 240,
+            notes: 'Main lift. 5/3/1 wave off training max; last set AMRAP.',
+          },
+          {
+            name: 'Deadlift',
+            muscleGroup: 'BACK_THICKNESS',
+            category: 'COMPOUND',
+            targetSets: 5,
+            targetRepsMin: 10,
+            targetRepsMax: 10,
+            targetRIR: 3,
+            restSec: 120,
+            notes: 'Boring But Big supplemental: 5x10 at ~50-60% TM.',
+          },
+          {
+            name: 'Hanging Leg Raise',
+            muscleGroup: 'ABS',
+            category: 'ISOLATION',
+            targetSets: 4,
+            targetRepsMin: 10,
+            targetRepsMax: 15,
+            targetRIR: 2,
+            restSec: 60,
+          },
+        ],
+      },
+      {
+        name: 'Day 3 - Bench Press',
+        dayOfWeek: 5,
+        exercises: [
+          {
+            name: 'Bench Press',
+            muscleGroup: 'CHEST',
+            category: 'COMPOUND',
+            targetSets: 3,
+            targetRepsMin: 1,
+            targetRepsMax: 5,
+            targetRIR: 1,
+            restSec: 180,
+            notes: 'Main lift. 5/3/1 wave off training max; last set AMRAP.',
+          },
+          {
+            name: 'Bench Press',
+            muscleGroup: 'CHEST',
+            category: 'COMPOUND',
+            targetSets: 5,
+            targetRepsMin: 10,
+            targetRepsMax: 10,
+            targetRIR: 3,
+            restSec: 90,
+            notes: 'Boring But Big supplemental: 5x10 at ~50-60% TM.',
+          },
+          {
+            name: 'Barbell Row',
+            muscleGroup: 'BACK_THICKNESS',
+            category: 'COMPOUND',
+            targetSets: 5,
+            targetRepsMin: 8,
+            targetRepsMax: 12,
+            targetRIR: 2,
+            restSec: 90,
+          },
+        ],
+      },
+      {
+        name: 'Day 4 - Squat',
+        dayOfWeek: 6,
+        exercises: [
+          {
+            name: 'Back Squat',
+            muscleGroup: 'QUADS',
+            category: 'COMPOUND',
+            targetSets: 3,
+            targetRepsMin: 1,
+            targetRepsMax: 5,
+            targetRIR: 1,
+            restSec: 240,
+            notes: 'Main lift. 5/3/1 wave off training max; last set AMRAP.',
+          },
+          {
+            name: 'Back Squat',
+            muscleGroup: 'QUADS',
+            category: 'COMPOUND',
+            targetSets: 5,
+            targetRepsMin: 10,
+            targetRepsMax: 10,
+            targetRIR: 3,
+            restSec: 120,
+            notes: 'Boring But Big supplemental: 5x10 at ~50-60% TM.',
+          },
+          {
+            name: 'Leg Curl',
+            muscleGroup: 'HAMSTRINGS',
+            category: 'ISOLATION',
+            targetSets: 4,
+            targetRepsMin: 10,
+            targetRepsMax: 15,
+            targetRIR: 2,
+            restSec: 60,
+          },
+        ],
+      },
+    ],
+  },
+};
+
+// GZCLP - Cody Lemon's linear-progression variant of GZCL. T1 main lift (5x3+),
+// T2 secondary (3x10), T3 accessory (3x15+). 3 day rotation across 4 lifts.
+const GZCLP: ProgramTemplate = {
+  slug: 'gzclp-3day',
+  name: 'GZCLP (linear progression)',
+  summary: 'GZCL-based linear progression: T1 5x3, T2 3x10, T3 3x15+, 3 days.',
+  attribution:
+    'Cody Lemon GZCLP. T1: 5x3+ heavy, add weight each session, drop to 6x2 then 10x1 on a stall. T2: 3x10 (then 3x8, 3x6). T3: 3x15+ AMRAP last set, add weight when last set hits 25.',
+  program: {
+    name: 'GZCLP',
+    description:
+      'GZCL-based linear progression with T1 (main strength), T2 (secondary volume) and T3 (accessory) tiers. Add weight each session until you stall, then drop to the next rep scheme.',
+    phase: 'Strength',
+    workouts: [
+      {
+        name: 'Day A - Squat / Bench',
+        dayOfWeek: 1,
+        exercises: [
+          {
+            name: 'Back Squat',
+            muscleGroup: 'QUADS',
+            category: 'COMPOUND',
+            targetSets: 5,
+            targetRepsMin: 3,
+            targetRepsMax: 3,
+            targetRIR: 1,
+            restSec: 180,
+            notes: 'T1: 5x3+, last set AMRAP. Add weight each session.',
+          },
+          {
+            name: 'Bench Press',
+            muscleGroup: 'CHEST',
+            category: 'COMPOUND',
+            targetSets: 3,
+            targetRepsMin: 10,
+            targetRepsMax: 10,
+            targetRIR: 2,
+            restSec: 120,
+            notes: 'T2: 3x10, then 3x8 then 3x6 on stalls.',
+          },
+          {
+            name: 'Lat Pulldown',
+            muscleGroup: 'BACK_WIDTH',
+            category: 'COMPOUND',
+            targetSets: 3,
+            targetRepsMin: 15,
+            targetRepsMax: 25,
+            targetRIR: 2,
+            restSec: 90,
+            notes: 'T3: 3x15+, last set AMRAP. Add weight when last set hits 25.',
+          },
+        ],
+      },
+      {
+        name: 'Day B - Overhead Press / Deadlift',
+        dayOfWeek: 3,
+        exercises: [
+          {
+            name: 'Overhead Press',
+            muscleGroup: 'SHOULDERS_FRONT',
+            category: 'COMPOUND',
+            targetSets: 5,
+            targetRepsMin: 3,
+            targetRepsMax: 3,
+            targetRIR: 1,
+            restSec: 180,
+            notes: 'T1: 5x3+, last set AMRAP. Add weight each session.',
+          },
+          {
+            name: 'Deadlift',
+            muscleGroup: 'BACK_THICKNESS',
+            category: 'COMPOUND',
+            targetSets: 3,
+            targetRepsMin: 10,
+            targetRepsMax: 10,
+            targetRIR: 2,
+            restSec: 150,
+            notes: 'T2: 3x10, then 3x8 then 3x6 on stalls.',
+          },
+          {
+            name: 'Dumbbell Row',
+            muscleGroup: 'BACK_THICKNESS',
+            category: 'COMPOUND',
+            targetSets: 3,
+            targetRepsMin: 15,
+            targetRepsMax: 25,
+            targetRIR: 2,
+            restSec: 90,
+            notes: 'T3: 3x15+, last set AMRAP.',
+          },
+        ],
+      },
+      {
+        name: 'Day C - Bench / Squat',
+        dayOfWeek: 5,
+        exercises: [
+          {
+            name: 'Bench Press',
+            muscleGroup: 'CHEST',
+            category: 'COMPOUND',
+            targetSets: 5,
+            targetRepsMin: 3,
+            targetRepsMax: 3,
+            targetRIR: 1,
+            restSec: 180,
+            notes: 'T1: 5x3+, last set AMRAP. Add weight each session.',
+          },
+          {
+            name: 'Back Squat',
+            muscleGroup: 'QUADS',
+            category: 'COMPOUND',
+            targetSets: 3,
+            targetRepsMin: 10,
+            targetRepsMax: 10,
+            targetRIR: 2,
+            restSec: 120,
+            notes: 'T2: 3x10, then 3x8 then 3x6 on stalls.',
+          },
+          {
+            name: 'Cable Curl',
+            muscleGroup: 'BICEPS',
+            category: 'ISOLATION',
+            targetSets: 3,
+            targetRepsMin: 15,
+            targetRepsMax: 25,
+            targetRIR: 2,
+            restSec: 60,
+            notes: 'T3: 3x15+, last set AMRAP.',
+          },
+        ],
+      },
+    ],
+  },
+};
+
+// Push / Pull / Legs - a 6-day hypertrophy split.
+const PPL: ProgramTemplate = {
+  slug: 'ppl-6day',
+  name: 'Push / Pull / Legs (6-day)',
+  summary: 'Classic 6-day PPL hypertrophy split, 8-12 rep work at 1-2 RIR.',
+  attribution:
+    'Standard Push/Pull/Legs run twice per week. Hypertrophy rep ranges (8-15), 1-2 RIR, progress load when you hit the top of the range across all sets.',
+  program: {
+    name: 'Push Pull Legs',
+    description:
+      'A 6-day Push/Pull/Legs hypertrophy split. Train each session twice per week; progress load when the top of the rep range is reached on all sets.',
+    phase: 'Hypertrophy',
+    workouts: [
+      {
+        name: 'Push A',
+        dayOfWeek: 1,
+        exercises: [
+          { name: 'Bench Press', muscleGroup: 'CHEST', category: 'COMPOUND', targetSets: 4, targetRepsMin: 6, targetRepsMax: 10, targetRIR: 1, restSec: 150 },
+          { name: 'Overhead Press', muscleGroup: 'SHOULDERS_FRONT', category: 'COMPOUND', targetSets: 3, targetRepsMin: 8, targetRepsMax: 12, targetRIR: 2, restSec: 120 },
+          { name: 'Incline Dumbbell Press', muscleGroup: 'CHEST', category: 'COMPOUND', targetSets: 3, targetRepsMin: 10, targetRepsMax: 12, targetRIR: 1, restSec: 90 },
+          { name: 'Lateral Raise', muscleGroup: 'SHOULDERS_LATERAL', category: 'ISOLATION', targetSets: 4, targetRepsMin: 12, targetRepsMax: 20, targetRIR: 1, restSec: 60 },
+          { name: 'Triceps Pushdown', muscleGroup: 'TRICEPS', category: 'ISOLATION', targetSets: 3, targetRepsMin: 10, targetRepsMax: 15, targetRIR: 1, restSec: 60 },
+        ],
+      },
+      {
+        name: 'Pull A',
+        dayOfWeek: 2,
+        exercises: [
+          { name: 'Deadlift', muscleGroup: 'BACK_THICKNESS', category: 'COMPOUND', targetSets: 3, targetRepsMin: 5, targetRepsMax: 8, targetRIR: 2, restSec: 180 },
+          { name: 'Pull-up', muscleGroup: 'BACK_WIDTH', category: 'COMPOUND', targetSets: 4, targetRepsMin: 6, targetRepsMax: 12, targetRIR: 1, restSec: 120 },
+          { name: 'Barbell Row', muscleGroup: 'BACK_THICKNESS', category: 'COMPOUND', targetSets: 3, targetRepsMin: 8, targetRepsMax: 12, targetRIR: 2, restSec: 120 },
+          { name: 'Face Pull', muscleGroup: 'SHOULDERS_REAR', category: 'ISOLATION', targetSets: 3, targetRepsMin: 15, targetRepsMax: 20, targetRIR: 1, restSec: 60 },
+          { name: 'Barbell Curl', muscleGroup: 'BICEPS', category: 'ISOLATION', targetSets: 3, targetRepsMin: 8, targetRepsMax: 12, targetRIR: 1, restSec: 60 },
+        ],
+      },
+      {
+        name: 'Legs A',
+        dayOfWeek: 3,
+        exercises: [
+          { name: 'Back Squat', muscleGroup: 'QUADS', category: 'COMPOUND', targetSets: 4, targetRepsMin: 6, targetRepsMax: 10, targetRIR: 1, restSec: 180 },
+          { name: 'Romanian Deadlift', muscleGroup: 'HAMSTRINGS', category: 'COMPOUND', targetSets: 3, targetRepsMin: 8, targetRepsMax: 12, targetRIR: 2, restSec: 120 },
+          { name: 'Leg Press', muscleGroup: 'QUADS', category: 'COMPOUND', targetSets: 3, targetRepsMin: 10, targetRepsMax: 15, targetRIR: 1, restSec: 90 },
+          { name: 'Leg Curl', muscleGroup: 'HAMSTRINGS', category: 'ISOLATION', targetSets: 3, targetRepsMin: 10, targetRepsMax: 15, targetRIR: 1, restSec: 60 },
+          { name: 'Standing Calf Raise', muscleGroup: 'CALVES', category: 'ISOLATION', targetSets: 4, targetRepsMin: 10, targetRepsMax: 15, targetRIR: 1, restSec: 60 },
+        ],
+      },
+      {
+        name: 'Push B',
+        dayOfWeek: 4,
+        exercises: [
+          { name: 'Overhead Press', muscleGroup: 'SHOULDERS_FRONT', category: 'COMPOUND', targetSets: 4, targetRepsMin: 6, targetRepsMax: 10, targetRIR: 1, restSec: 150 },
+          { name: 'Incline Dumbbell Press', muscleGroup: 'CHEST', category: 'COMPOUND', targetSets: 3, targetRepsMin: 8, targetRepsMax: 12, targetRIR: 2, restSec: 120 },
+          { name: 'Cable Fly', muscleGroup: 'CHEST', category: 'ISOLATION', targetSets: 3, targetRepsMin: 12, targetRepsMax: 15, targetRIR: 1, restSec: 60 },
+          { name: 'Lateral Raise', muscleGroup: 'SHOULDERS_LATERAL', category: 'ISOLATION', targetSets: 4, targetRepsMin: 12, targetRepsMax: 20, targetRIR: 1, restSec: 60 },
+          { name: 'Overhead Triceps Extension', muscleGroup: 'TRICEPS', category: 'ISOLATION', targetSets: 3, targetRepsMin: 10, targetRepsMax: 15, targetRIR: 1, restSec: 60 },
+        ],
+      },
+      {
+        name: 'Pull B',
+        dayOfWeek: 5,
+        exercises: [
+          { name: 'Lat Pulldown', muscleGroup: 'BACK_WIDTH', category: 'COMPOUND', targetSets: 4, targetRepsMin: 8, targetRepsMax: 12, targetRIR: 1, restSec: 120 },
+          { name: 'Seated Cable Row', muscleGroup: 'BACK_THICKNESS', category: 'COMPOUND', targetSets: 3, targetRepsMin: 8, targetRepsMax: 12, targetRIR: 2, restSec: 120 },
+          { name: 'Dumbbell Row', muscleGroup: 'BACK_THICKNESS', category: 'COMPOUND', targetSets: 3, targetRepsMin: 10, targetRepsMax: 12, targetRIR: 1, restSec: 90 },
+          { name: 'Rear Delt Fly', muscleGroup: 'SHOULDERS_REAR', category: 'ISOLATION', targetSets: 3, targetRepsMin: 15, targetRepsMax: 20, targetRIR: 1, restSec: 60 },
+          { name: 'Hammer Curl', muscleGroup: 'BICEPS', category: 'ISOLATION', targetSets: 3, targetRepsMin: 10, targetRepsMax: 15, targetRIR: 1, restSec: 60 },
+        ],
+      },
+      {
+        name: 'Legs B',
+        dayOfWeek: 6,
+        exercises: [
+          { name: 'Front Squat', muscleGroup: 'QUADS', category: 'COMPOUND', targetSets: 4, targetRepsMin: 6, targetRepsMax: 10, targetRIR: 1, restSec: 180 },
+          { name: 'Romanian Deadlift', muscleGroup: 'HAMSTRINGS', category: 'COMPOUND', targetSets: 3, targetRepsMin: 8, targetRepsMax: 12, targetRIR: 2, restSec: 120 },
+          { name: 'Bulgarian Split Squat', muscleGroup: 'GLUTES', category: 'COMPOUND', targetSets: 3, targetRepsMin: 8, targetRepsMax: 12, targetRIR: 1, restSec: 90 },
+          { name: 'Leg Extension', muscleGroup: 'QUADS', category: 'ISOLATION', targetSets: 3, targetRepsMin: 12, targetRepsMax: 15, targetRIR: 1, restSec: 60 },
+          { name: 'Seated Calf Raise', muscleGroup: 'CALVES', category: 'ISOLATION', targetSets: 4, targetRepsMin: 12, targetRepsMax: 20, targetRIR: 1, restSec: 60 },
+        ],
+      },
+    ],
+  },
+};
+
+// Upper / Lower - a 4-day split.
+const UPPER_LOWER: ProgramTemplate = {
+  slug: 'upper-lower-4day',
+  name: 'Upper / Lower (4-day)',
+  summary: '4-day Upper/Lower split balancing strength and hypertrophy work.',
+  attribution:
+    'Standard 4-day Upper/Lower. Heavier compound work (5-8 reps) early in each session, hypertrophy accessories (8-15 reps) after, 1-2 RIR.',
+  program: {
+    name: 'Upper Lower',
+    description:
+      'A 4-day Upper/Lower split. Lead with a heavier compound, then accumulate hypertrophy volume on accessories. Progress load at the top of each rep range.',
+    phase: 'Hypertrophy',
+    workouts: [
+      {
+        name: 'Upper A',
+        dayOfWeek: 1,
+        exercises: [
+          { name: 'Bench Press', muscleGroup: 'CHEST', category: 'COMPOUND', targetSets: 4, targetRepsMin: 5, targetRepsMax: 8, targetRIR: 1, restSec: 180 },
+          { name: 'Barbell Row', muscleGroup: 'BACK_THICKNESS', category: 'COMPOUND', targetSets: 4, targetRepsMin: 6, targetRepsMax: 10, targetRIR: 1, restSec: 150 },
+          { name: 'Overhead Press', muscleGroup: 'SHOULDERS_FRONT', category: 'COMPOUND', targetSets: 3, targetRepsMin: 8, targetRepsMax: 12, targetRIR: 2, restSec: 120 },
+          { name: 'Lat Pulldown', muscleGroup: 'BACK_WIDTH', category: 'COMPOUND', targetSets: 3, targetRepsMin: 10, targetRepsMax: 12, targetRIR: 1, restSec: 90 },
+          { name: 'Barbell Curl', muscleGroup: 'BICEPS', category: 'ISOLATION', targetSets: 3, targetRepsMin: 8, targetRepsMax: 12, targetRIR: 1, restSec: 60 },
+          { name: 'Triceps Pushdown', muscleGroup: 'TRICEPS', category: 'ISOLATION', targetSets: 3, targetRepsMin: 10, targetRepsMax: 15, targetRIR: 1, restSec: 60 },
+        ],
+      },
+      {
+        name: 'Lower A',
+        dayOfWeek: 2,
+        exercises: [
+          { name: 'Back Squat', muscleGroup: 'QUADS', category: 'COMPOUND', targetSets: 4, targetRepsMin: 5, targetRepsMax: 8, targetRIR: 1, restSec: 180 },
+          { name: 'Romanian Deadlift', muscleGroup: 'HAMSTRINGS', category: 'COMPOUND', targetSets: 3, targetRepsMin: 8, targetRepsMax: 12, targetRIR: 2, restSec: 150 },
+          { name: 'Leg Press', muscleGroup: 'QUADS', category: 'COMPOUND', targetSets: 3, targetRepsMin: 10, targetRepsMax: 15, targetRIR: 1, restSec: 90 },
+          { name: 'Leg Curl', muscleGroup: 'HAMSTRINGS', category: 'ISOLATION', targetSets: 3, targetRepsMin: 10, targetRepsMax: 15, targetRIR: 1, restSec: 60 },
+          { name: 'Standing Calf Raise', muscleGroup: 'CALVES', category: 'ISOLATION', targetSets: 4, targetRepsMin: 10, targetRepsMax: 15, targetRIR: 1, restSec: 60 },
+        ],
+      },
+      {
+        name: 'Upper B',
+        dayOfWeek: 4,
+        exercises: [
+          { name: 'Overhead Press', muscleGroup: 'SHOULDERS_FRONT', category: 'COMPOUND', targetSets: 4, targetRepsMin: 5, targetRepsMax: 8, targetRIR: 1, restSec: 180 },
+          { name: 'Pull-up', muscleGroup: 'BACK_WIDTH', category: 'COMPOUND', targetSets: 4, targetRepsMin: 6, targetRepsMax: 10, targetRIR: 1, restSec: 150 },
+          { name: 'Incline Dumbbell Press', muscleGroup: 'CHEST', category: 'COMPOUND', targetSets: 3, targetRepsMin: 8, targetRepsMax: 12, targetRIR: 2, restSec: 120 },
+          { name: 'Seated Cable Row', muscleGroup: 'BACK_THICKNESS', category: 'COMPOUND', targetSets: 3, targetRepsMin: 10, targetRepsMax: 12, targetRIR: 1, restSec: 90 },
+          { name: 'Lateral Raise', muscleGroup: 'SHOULDERS_LATERAL', category: 'ISOLATION', targetSets: 4, targetRepsMin: 12, targetRepsMax: 20, targetRIR: 1, restSec: 60 },
+          { name: 'Hammer Curl', muscleGroup: 'BICEPS', category: 'ISOLATION', targetSets: 3, targetRepsMin: 10, targetRepsMax: 15, targetRIR: 1, restSec: 60 },
+        ],
+      },
+      {
+        name: 'Lower B',
+        dayOfWeek: 5,
+        exercises: [
+          { name: 'Deadlift', muscleGroup: 'BACK_THICKNESS', category: 'COMPOUND', targetSets: 3, targetRepsMin: 4, targetRepsMax: 6, targetRIR: 2, restSec: 240 },
+          { name: 'Front Squat', muscleGroup: 'QUADS', category: 'COMPOUND', targetSets: 3, targetRepsMin: 6, targetRepsMax: 10, targetRIR: 1, restSec: 150 },
+          { name: 'Bulgarian Split Squat', muscleGroup: 'GLUTES', category: 'COMPOUND', targetSets: 3, targetRepsMin: 8, targetRepsMax: 12, targetRIR: 1, restSec: 90 },
+          { name: 'Leg Extension', muscleGroup: 'QUADS', category: 'ISOLATION', targetSets: 3, targetRepsMin: 12, targetRepsMax: 15, targetRIR: 1, restSec: 60 },
+          { name: 'Seated Calf Raise', muscleGroup: 'CALVES', category: 'ISOLATION', targetSets: 4, targetRepsMin: 12, targetRepsMax: 20, targetRIR: 1, restSec: 60 },
+        ],
+      },
+    ],
+  },
+};
+
+// nSuns 4-day LP (531 variant). T1 main lift uses the nSuns 9-set wave; we
+// express it as a single working block with notes carrying the wave intent.
+const NSUNS: ProgramTemplate = {
+  slug: 'nsuns-4day',
+  name: 'nSuns 531 LP (4-day)',
+  summary: 'nSuns 531 linear progression, 4 days, volume-heavy main-lift waves.',
+  attribution:
+    'nSuns 531 LP. The main lift runs a 9-set wave (e.g. 8/6/4/4/4/5/6/7/8+ reps at rising then falling %TM); the AMRAP on the key set drives the weekly TM increase. Express the wave by logging the prescribed reps each set.',
+  program: {
+    name: 'nSuns 531 LP',
+    description:
+      'nSuns 531 linear progression. Each main lift runs a 9-set intensity wave with an AMRAP set that decides the next weeks training-max bump. Run the prescribed reps per set as written.',
+    phase: 'Strength',
+    workouts: [
+      {
+        name: 'Day 1 - Bench / OHP',
+        dayOfWeek: 1,
+        exercises: [
+          { name: 'Bench Press', muscleGroup: 'CHEST', category: 'COMPOUND', targetSets: 9, targetRepsMin: 1, targetRepsMax: 8, targetRIR: 1, restSec: 150, notes: 'nSuns T1 wave: 8/6/4/4/4/5/6/7/8+ reps; key set is AMRAP.' },
+          { name: 'Overhead Press', muscleGroup: 'SHOULDERS_FRONT', category: 'COMPOUND', targetSets: 8, targetRepsMin: 4, targetRepsMax: 8, targetRIR: 2, restSec: 120, notes: 'nSuns T2 wave: 6/5/3/5/7/4/6/8 reps.' },
+          { name: 'Chin-up', muscleGroup: 'BACK_WIDTH', category: 'COMPOUND', targetSets: 4, targetRepsMin: 8, targetRepsMax: 12, targetRIR: 2, restSec: 90 },
+        ],
+      },
+      {
+        name: 'Day 2 - Squat / Sumo Deadlift',
+        dayOfWeek: 2,
+        exercises: [
+          { name: 'Back Squat', muscleGroup: 'QUADS', category: 'COMPOUND', targetSets: 9, targetRepsMin: 1, targetRepsMax: 8, targetRIR: 1, restSec: 180, notes: 'nSuns T1 wave: 8/6/4/4/4/5/6/7/8+ reps; key set is AMRAP.' },
+          { name: 'Deadlift', muscleGroup: 'BACK_THICKNESS', category: 'COMPOUND', targetSets: 8, targetRepsMin: 3, targetRepsMax: 8, targetRIR: 2, restSec: 150, notes: 'nSuns T2 wave: 5/5/3/5/7/4/6/8 reps.' },
+          { name: 'Leg Curl', muscleGroup: 'HAMSTRINGS', category: 'ISOLATION', targetSets: 4, targetRepsMin: 10, targetRepsMax: 15, targetRIR: 2, restSec: 60 },
+        ],
+      },
+      {
+        name: 'Day 3 - OHP / Incline Bench',
+        dayOfWeek: 4,
+        exercises: [
+          { name: 'Overhead Press', muscleGroup: 'SHOULDERS_FRONT', category: 'COMPOUND', targetSets: 9, targetRepsMin: 1, targetRepsMax: 8, targetRIR: 1, restSec: 150, notes: 'nSuns T1 wave: 8/6/4/4/4/5/6/7/8+ reps; key set is AMRAP.' },
+          { name: 'Incline Bench Press', muscleGroup: 'CHEST', category: 'COMPOUND', targetSets: 8, targetRepsMin: 4, targetRepsMax: 8, targetRIR: 2, restSec: 120, notes: 'nSuns T2 wave: 6/5/3/5/7/4/6/8 reps.' },
+          { name: 'Lateral Raise', muscleGroup: 'SHOULDERS_LATERAL', category: 'ISOLATION', targetSets: 4, targetRepsMin: 12, targetRepsMax: 20, targetRIR: 1, restSec: 60 },
+        ],
+      },
+      {
+        name: 'Day 4 - Deadlift / Front Squat',
+        dayOfWeek: 5,
+        exercises: [
+          { name: 'Deadlift', muscleGroup: 'BACK_THICKNESS', category: 'COMPOUND', targetSets: 9, targetRepsMin: 1, targetRepsMax: 8, targetRIR: 1, restSec: 240, notes: 'nSuns T1 wave: 5/3/1/3/3/3/5/7/4+ reps; key set is AMRAP.' },
+          { name: 'Front Squat', muscleGroup: 'QUADS', category: 'COMPOUND', targetSets: 8, targetRepsMin: 3, targetRepsMax: 8, targetRIR: 2, restSec: 150, notes: 'nSuns T2 wave: 5/5/3/5/7/4/6/8 reps.' },
+          { name: 'Hanging Leg Raise', muscleGroup: 'ABS', category: 'ISOLATION', targetSets: 4, targetRepsMin: 10, targetRepsMax: 15, targetRIR: 2, restSec: 60 },
+        ],
+      },
+    ],
+  },
+};
+
+// The public catalog. Validated at module load (see programTemplates) so a
+// malformed template fails fast in tests and the build, never at runtime for a
+// user.
+const RAW_TEMPLATES: ProgramTemplate[] = [
+  FIVE_THREE_ONE,
+  GZCLP,
+  PPL,
+  UPPER_LOWER,
+  NSUNS,
+];
+
+// Validate every template's program against the same schema the build route
+// uses, so a typo here cannot produce a program the API would reject.
+for (const t of RAW_TEMPLATES) {
+  const result = generatedProgramSchema.safeParse(t.program);
+  if (!result.success) {
+    throw new Error(
+      `Invalid built-in template "${t.slug}": ${result.error.issues
+        .map((i) => `${i.path.join('.')}: ${i.message}`)
+        .join('; ')}`,
+    );
+  }
+}
+
+export const programTemplates: ProgramTemplate[] = RAW_TEMPLATES;
+
+// Look up a template by slug.
+export function getTemplateBySlug(slug: string): ProgramTemplate | undefined {
+  return programTemplates.find((t) => t.slug === slug);
+}

--- a/tests/integration/core.test.ts
+++ b/tests/integration/core.test.ts
@@ -4,6 +4,7 @@ import { seedExerciseCatalog, EXERCISE_CATALOG } from '@/lib/exercise-catalog';
 import { buildProgramFromGenerated } from '@/lib/program-generation';
 import type { GeneratedProgram } from '@/lib/schemas/program-generation';
 import { buildCoachPayload } from '@/lib/coach';
+import { programTemplates, getTemplateBySlug } from '@/lib/programs/templates';
 
 async function makeUser(email: string) {
   return db.user.create({ data: { email, passwordHash: 'x' } });
@@ -85,6 +86,66 @@ describe('buildProgramFromGenerated', () => {
 
     const names = program?.workouts[0]?.exercises.map((pe) => pe.exercise.name).sort();
     expect(names).toEqual(['Barbell bench press', 'Brand New Cable Thing']);
+  });
+});
+
+describe('built-in program templates materialize into a Program', () => {
+  it('persists every template as a runnable program for the user', async () => {
+    const user = await makeUser('templates@test.dev');
+
+    for (const template of programTemplates) {
+      const programId = await buildProgramFromGenerated(user.id, template.program);
+      const program = await db.program.findUnique({
+        where: { id: programId },
+        include: { workouts: { include: { exercises: true } } },
+      });
+
+      expect(program?.userId).toBe(user.id);
+      // Materialized as inactive, like any generated program.
+      expect(program?.isActive).toBe(false);
+      expect(program?.name).toBe(template.program.name);
+      expect(program?.workouts).toHaveLength(template.program.workouts.length);
+
+      // Every workout has its exercises with the template's targets.
+      for (const w of template.program.workouts) {
+        const persistedWorkout = program?.workouts.find((pw) => pw.name === w.name);
+        expect(persistedWorkout?.exercises).toHaveLength(w.exercises.length);
+      }
+    }
+  });
+
+  it('can run a session from a template-instantiated program', async () => {
+    const user = await makeUser('template-session@test.dev');
+    const template = getTemplateBySlug('upper-lower-4day');
+    expect(template).toBeDefined();
+
+    const programId = await buildProgramFromGenerated(user.id, template!.program);
+    const program = await db.program.findUnique({
+      where: { id: programId },
+      include: { workouts: { include: { exercises: true } } },
+    });
+    const firstWorkout = program!.workouts[0]!;
+
+    const session = await db.session.create({
+      data: { userId: user.id, programId, workoutId: firstWorkout.id },
+    });
+    const firstExercise = firstWorkout.exercises[0]!;
+    const set = await db.set.create({
+      data: {
+        sessionId: session.id,
+        exerciseId: firstExercise.exerciseId,
+        weight: 60,
+        reps: 8,
+        setNumber: 1,
+      },
+    });
+
+    expect(set.sessionId).toBe(session.id);
+    const sessionWithSets = await db.session.findUnique({
+      where: { id: session.id },
+      include: { sets: true },
+    });
+    expect(sessionWithSets?.sets).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
Closes #37

## What

Adds a curated catalog of well-known program templates a user can instantiate in one click, without the AI rewriting the structure.

- `lib/programs/templates.ts`: static, typed templates - 5/3/1 (Boring But Big, 4-day), GZCLP, nSuns 531 LP (4-day), a 6-day Push/Pull/Legs split, a 4-day Upper/Lower split. Each carries name/summary/attribution and a `GeneratedProgram`. Loading schemes (5/3/1 %, GZCLP tiers, nSuns waves) are expressed as set/rep/RIR targets plus per-exercise notes carrying the "as written" intent, since GymCoach tracks sets/reps/RIR rather than a percentage engine.
- Each template's program is validated against `generatedProgramSchema` **at module load**, so a typo fails fast in tests/build, never for a user.
- `components/programs/template-picker.tsx` + `app/(app)/programs/new/template/page.tsx`: a "Start from a template" picker that materializes the chosen template through the existing `/api/programs/build` route (same validated path as the AI generator). The coach therefore treats it like any user-authored program.
- Entry point added to `programs/new`.

## How I tested

- `lib/programs/templates.test.ts`: catalog completeness (the 4 required programs present), unique slugs, schema validity, metadata, rep-range sanity, slug lookup.
- `tests/integration/core.test.ts`: materializes every template into a real `Program` for a user, and runs a session (logs a set) from an Upper/Lower template-instantiated program.
- `bash scripts/verify.sh` green; full integration suite (`npm run test:integration` against the test Postgres on :5434) green - 15/15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)