### PR TITLE
feat: capture per-muscle soreness and a note in the readiness check-in

### DIFF
--- a/components/session/readiness-checkin.test.tsx
+++ b/components/session/readiness-checkin.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ReadinessCheckin } from './readiness-checkin';
+
+// sonner's toast is a side effect we do not assert on here; stub it so the
+// component can call it without a real toaster mounted.
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+function lastFetchBody(fetchMock: ReturnType<typeof vi.fn>) {
+  const call = fetchMock.mock.calls.at(-1);
+  return JSON.parse((call?.[1] as RequestInit).body as string);
+}
+
+describe('ReadinessCheckin', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }),
+    );
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  async function openForm() {
+    const user = userEvent.setup();
+    render(<ReadinessCheckin />);
+    await user.click(
+      screen.getByRole('button', { name: /readiness check-in \(optional\)/i }),
+    );
+    return user;
+  }
+
+  it('submits only readiness + sleep on the quick path (no soreness/note)', async () => {
+    const user = await openForm();
+
+    await user.click(screen.getByRole('button', { name: 'Overall readiness: 4' }));
+    await user.click(screen.getByRole('button', { name: 'Sleep quality: 3' }));
+    await user.click(screen.getByRole('button', { name: 'Save check-in' }));
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    expect(fetchMock).toHaveBeenCalledWith('/api/readiness', expect.anything());
+    expect(lastFetchBody(fetchMock)).toEqual({ readiness: 4, sleepQuality: 3 });
+  });
+
+  it('does not submit and warns when readiness or sleep is missing', async () => {
+    const user = await openForm();
+    await user.click(screen.getByRole('button', { name: 'Overall readiness: 4' }));
+    await user.click(screen.getByRole('button', { name: 'Save check-in' }));
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps the soreness/note section collapsed until the user opens it', async () => {
+    await openForm();
+    expect(screen.queryByText('Per-muscle soreness')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /add soreness \/ note \(optional\)/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('submits a partial soreness map and a note when filled in', async () => {
+    const user = await openForm();
+
+    await user.click(screen.getByRole('button', { name: 'Overall readiness: 5' }));
+    await user.click(screen.getByRole('button', { name: 'Sleep quality: 4' }));
+    await user.click(
+      screen.getByRole('button', { name: /add soreness \/ note \(optional\)/i }),
+    );
+
+    // Rate only two groups; the rest stay unrated and must be absent.
+    await user.click(screen.getByRole('button', { name: 'Chest soreness: 3' }));
+    await user.click(screen.getByRole('button', { name: 'Quads soreness: 5' }));
+    await user.type(screen.getByLabelText('Note'), 'Left shoulder tight.');
+    await user.click(screen.getByRole('button', { name: 'Save check-in' }));
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    expect(lastFetchBody(fetchMock)).toEqual({
+      readiness: 5,
+      sleepQuality: 4,
+      soreness: { CHEST: 3, QUADS: 5 },
+      note: 'Left shoulder tight.',
+    });
+  });
+
+  it('clears a soreness rating when its current value is tapped again', async () => {
+    const user = await openForm();
+
+    await user.click(screen.getByRole('button', { name: 'Overall readiness: 2' }));
+    await user.click(screen.getByRole('button', { name: 'Sleep quality: 2' }));
+    await user.click(
+      screen.getByRole('button', { name: /add soreness \/ note \(optional\)/i }),
+    );
+
+    const chest3 = screen.getByRole('button', { name: 'Chest soreness: 3' });
+    await user.click(chest3); // set
+    await user.click(chest3); // clear
+    await user.click(screen.getByRole('button', { name: 'Save check-in' }));
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    // Empty soreness map must be omitted entirely, back to the quick payload.
+    expect(lastFetchBody(fetchMock)).toEqual({ readiness: 2, sleepQuality: 2 });
+  });
+});

--- a/components/session/readiness-checkin.tsx
+++ b/components/session/readiness-checkin.tsx
@@ -3,35 +3,79 @@
 import { useState } from 'react';
 import { HeartPulse } from 'lucide-react';
 import { toast } from 'sonner';
+import type { MuscleGroup } from '@prisma/client';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { readinessCheckinInputSchema } from '@/lib/schemas/readiness';
+import { MUSCLE_GROUP_LABELS } from '@/lib/schemas/exercise';
 
 // Optional, skippable pre-session readiness check-in (issue #38). Adds no
 // friction: it is collapsed by default behind a single tap and never blocks
 // starting a session. The latest check-in feeds the coach payload as an input
 // signal; it does not change anything about how a session is logged.
+//
+// Soreness (per-muscle-group 1-5) and a free-text note are equally optional
+// (issue #48): they live behind a second "Add soreness / note" toggle so the
+// quick two-tap readiness + sleep path stays unchanged. Only rated groups are
+// submitted, matching the partial-map semantics the schema and coach expect.
 
 const SCALE = [1, 2, 3, 4, 5];
+
+const MUSCLE_GROUPS = Object.keys(MUSCLE_GROUP_LABELS) as MuscleGroup[];
 
 export function ReadinessCheckin() {
   const [open, setOpen] = useState(false);
   const [readiness, setReadiness] = useState<number | null>(null);
   const [sleepQuality, setSleepQuality] = useState<number | null>(null);
+  const [detailsOpen, setDetailsOpen] = useState(false);
+  const [soreness, setSoreness] = useState<Partial<Record<MuscleGroup, number>>>({});
+  const [note, setNote] = useState('');
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
+
+  function setSorenessFor(group: MuscleGroup, value: number) {
+    setSoreness((prev) => {
+      // Tapping the current rating again clears it, so a group can be unrated.
+      if (prev[group] === value) {
+        const next = { ...prev };
+        delete next[group];
+        return next;
+      }
+      return { ...prev, [group]: value };
+    });
+  }
 
   async function submit() {
     if (readiness === null || sleepQuality === null) {
       toast.error('Rate both readiness and sleep first.');
       return;
     }
+    // Only send a soreness map / note when the user actually filled them in, so
+    // the quick path stays a clean { readiness, sleepQuality } payload.
+    const trimmedNote = note.trim();
+    const payload = {
+      readiness,
+      sleepQuality,
+      ...(Object.keys(soreness).length > 0 ? { soreness } : {}),
+      ...(trimmedNote.length > 0 ? { note: trimmedNote } : {}),
+    };
+
+    // Validate locally with the same schema the route uses, so a bad note
+    // length (etc.) is caught before the round-trip.
+    const parsed = readinessCheckinInputSchema.safeParse(payload);
+    if (!parsed.success) {
+      toast.error(parsed.error.issues[0]?.message ?? 'Check-in input is invalid.');
+      return;
+    }
+
     setSaving(true);
     try {
       const res = await fetch('/api/readiness', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ readiness, sleepQuality }),
+        body: JSON.stringify(parsed.data),
       });
       if (!res.ok) {
         const j = (await res.json().catch(() => ({}))) as { error?: string };
@@ -75,6 +119,57 @@ export function ReadinessCheckin() {
       <CardContent className="flex flex-col gap-4">
         <ScaleRow label="Overall readiness" value={readiness} onChange={setReadiness} />
         <ScaleRow label="Sleep quality" value={sleepQuality} onChange={setSleepQuality} />
+
+        {!detailsOpen ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="self-start"
+            onClick={() => setDetailsOpen(true)}
+          >
+            Add soreness / note (optional)
+          </Button>
+        ) : (
+          <div className="flex flex-col gap-4 border-t pt-4">
+            <div className="space-y-2">
+              <Label className="text-xs uppercase tracking-wide text-muted-foreground">
+                Per-muscle soreness
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                Rate only the groups that feel sore (1 fresh, 5 very sore). Tap a
+                rating again to clear it.
+              </p>
+              <div className="flex flex-col gap-3">
+                {MUSCLE_GROUPS.map((group) => (
+                  <SorenessRow
+                    key={group}
+                    label={MUSCLE_GROUP_LABELS[group]}
+                    value={soreness[group] ?? null}
+                    onChange={(v) => setSorenessFor(group, v)}
+                  />
+                ))}
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label
+                htmlFor="readiness-note"
+                className="text-xs uppercase tracking-wide text-muted-foreground"
+              >
+                Note
+              </Label>
+              <Textarea
+                id="readiness-note"
+                value={note}
+                onChange={(e) => setNote(e.target.value)}
+                maxLength={500}
+                rows={3}
+                placeholder="Anything the coach should know (optional)."
+              />
+            </div>
+          </div>
+        )}
+
         <div className="flex justify-end gap-2">
           <Button
             type="button"
@@ -116,6 +211,38 @@ function ScaleRow({
             onClick={() => onChange(n)}
             className="min-h-tap text-lg font-semibold"
             aria-label={`${label}: ${n}`}
+            aria-pressed={value === n}
+          >
+            {n}
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SorenessRow({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: number | null;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-sm">{label}</span>
+      <div className="grid grid-cols-5 gap-1">
+        {SCALE.map((n) => (
+          <Button
+            key={n}
+            type="button"
+            size="sm"
+            variant={value === n ? 'default' : 'outline'}
+            onClick={() => onChange(n)}
+            className="min-h-tap w-9 px-0 text-sm font-semibold"
+            aria-label={`${label} soreness: ${n}`}
             aria-pressed={value === n}
           >
             {n}


### PR DESCRIPTION
## Summary

Wires the pre-session readiness check-in UI to capture the per-muscle-group soreness map and the optional note that the data model, `/api/readiness` route, and coach prompt already supported (#38). Until now the UI only submitted `readiness` + `sleepQuality`, so the coach was told to factor in soreness signals the user could never enter.

## What changed

- `components/session/readiness-checkin.tsx`:
  - New optional "Add soreness / note (optional)" toggle, collapsed by default, so the existing quick two-tap (readiness + sleep) path is unchanged and stays skippable.
  - Per-muscle-group soreness rated 1-5 (labels from the shared `MUSCLE_GROUP_LABELS`); tapping the current rating again clears it, so a group can be unrated.
  - Optional note via the existing `components/ui/textarea` primitive, hard-capped at 500 chars to match the schema.
  - Only rated groups are submitted (a partial map); an empty soreness map / blank note are omitted, keeping the quick payload a clean `{ readiness, sleepQuality }`.
  - The payload is validated client-side with the same `readinessCheckinInputSchema` the route uses (no duplicated validation).
- `components/session/readiness-checkin.test.tsx`: new component tests covering the quick path, the missing-rating guard, collapsed-by-default, the partial soreness map + note round-trip, and the tap-to-clear behavior.

No production change to the route, schema, prompt, or coach output contract.

Closes #48

## How I tested

- `bash scripts/verify.sh` -> GREEN-GATE PASSED (prisma generate + lint + typecheck + unit + build).
- `npx vitest run components/session/readiness-checkin.test.tsx` -> 5 passed.
- Probed `readinessCheckinInputSchema` against every payload the component builds (quick path, soreness + note, max-length note) -> all validate, confirming no regression to the quick path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)