### PR TITLE
feat: readiness/soreness check-in feeding coach auto-regulation

### DIFF
--- a/app/(app)/session/new/page.tsx
+++ b/app/(app)/session/new/page.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { StartWorkoutButton } from '@/components/session/start-workout-button';
+import { ReadinessCheckin } from '@/components/session/readiness-checkin';
 import { DAY_LABELS } from '@/lib/schemas/workout';
 
 export default async function NewSessionPage() {
@@ -70,7 +71,9 @@ export default async function NewSessionPage() {
             </CardContent>
           </Card>
         ) : (
-          <ul className="flex flex-col gap-3">
+          <>
+            <ReadinessCheckin />
+            <ul className="flex flex-col gap-3">
             {activeProgram.workouts.map((w) => {
               const day = w.dayOfWeek != null ? DAY_LABELS[w.dayOfWeek - 1] : null;
               return (
@@ -97,7 +100,8 @@ export default async function NewSessionPage() {
                 </li>
               );
             })}
-          </ul>
+            </ul>
+          </>
         )}
       </div>
     </main>

--- a/app/api/readiness/route.ts
+++ b/app/api/readiness/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+import type { Prisma } from '@prisma/client';
+import { db } from '@/lib/db';
+import { handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
+import { readinessCheckinInputSchema } from '@/lib/schemas/readiness';
+
+// GET /api/readiness: the user's latest readiness check-in (or null).
+export async function GET() {
+  try {
+    const userId = await requireApiUserId();
+    const latest = await db.readinessCheckin.findFirst({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+    });
+    return NextResponse.json(latest ?? null);
+  } catch (err) {
+    return handleApiError(err);
+  }
+}
+
+// POST /api/readiness: records a new readiness check-in for the user.
+export async function POST(req: Request) {
+  try {
+    const userId = await requireApiUserId();
+    const data = await parseJsonBody(req, readinessCheckinInputSchema);
+    const created = await db.readinessCheckin.create({
+      data: {
+        userId,
+        readiness: data.readiness,
+        sleepQuality: data.sleepQuality,
+        soreness: (data.soreness ?? undefined) as Prisma.InputJsonValue | undefined,
+        note: data.note ?? null,
+      },
+    });
+    return NextResponse.json(created, { status: 201 });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/components/session/readiness-checkin.tsx
+++ b/components/session/readiness-checkin.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useState } from 'react';
+import { HeartPulse } from 'lucide-react';
+import { toast } from 'sonner';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+
+// Optional, skippable pre-session readiness check-in (issue #38). Adds no
+// friction: it is collapsed by default behind a single tap and never blocks
+// starting a session. The latest check-in feeds the coach payload as an input
+// signal; it does not change anything about how a session is logged.
+
+const SCALE = [1, 2, 3, 4, 5];
+
+export function ReadinessCheckin() {
+  const [open, setOpen] = useState(false);
+  const [readiness, setReadiness] = useState<number | null>(null);
+  const [sleepQuality, setSleepQuality] = useState<number | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  async function submit() {
+    if (readiness === null || sleepQuality === null) {
+      toast.error('Rate both readiness and sleep first.');
+      return;
+    }
+    setSaving(true);
+    try {
+      const res = await fetch('/api/readiness', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ readiness, sleepQuality }),
+      });
+      if (!res.ok) {
+        const j = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(j.error ?? `Error ${res.status}`);
+      }
+      toast.success('Check-in saved. The coach will factor it in.');
+      setSaved(true);
+      setOpen(false);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Could not save the check-in.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!open) {
+    return (
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="self-start"
+        onClick={() => setOpen(true)}
+      >
+        <HeartPulse className="size-4" />
+        <span className="ml-2">
+          {saved ? 'Update readiness check-in' : 'Readiness check-in (optional)'}
+        </span>
+      </Button>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <h2 className="text-base font-semibold">How recovered do you feel?</h2>
+        <p className="text-xs text-muted-foreground">
+          Optional. Rate 1 (low) to 5 (high); the coach uses it to auto-regulate.
+        </p>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <ScaleRow label="Overall readiness" value={readiness} onChange={setReadiness} />
+        <ScaleRow label="Sleep quality" value={sleepQuality} onChange={setSleepQuality} />
+        <div className="flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => setOpen(false)}
+            disabled={saving}
+          >
+            Skip
+          </Button>
+          <Button type="button" onClick={submit} disabled={saving}>
+            {saving ? 'Saving...' : 'Save check-in'}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ScaleRow({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: number | null;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <Label className="text-xs uppercase tracking-wide text-muted-foreground">
+        {label}
+      </Label>
+      <div className="grid grid-cols-5 gap-2">
+        {SCALE.map((n) => (
+          <Button
+            key={n}
+            type="button"
+            variant={value === n ? 'default' : 'outline'}
+            onClick={() => onChange(n)}
+            className="min-h-tap text-lg font-semibold"
+            aria-label={`${label}: ${n}`}
+            aria-pressed={value === n}
+          >
+            {n}
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/lib/coach.ts
+++ b/lib/coach.ts
@@ -31,6 +31,11 @@ export interface CoachPayload {
   weekCurrent: WeekSummary;
   weekPrevious: WeekSummary | null;
   activeProgram: ProgramSummary | null;
+  // Latest pre-session readiness / soreness check-in (issue #38), when the user
+  // filled one in recently. Input signal for recovery-anchored auto-regulation;
+  // null when there is no recent check-in. The coach reasons over this but its
+  // output contract (the <adjustments> block) is unchanged.
+  latestReadiness: ReadinessSummary | null;
   // For each program exercise: the progression over the last 8 weeks
   // (max loads + 1RM per session, effective values with bodyweight included).
   recentProgress: Array<{
@@ -48,6 +53,20 @@ export interface CoachPayload {
       estimated1RM: number;
     }>;
   }>;
+}
+
+interface ReadinessSummary {
+  // ISO date of the check-in.
+  date: string;
+  // Whole-days-ago since the check-in, so the coach can weight its relevance.
+  daysAgo: number;
+  // Overall readiness to train, 1 (drained) to 5 (primed).
+  readiness: number;
+  // Sleep quality the previous night, 1 (poor) to 5 (great).
+  sleepQuality: number;
+  // Optional per-muscle-group soreness ratings (group -> 1-5).
+  soreness: Record<string, number> | null;
+  note: string | null;
 }
 
 interface WeekSummary {
@@ -122,10 +141,12 @@ export async function buildCoachPayload(userId: string): Promise<CoachPayload> {
   });
   const bodyweight = user?.bodyweight ?? null;
 
-  const [currentWeek, previousWeek, activeProgram, recentSets] = await Promise.all([
+  const [currentWeek, previousWeek, activeProgram, latestReadiness, recentSets] =
+    await Promise.all([
     weekSummary(userId, currentWeekStart, addDays(currentWeekStart, 7), bodyweight),
     weekSummary(userId, previousWeekStart, currentWeekStart, bodyweight),
     fetchActiveProgram(userId),
+    fetchLatestReadiness(userId, now),
     db.set.findMany({
       where: {
         isWarmup: false,
@@ -224,6 +245,7 @@ export async function buildCoachPayload(userId: string): Promise<CoachPayload> {
     weekCurrent: currentWeek,
     weekPrevious: previousWeek.sessions.length === 0 ? null : previousWeek,
     activeProgram,
+    latestReadiness,
     recentProgress: recentProgress.sort((a, b) =>
       a.exerciseName.localeCompare(b.exerciseName),
     ),
@@ -359,6 +381,43 @@ async function fetchActiveProgram(userId: string): Promise<ProgramSummary | null
         targetRIR: pe.targetRIR,
       })),
     })),
+  };
+}
+
+// The most recent readiness check-in, but only if it is recent enough to be
+// relevant (within the last 7 days). Returns null otherwise. This is an INPUT
+// signal for the coach; it does not change the coach output contract.
+async function fetchLatestReadiness(
+  userId: string,
+  now: Date,
+): Promise<ReadinessSummary | null> {
+  const sevenDaysAgo = addDays(now, -7);
+  const checkin = await db.readinessCheckin.findFirst({
+    where: { userId, createdAt: { gte: sevenDaysAgo } },
+    orderBy: { createdAt: 'desc' },
+  });
+  if (!checkin) return null;
+
+  const daysAgo = Math.floor(
+    (now.getTime() - checkin.createdAt.getTime()) / (1000 * 60 * 60 * 24),
+  );
+
+  // soreness is stored as JSON; coerce to a plain { group: 1-5 } map defensively.
+  let soreness: Record<string, number> | null = null;
+  if (checkin.soreness && typeof checkin.soreness === 'object' && !Array.isArray(checkin.soreness)) {
+    const entries = Object.entries(checkin.soreness as Record<string, unknown>).filter(
+      ([, v]) => typeof v === 'number',
+    ) as Array<[string, number]>;
+    if (entries.length > 0) soreness = Object.fromEntries(entries);
+  }
+
+  return {
+    date: checkin.createdAt.toISOString(),
+    daysAgo,
+    readiness: checkin.readiness,
+    sleepQuality: checkin.sleepQuality,
+    soreness,
+    note: checkin.note,
   };
 }
 

--- a/lib/prompts/coach-system-prompt.ts
+++ b/lib/prompts/coach-system-prompt.ts
@@ -13,6 +13,13 @@ For each debrief, you produce:
 4. **Next-week suggestions**: loads to aim for, volume adjustments
 5. **Points of attention**: noted pain, technique, imbalances
 
+When the payload includes a recent readiness check-in (latestReadiness: overall
+readiness, sleep quality, and per-muscle-group soreness on 1-5 scales), factor it
+into your fatigue read and next-week suggestions: low readiness, poor sleep, or
+high soreness in a trained muscle group are reasons to hold or reduce volume/load;
+strong readiness can justify pushing. Treat it as one signal among the training
+data, never the only one, and only when it is recent.
+
 Be concise (max 600 words), actionable, factual. Cite studies when relevant
 (Schoenfeld, Helms, Israetel). Do not make up data that is not in the payload.
 

--- a/lib/schemas/readiness.test.ts
+++ b/lib/schemas/readiness.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { readinessCheckinInputSchema } from './readiness';
+
+describe('readinessCheckinInputSchema', () => {
+  it('accepts a minimal valid check-in', () => {
+    const r = readinessCheckinInputSchema.safeParse({ readiness: 4, sleepQuality: 3 });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts per-muscle-group soreness on a 1-5 scale', () => {
+    const r = readinessCheckinInputSchema.safeParse({
+      readiness: 3,
+      sleepQuality: 4,
+      soreness: { QUADS: 5, CHEST: 2 },
+      note: 'legs are toast',
+    });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.soreness).toEqual({ QUADS: 5, CHEST: 2 });
+  });
+
+  it('rejects readiness outside 1-5', () => {
+    expect(readinessCheckinInputSchema.safeParse({ readiness: 0, sleepQuality: 3 }).success).toBe(false);
+    expect(readinessCheckinInputSchema.safeParse({ readiness: 6, sleepQuality: 3 }).success).toBe(false);
+  });
+
+  it('rejects sleepQuality outside 1-5', () => {
+    expect(readinessCheckinInputSchema.safeParse({ readiness: 3, sleepQuality: 9 }).success).toBe(false);
+  });
+
+  it('rejects a soreness value outside 1-5', () => {
+    const r = readinessCheckinInputSchema.safeParse({
+      readiness: 3,
+      sleepQuality: 3,
+      soreness: { QUADS: 7 },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects an unknown muscle group key', () => {
+    const r = readinessCheckinInputSchema.safeParse({
+      readiness: 3,
+      sleepQuality: 3,
+      soreness: { NOT_A_MUSCLE: 3 },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects a non-integer rating', () => {
+    expect(readinessCheckinInputSchema.safeParse({ readiness: 2.5, sleepQuality: 3 }).success).toBe(false);
+  });
+
+  it('caps the note length', () => {
+    const r = readinessCheckinInputSchema.safeParse({
+      readiness: 3,
+      sleepQuality: 3,
+      note: 'x'.repeat(501),
+    });
+    expect(r.success).toBe(false);
+  });
+});

--- a/lib/schemas/readiness.ts
+++ b/lib/schemas/readiness.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+import { MuscleGroup } from '@prisma/client';
+
+// Pre-session readiness / soreness check-in input (issue #38). Optional and
+// skippable in the UI; this schema only validates a check-in the user chose to
+// submit. Soreness is a partial map of muscle group -> 1-5 rating.
+
+const ratingScale = z.coerce.number().int().min(1).max(5);
+
+// A partial record over the MuscleGroup enum. `.partial()` makes every key
+// optional, so the user can rate only the groups they trained.
+export const sorenessSchema = z
+  .record(z.nativeEnum(MuscleGroup), ratingScale)
+  .optional()
+  .nullable();
+
+export const readinessCheckinInputSchema = z.object({
+  readiness: ratingScale,
+  sleepQuality: ratingScale,
+  soreness: sorenessSchema,
+  note: z.string().trim().max(500).optional().nullable(),
+});
+
+export type ReadinessCheckinInput = z.infer<typeof readinessCheckinInputSchema>;
+export type Soreness = Partial<Record<MuscleGroup, number>>;

--- a/prisma/migrations/20260609000000_add_readiness_checkin/migration.sql
+++ b/prisma/migrations/20260609000000_add_readiness_checkin/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "ReadinessCheckin" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "readiness" INTEGER NOT NULL,
+    "sleepQuality" INTEGER NOT NULL,
+    "soreness" JSONB,
+    "note" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ReadinessCheckin_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ReadinessCheckin_userId_createdAt_idx" ON "ReadinessCheckin"("userId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "ReadinessCheckin" ADD CONSTRAINT "ReadinessCheckin_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,7 @@ model User {
   sessions      Session[]
   exercises     Exercise[]
   conversations Conversation[]
+  readinessCheckins ReadinessCheckin[]
 }
 
 enum Sex {
@@ -212,4 +213,26 @@ model CoachSession {
   response  String    @db.Text
   appliedAt DateTime?
   createdAt DateTime  @default(now())
+}
+
+// Pre-session readiness / soreness check-in (issue #38). Additive, optional:
+// the app never requires a check-in, and the coach treats it as one more input
+// signal for recovery-anchored auto-regulation. Soreness is stored per muscle
+// group as a JSON map (group -> 1-5) so adding groups later needs no migration.
+model ReadinessCheckin {
+  id           String   @id @default(cuid())
+  userId       String
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  // Overall readiness to train, 1 (drained) to 5 (primed).
+  readiness    Int
+  // Sleep quality the previous night, 1 (poor) to 5 (great).
+  sleepQuality Int
+  // Optional per-muscle-group soreness: { "QUADS": 4, "CHEST": 2, ... } on a
+  // 1-5 scale. Stored as JSON to stay flexible without a schema change.
+  soreness     Json?
+  // Optional free-text note.
+  note         String?
+  createdAt    DateTime @default(now())
+
+  @@index([userId, createdAt])
 }

--- a/tests/integration/core.test.ts
+++ b/tests/integration/core.test.ts
@@ -187,3 +187,67 @@ describe('buildCoachPayload isolation', () => {
     expect(names).not.toContain('B-Only Squat');
   });
 });
+
+describe('buildCoachPayload readiness (issue #38)', () => {
+  it('surfaces the latest recent readiness check-in into the payload', async () => {
+    const user = await makeUser('readiness@test.dev');
+
+    // An older check-in and a newer one: the newest should win.
+    await db.readinessCheckin.create({
+      data: {
+        userId: user.id,
+        readiness: 2,
+        sleepQuality: 2,
+        createdAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
+      },
+    });
+    await db.readinessCheckin.create({
+      data: {
+        userId: user.id,
+        readiness: 4,
+        sleepQuality: 5,
+        soreness: { QUADS: 5, CHEST: 2 },
+        note: 'legs sore',
+      },
+    });
+
+    const payload = await buildCoachPayload(user.id);
+    expect(payload.latestReadiness).not.toBeNull();
+    expect(payload.latestReadiness?.readiness).toBe(4);
+    expect(payload.latestReadiness?.sleepQuality).toBe(5);
+    expect(payload.latestReadiness?.soreness).toEqual({ QUADS: 5, CHEST: 2 });
+    expect(payload.latestReadiness?.note).toBe('legs sore');
+  });
+
+  it('ignores a stale check-in older than 7 days', async () => {
+    const user = await makeUser('stale-readiness@test.dev');
+    await db.readinessCheckin.create({
+      data: {
+        userId: user.id,
+        readiness: 3,
+        sleepQuality: 3,
+        createdAt: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000),
+      },
+    });
+
+    const payload = await buildCoachPayload(user.id);
+    expect(payload.latestReadiness).toBeNull();
+  });
+
+  it('does not leak another user check-in', async () => {
+    const userA = await makeUser('ra@test.dev');
+    const userB = await makeUser('rb@test.dev');
+    await db.readinessCheckin.create({
+      data: { userId: userB.id, readiness: 5, sleepQuality: 5 },
+    });
+
+    const payload = await buildCoachPayload(userA.id);
+    expect(payload.latestReadiness).toBeNull();
+  });
+
+  it('is null when the user never checked in', async () => {
+    const user = await makeUser('no-readiness@test.dev');
+    const payload = await buildCoachPayload(user.id);
+    expect(payload.latestReadiness).toBeNull();
+  });
+});

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -11,7 +11,7 @@ if (!process.env.DATABASE_URL) {
 // Truncates every table between tests so each starts from a clean slate.
 export async function resetDb(): Promise<void> {
   await db.$executeRawUnsafe(
-    'TRUNCATE TABLE "Message","Conversation","Set","Session","ProgramExercise","Workout","Program","Exercise","CoachSession","User" RESTART IDENTITY CASCADE;',
+    'TRUNCATE TABLE "Message","Conversation","ReadinessCheckin","Set","Session","ProgramExercise","Workout","Program","Exercise","CoachSession","User" RESTART IDENTITY CASCADE;',
   );
 }
 


### PR DESCRIPTION
Closes #38

## What

Adds a lightweight, optional readiness check-in that feeds the AI coach a recovery signal for auto-regulation - the research-backed differentiator (auto-regulation anchored on real recovery signals, not a "random generator").

- **Prisma**: a new `ReadinessCheckin` model (per-user, timestamped: `readiness` 1-5, `sleepQuality` 1-5, optional per-muscle-group `soreness` JSON, optional `note`). Migration `20260609000000_add_readiness_checkin`.
- **Zod**: `lib/schemas/readiness.ts` validates the input; soreness is a partial `MuscleGroup -> 1-5` map. `/api/readiness` GET (latest) + POST (create), both Zod-validated and user-scoped.
- **UI**: `components/session/readiness-checkin.tsx` - an optional, collapsed-by-default, skippable check-in on the "Start a session" page. Adds no friction to logging.
- **Coach payload**: a new `latestReadiness` INPUT field on `CoachPayload` (latest check-in within 7 days, with `daysAgo`). `callCoach` already serializes the whole payload into the prompt, so the coach demonstrably receives it.

## Guardrails honored (additive-only)

- **Migration is strictly additive**: verified with `prisma migrate diff --from-migrations --to-schema-datamodel` -> "No difference detected". The SQL is `CREATE TABLE` + `CREATE INDEX` + `ADD` FK only. No backfill, no destructive column change.
- **LLM output contract unchanged**: `adjustmentSchema` and the `<adjustments>` block are untouched. Readiness is added only as INPUT; the coach prompt gains guidance to *reason over* readiness, not a new output field.

## How I tested

- `lib/schemas/readiness.test.ts` (8): scale bounds, unknown muscle-group key, soreness range, note cap, non-integer rejection.
- `tests/integration/core.test.ts`: latest-within-7-days wins, stale (>7d) ignored, no cross-user leak, null when never checked in.
- `bash scripts/verify.sh` green; full integration suite green (19/19) against the test Postgres on :5434.

## Subagent challenge

Reviewed under two lenses: correctness (input threading, JSON coercion, user-scoping) and migration-stays-additive (confirmed via `migrate diff`). No blocking findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)