### PR TITLE
chore: audit coach prompts/UX - advise within the program, explain why

### DIFF
--- a/lib/prompts/coach-system-prompt.test.ts
+++ b/lib/prompts/coach-system-prompt.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { COACH_SYSTEM_PROMPT } from './coach-system-prompt';
+import { PROGRAM_GEN_SYSTEM_PROMPT } from './program-system-prompt';
+
+// Issue #40: the coach must advise WITHIN the user's program and explain why,
+// never silently restructure it. These tests pin the positioning into the
+// stable system prompts so a future edit cannot quietly drop it.
+
+describe('coach system prompt positioning', () => {
+  it('instructs the coach to advise within the active program, not replace it', () => {
+    expect(COACH_SYSTEM_PROMPT).toMatch(/advise WITHIN the user's active program/i);
+    expect(COACH_SYSTEM_PROMPT).toMatch(/Do NOT redesign the program/i);
+  });
+
+  it('requires every suggestion to explain its "why"', () => {
+    expect(COACH_SYSTEM_PROMPT).toMatch(/explain its "why"/i);
+    expect(COACH_SYSTEM_PROMPT).toMatch(/fill the "rationale"/i);
+  });
+
+  it('forbids adding, removing or swapping exercises in an adjustment', () => {
+    expect(COACH_SYSTEM_PROMPT).toMatch(
+      /Never propose adding, removing or swapping an exercise/i,
+    );
+  });
+
+  it('states adjustments are user-accepted, never auto-applied', () => {
+    expect(COACH_SYSTEM_PROMPT).toMatch(/never applied\s+automatically/i);
+  });
+
+  it('still defines the <adjustments> output contract (unchanged)', () => {
+    // Guardrail: the audit must not have altered the output contract.
+    expect(COACH_SYSTEM_PROMPT).toContain('<adjustments>');
+    expect(COACH_SYSTEM_PROMPT).toContain('"exerciseName"');
+    expect(COACH_SYSTEM_PROMPT).toContain('"suggestedRepsMin"');
+    expect(COACH_SYSTEM_PROMPT).toContain('"suggestedRestSec"');
+  });
+});
+
+describe('program generation prompt positioning', () => {
+  it('frames the program as a user-controlled, editable draft', () => {
+    expect(PROGRAM_GEN_SYSTEM_PROMPT).toMatch(/draft/i);
+    expect(PROGRAM_GEN_SYSTEM_PROMPT).toMatch(/Honor any structure.*the user states/i);
+  });
+});

--- a/lib/prompts/coach-system-prompt.ts
+++ b/lib/prompts/coach-system-prompt.ts
@@ -6,6 +6,17 @@ export const COACH_SYSTEM_PROMPT = `You are a sports-science coach specialized i
 You receive a user's weekly training data along with their active program.
 The user's profile (sex, height, weight, goal, frequency) is provided in the payload when it is filled in.
 
+Your role is to advise WITHIN the user's active program, not to replace it. The
+program is the user's choice. Work inside its structure (its exercises, split and
+intent) and tune the dials it already exposes: load, sets, reps and RIR targets,
+rest. Do NOT redesign the program, swap its exercises, or change its split. If you
+believe a deeper structural change is warranted, say so in plain words as a
+recommendation for the user to decide on - never as an applied change.
+
+Every suggestion must explain its "why": tie it to a specific signal in the
+payload (a plateau, a fatigue trend, an RIR/load pattern, the user's goal). No
+unexplained changes.
+
 For each debrief, you produce:
 1. **Performance recap**: exercises with progression vs the previous session
 2. **Detected plateaus**: exercises with no progression for 3+ weeks
@@ -41,8 +52,15 @@ NOTHING after this block. Strict format:
 ]
 </adjustments>
 
-Only propose an adjustment if you have a justification in the data. At most 8
-adjustments. If there is nothing to adjust, do not include the block.
+Only propose an adjustment if you have a justification in the data, and always
+fill the "rationale" with that justification (the "why"). Every adjustment must
+stay within the existing program: it may only retune load, sets, reps, RIR, rest
+or notes for an exercise that is ALREADY in the active program (match
+exerciseName exactly). Never propose adding, removing or swapping an exercise
+here, and never restructure the program. These are suggestions the user reviews,
+edits and explicitly accepts before anything is applied - they are never applied
+automatically. At most 8 adjustments. If there is nothing to adjust, do not
+include the block.
 
 IMPORTANT: when you include an adjustment, ALWAYS fill in the 5 structured fields:
 suggestedRepsMin, suggestedRepsMax, suggestedSets, suggestedRIR, suggestedRestSec. If

--- a/lib/prompts/program-system-prompt.ts
+++ b/lib/prompts/program-system-prompt.ts
@@ -3,6 +3,8 @@
 // lib/schemas/program-generation.ts.
 export const PROGRAM_GEN_SYSTEM_PROMPT = `You are a strength and hypertrophy coach. From a user's goal (in natural language) and their context, you design a complete, realistic resistance-training program.
 
+This program is a draft: the user reviews and edits it before it is saved, and they remain in control of their training. Honor any structure, split, exercise or constraint the user states in their goal rather than imposing your own template.
+
 You receive a JSON context with the user's profile and the exercises already in their catalog. Prefer reusing exercises from that catalog by their exact name when they fit; you may also add new exercises when needed.
 
 Respond with a SINGLE JSON object and NOTHING else (no prose, no markdown, no code fences). The object must match exactly this shape:


### PR DESCRIPTION
Closes #40

## Audit findings (silent-rewrite risks)

The current architecture already prevents the coach from silently rewriting the user's program:

- **Adjustments are never auto-applied.** The coach emits an `<adjustments>` block; `extractAdjustments` parses it and Zod-validates each entry (`adjustmentSchema`). The UI (`components/coach/coach-adjustments.tsx`) shows them as **opt-in, editable** toggles. Nothing is written until the user explicitly clicks "Apply".
- **The apply path is Zod-validated and scoped.** `POST /api/coach/[id]/apply` re-validates with `applyAdjustmentsSchema`, only updates `ProgramExercise` rows for exercises **already in the active program** (matched by exact name), and **appends a dated note** rather than overwriting history. Unmatched exercises are skipped, not created. No restructuring path exists.
- **Generated programs are drafts.** `programs/generate` returns a preview the user edits before `POST /api/programs/build`.

So: no user-data-affecting coach output bypasses Zod, and there is no silent-rewrite path. The gap was in the **prompt wording**, which never explicitly told the model to stay within the program or to always explain the why.

## Fixes (wording only - output contract unchanged)

- Coach system prompt: advise **within** the active program (retune load/sets/reps/RIR/rest/notes only; never redesign, swap exercises, or restructure - structural ideas go in prose for the user to decide); **explain the "why"** of every suggestion (fill `rationale`); adjustments are user-reviewed and **never applied automatically**.
- Program-gen prompt: frames output as a user-controlled, editable **draft** that honors the user's stated structure/constraints.
- The `<adjustments>` JSON schema and field names are **untouched** - pinned by a guardrail test.

## Tests

- `lib/prompts/coach-system-prompt.test.ts` (6): assert the positioning wording AND that the `<adjustments>` output contract is unchanged.
- `bash scripts/verify.sh` green.

No LLM output-contract change, so this did not hit the stop-list; opened as a normal PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)