### PR TITLE
feat: factor readiness/soreness into deterministic progression

### DIFF
--- a/lib/progression.test.ts
+++ b/lib/progression.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import type { Exercise, ProgramExercise } from '@prisma/client';
-import { suggestNextWeight, weightIncrement } from './progression';
+import {
+  READINESS_DELOAD_FRACTION,
+  READINESS_RECENCY_HOURS,
+  suggestNextWeight,
+  weightIncrement,
+  type ReadinessSignal,
+} from './progression';
 
 const compoundExo: Exercise = {
   id: 'e1',
@@ -131,5 +137,139 @@ describe('suggestNextWeight', () => {
       ],
     );
     expect(res).toMatchObject({ weight: 1, reason: 'progression', delta: 1 });
+  });
+});
+
+describe('suggestNextWeight - readiness auto-regulation (issue #53)', () => {
+  // Sets that, with no readiness signal, progress the compound (QUADS) to 82.5.
+  const progressingSets = [
+    { weight: 80, reps: 10, rir: 2 },
+    { weight: 80, reps: 10, rir: 2 },
+    { weight: 80, reps: 10, rir: 2 },
+  ];
+  // Sets that, with no readiness signal, hold the compound at 80 (one fell short).
+  const holdingSets = [
+    { weight: 80, reps: 10, rir: 2 },
+    { weight: 80, reps: 9, rir: 2 },
+    { weight: 80, reps: 10, rir: 2 },
+  ];
+
+  // ----- Backward compatibility: no data => identical to today -----
+
+  it('is byte-for-byte identical when no readiness arg is passed (progression)', () => {
+    const withArg = suggestNextWeight(makePe(compoundExo), progressingSets);
+    const withUndefined = suggestNextWeight(makePe(compoundExo), progressingSets, undefined);
+    const withNull = suggestNextWeight(makePe(compoundExo), progressingSets, null);
+    const expected = {
+      weight: 82.5,
+      reason: 'progression',
+      delta: 2.5,
+      workingWeight: 80,
+      targetRepsMax: 10,
+    };
+    expect(withArg).toEqual(expected);
+    expect(withUndefined).toEqual(expected);
+    expect(withNull).toEqual(expected);
+  });
+
+  it('is identical to today on the no-history path even with a readiness signal', () => {
+    const readiness: ReadinessSignal = { readiness: 1, soreness: { QUADS: 5 }, ageHours: 1 };
+    expect(suggestNextWeight(makePe(compoundExo), [], readiness)).toEqual({
+      weight: null,
+      reason: 'no-history',
+    });
+  });
+
+  it('ignores a stale check-in outside the recency window (unchanged output)', () => {
+    const stale: ReadinessSignal = {
+      readiness: 1,
+      soreness: { QUADS: 5 },
+      ageHours: READINESS_RECENCY_HOURS + 1,
+    };
+    expect(suggestNextWeight(makePe(compoundExo), progressingSets, stale)).toEqual(
+      suggestNextWeight(makePe(compoundExo), progressingSets),
+    );
+  });
+
+  it('ignores a recent but good check-in (unchanged output)', () => {
+    const good: ReadinessSignal = { readiness: 5, soreness: { QUADS: 1 }, ageHours: 2 };
+    expect(suggestNextWeight(makePe(compoundExo), progressingSets, good)).toEqual(
+      suggestNextWeight(makePe(compoundExo), progressingSets),
+    );
+  });
+
+  // ----- Hold: poor recovery skips the increment -----
+
+  it('holds the load when soreness on the worked group is high (>= 4)', () => {
+    const sore: ReadinessSignal = { readiness: 4, soreness: { QUADS: 4 }, ageHours: 5 };
+    const res = suggestNextWeight(makePe(compoundExo), progressingSets, sore);
+    expect(res).toEqual({
+      weight: 80,
+      reason: 'readiness-hold',
+      workingWeight: 80,
+      targetRepsMax: 10,
+    });
+  });
+
+  it('holds the load when overall readiness is low (<= 2)', () => {
+    const drained: ReadinessSignal = { readiness: 2, soreness: null, ageHours: 10 };
+    const res = suggestNextWeight(makePe(compoundExo), progressingSets, drained);
+    expect(res).toMatchObject({ weight: 80, reason: 'readiness-hold' });
+  });
+
+  it('only checks soreness for the exercise primary muscle group', () => {
+    // High soreness on CHEST must not hold a QUADS exercise.
+    const otherGroupSore: ReadinessSignal = {
+      readiness: 4,
+      soreness: { CHEST: 5 },
+      ageHours: 5,
+    };
+    expect(suggestNextWeight(makePe(compoundExo), progressingSets, otherGroupSore)).toEqual(
+      suggestNextWeight(makePe(compoundExo), progressingSets),
+    );
+  });
+
+  // ----- Deload: very poor recovery steps down once -----
+
+  it('steps down once when soreness on the worked group is severe (5)', () => {
+    const severe: ReadinessSignal = { readiness: 3, soreness: { QUADS: 5 }, ageHours: 3 };
+    const res = suggestNextWeight(makePe(compoundExo), progressingSets, severe);
+    expect(res).toEqual({
+      weight: +(80 * (1 - READINESS_DELOAD_FRACTION)).toFixed(2),
+      reason: 'readiness-deload',
+      workingWeight: 80,
+      targetRepsMax: 10,
+    });
+  });
+
+  it('steps down once when overall readiness is drained (1)', () => {
+    const drained: ReadinessSignal = { readiness: 1, soreness: null, ageHours: 3 };
+    const res = suggestNextWeight(makePe(compoundExo), progressingSets, drained);
+    expect(res).toMatchObject({ weight: 72, reason: 'readiness-deload', workingWeight: 80 });
+  });
+
+  // ----- Invariant: readiness NEVER raises the suggestion -----
+
+  it('never raises the suggestion: every recovery state stays at or below baseline', () => {
+    const baseline = suggestNextWeight(makePe(compoundExo), progressingSets).weight as number;
+    const signals: ReadinessSignal[] = [
+      { readiness: 1, soreness: { QUADS: 5 }, ageHours: 1 }, // worst case
+      { readiness: 2, soreness: { QUADS: 4 }, ageHours: 1 },
+      { readiness: 1, soreness: null, ageHours: 1 },
+      { readiness: 5, soreness: { QUADS: 5 }, ageHours: 1 },
+      { readiness: 5, soreness: { QUADS: 1 }, ageHours: 1 }, // good -> baseline
+    ];
+    for (const sig of signals) {
+      const res = suggestNextWeight(makePe(compoundExo), progressingSets, sig);
+      expect(res.weight as number).toBeLessThanOrEqual(baseline);
+    }
+  });
+
+  it('never raises even when the baseline was already a hold (same-as-last)', () => {
+    const baseline = suggestNextWeight(makePe(compoundExo), holdingSets).weight as number;
+    const deloadSignal: ReadinessSignal = { readiness: 1, soreness: { QUADS: 5 }, ageHours: 1 };
+    const res = suggestNextWeight(makePe(compoundExo), holdingSets, deloadSignal);
+    expect(res.weight as number).toBeLessThanOrEqual(baseline);
+    expect(res.reason).toBe('readiness-deload');
   });
 });

--- a/lib/progression.ts
+++ b/lib/progression.ts
@@ -1,4 +1,4 @@
-import type { Exercise, ProgramExercise, Set } from '@prisma/client';
+import type { Exercise, MuscleGroup, ProgramExercise, Set } from '@prisma/client';
 
 // ============================================================
 // Load suggestion - double progression
@@ -6,8 +6,20 @@ import type { Exercise, ProgramExercise, Set } from '@prisma/client';
 // Rule: if every working set of the last session reached the top of the
 // target rep range, we increase the load (+2.5 kg compound, +1 kg isolation).
 // Otherwise we keep the load and beat the reps.
+//
+// Auto-regulation (issue #53): a recent readiness/soreness check-in can make
+// the suggestion more conservative - it may HOLD the load (skip the increment)
+// or apply a single step-down when recovery is very poor. It can NEVER raise the
+// load beyond the normal progression rule (safety; avoids gaming the check-in).
+// With no readiness data in the recency window the output is identical to the
+// rule above.
 
-export type SuggestionReason = 'no-history' | 'same-as-last' | 'progression';
+export type SuggestionReason =
+  | 'no-history'
+  | 'same-as-last'
+  | 'progression'
+  | 'readiness-hold'
+  | 'readiness-deload';
 
 export interface SuggestionResult {
   weight: number | null;
@@ -20,9 +32,45 @@ export interface SuggestionResult {
   targetRepsMax?: number;
 }
 
+// ------------------------------------------------------------
+// Readiness thresholds (named constants with rationale)
+// ------------------------------------------------------------
+// Recency window: a check-in only auto-regulates today's suggestion if it is
+// fresh. 36h covers "logged last night or this morning" without letting a stale
+// reading from days ago silently hold the load.
+export const READINESS_RECENCY_HOURS = 36;
+// Overall readiness is rated 1 (drained) to 5 (primed). At or below this we hold
+// the load instead of adding weight.
+export const READINESS_HOLD_AT_OR_BELOW = 2;
+// The lowest readiness rating - "drained". Treated as very poor recovery and
+// triggers a conservative step-down rather than just a hold.
+export const READINESS_DELOAD_AT_OR_BELOW = 1;
+// Per-muscle soreness is rated 1 (none) to 5 (severe). At or above this for the
+// exercise's primary muscle group we hold the load.
+export const SORENESS_HOLD_AT_OR_ABOVE = 4;
+// Severe soreness ("can barely move it") - triggers a step-down.
+export const SORENESS_DELOAD_AT_OR_ABOVE = 5;
+// Conservative single step-down, expressed as a fraction of the working load.
+// 10% is a light, evidence-informed deload that protects a fatigued muscle
+// without throwing away the training block.
+export const READINESS_DELOAD_FRACTION = 0.1;
+
+// A recent readiness check-in, shaped for pure progression logic. The caller
+// resolves recency by passing `ageHours` (how old the check-in is), keeping this
+// module free of clock access and fully deterministic.
+export interface ReadinessSignal {
+  // Overall readiness to train, 1 (drained) to 5 (primed).
+  readiness: number;
+  // Optional per-muscle-group soreness, group -> 1 (none) to 5 (severe).
+  soreness?: Partial<Record<MuscleGroup, number>> | null;
+  // How old the check-in is, in hours. Used against READINESS_RECENCY_HOURS.
+  ageHours: number;
+}
+
 export function suggestNextWeight(
   programExercise: ProgramExercise & { exercise: Exercise },
   lastSets: Pick<Set, 'weight' | 'reps' | 'rir'>[],
+  readiness?: ReadinessSignal | null,
 ): SuggestionResult {
   if (lastSets.length === 0) {
     return { weight: null, reason: 'no-history' };
@@ -36,23 +84,75 @@ export function suggestNextWeight(
   const workingSets = lastSets.filter((s) => s.weight === workingWeight);
   const allHitTopRange = workingSets.every((s) => s.reps >= targetRepsMax);
 
-  if (allHitTopRange) {
-    const delta = weightIncrement(programExercise.exercise.category);
+  // Baseline (readiness-unaware) suggestion - identical to the original rule.
+  const delta = weightIncrement(programExercise.exercise.category);
+  const baseline: SuggestionResult = allHitTopRange
+    ? {
+        weight: +(workingWeight + delta).toFixed(2),
+        reason: 'progression',
+        workingWeight,
+        delta,
+        targetRepsMax,
+      }
+    : {
+        weight: workingWeight,
+        reason: 'same-as-last',
+        workingWeight,
+        targetRepsMax,
+      };
+
+  const recovery = assessRecovery(readiness, programExercise.exercise.muscleGroup);
+  if (recovery === 'ok') {
+    return baseline;
+  }
+
+  // Readiness may only hold or reduce. A step-down goes below the working load;
+  // a hold keeps the working load (never above it).
+  if (recovery === 'deload') {
+    const reduced = +(workingWeight * (1 - READINESS_DELOAD_FRACTION)).toFixed(2);
     return {
-      weight: +(workingWeight + delta).toFixed(2),
-      reason: 'progression',
+      weight: reduced,
+      reason: 'readiness-deload',
       workingWeight,
-      delta,
       targetRepsMax,
     };
   }
 
+  // hold: keep the working load, drop any progression increment.
   return {
     weight: workingWeight,
-    reason: 'same-as-last',
+    reason: 'readiness-hold',
     workingWeight,
     targetRepsMax,
   };
+}
+
+type Recovery = 'ok' | 'hold' | 'deload';
+
+// Decides whether a recent check-in should make the suggestion more
+// conservative. Returns 'ok' (no change) when there is no usable, in-window
+// signal, so the no-data path is byte-for-byte identical to the base rule.
+function assessRecovery(
+  readiness: ReadinessSignal | null | undefined,
+  muscleGroup: MuscleGroup,
+): Recovery {
+  if (!readiness) return 'ok';
+  // Out-of-window check-ins are ignored (stale signal must not hold the load).
+  if (!(readiness.ageHours <= READINESS_RECENCY_HOURS)) return 'ok';
+
+  const groupSoreness = readiness.soreness?.[muscleGroup];
+
+  const veryPoor =
+    readiness.readiness <= READINESS_DELOAD_AT_OR_BELOW ||
+    (typeof groupSoreness === 'number' && groupSoreness >= SORENESS_DELOAD_AT_OR_ABOVE);
+  if (veryPoor) return 'deload';
+
+  const poor =
+    readiness.readiness <= READINESS_HOLD_AT_OR_BELOW ||
+    (typeof groupSoreness === 'number' && groupSoreness >= SORENESS_HOLD_AT_OR_ABOVE);
+  if (poor) return 'hold';
+
+  return 'ok';
 }
 
 // Standard increment for the +/- buttons depending on the exercise category.


### PR DESCRIPTION
Adds an optional, additive readiness signal to the deterministic `suggestNextWeight` in `lib/progression.ts`.

## What changed
- New optional third parameter `readiness?: ReadinessSignal | null` (`{ readiness, soreness, ageHours }`). Pure and deterministic - the caller resolves recency by passing `ageHours`, so this module never touches the clock.
- When a recent (`<= 36h`) check-in indicates poor recovery for the exercise's primary muscle group:
  - high soreness (`>= 4`) on that group, OR low overall readiness (`<= 2`) -> HOLD the load (skip the increment), reason `readiness-hold`.
  - very poor recovery (soreness `== 5` OR readiness `== 1`) -> single conservative 10% step-down, reason `readiness-deload`.
- Readiness can ONLY hold or reduce, NEVER raise the load.
- With no in-window readiness data the output is identical to the previous double-progression rule.
- Muscle group resolved from the exercise's catalog `muscleGroup`. All thresholds are named, commented constants.
- No Prisma migration, no API/route change, no LLM output-contract change. Existing callers compile and behave identically (param is optional).

## How I tested
- `bash scripts/verify.sh` -> GREEN (prisma generate + lint + typecheck + unit + build).
- `npx vitest run lib/progression.test.ts` -> 20 passed. New tests cover: no-data unchanged path (undefined/null/absent), stale check-in ignored, good check-in ignored, hold on high soreness, hold on low readiness, soreness only checked for the primary group, step-down on severe soreness, step-down on drained readiness, and the never-raises invariant (including when the baseline was already a hold).

Closes #53