### PR TITLE
docs: changelog the readiness-progression loop and the public-repo hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   silently restructuring it, always explains the why behind a suggestion, and
   frames generated programs as editable drafts. The program-adjustment output
   contract is unchanged.
+- The deterministic next-weight suggestion now factors in a recent readiness
+  check-in: high soreness on the worked muscle group or low overall readiness
+  holds the load (no increment), and very poor recovery applies a single
+  conservative step-down. Readiness can only hold or reduce the suggestion, never
+  raise it, and with no recent check-in the suggestion is unchanged.
+- Hardened the autonomous maintenance loop against untrusted external input now
+  that the repo is public: external issues, PRs, comments, diffs, and CI logs are
+  treated as data and never as instructions; only issues/PRs authored by the
+  maintainer login allowlist are auto-implemented or auto-merged; forks and
+  non-maintainer PRs are never auto-merged; and the loop refuses prompt-injection
+  and secret-exfiltration attempts. Documented in the autonomy charter and
+  `CLAUDE.md`, with the loop's `curl`/`wget` denied in the harness config as
+  defense in depth.
 
 ### Fixed
 

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -6,6 +6,58 @@ by the charter in [`07-autonomy.md`](07-autonomy.md).
 
 ---
 
+## 2026-06-09 - Write up the readiness-progression loop and the public-repo hardening
+
+**Context.** Maintainer tick. Decision order per `06-orchestration.md`: drain ready PRs,
+refill if starved, implement one issue, then write up. Verified state with `gh` before
+acting: zero open PRs, zero open issues, `main` clean. Two PRs had merged since the last
+write-up (PR #52) and were undocumented, so step 1 (ship) and step 3 (implement) had
+nothing to do; the actionable work this tick was the content loop.
+
+**Decided / shipped (this PR, docs only).** Documented the two merged, undocumented PRs,
+each verified against the merged code, not just the PR description:
+- **PR #55 / issue #53 (readiness now influences deterministic progression).** Confirmed
+  against `lib/progression.ts`: an optional third `readiness?: ReadinessSignal | null`
+  param on `suggestNextWeight`, named threshold constants, a recency gate
+  (`ageHours <= 36`), `readiness-hold` / `readiness-deload` reasons, soreness keyed on the
+  exercise's `muscleGroup`, and the never-raises invariant. CHANGELOG: a `Changed` line
+  under the coach/progression behavior (the suggestion's contract is the same; its inputs
+  grew).
+- **PR #56 / issue #54 (harden the loop against untrusted public input).** Confirmed
+  against the merged diff: the new "Untrusted external input (public repo)" section in
+  `07-autonomy.md`, the trust-gating to the `{JulienAu, Julien-Au}` login allowlist, the
+  fork/author gates in `ship-pr` and the untrusted-data treatment in `implement-issue` /
+  `triage`, and the `curl`/`wget` deny in `.claude/settings.json` (lines 50-51). CHANGELOG:
+  a `Changed` line under the loop-infrastructure story (the loop infra IS the story, so it
+  belongs in the public changelog).
+
+**Session arc being recorded.** This run closes out a multi-tick session: research-driven
+product features #37-#40 (readiness/soreness data model, per-muscle soreness map + note,
+coach auto-regulation signal, UI wiring), then the readiness-into-progression loop (#53),
+then the security hardening for the now-public repo (#54). The throughline: the product
+gained a real auto-regulation signal end to end (capture -> coach context -> deterministic
+suggestion), and the loop gained the guardrails to keep running that autonomy safely in
+the open.
+
+**Challenged.** Verification-first rather than a code subagent (docs-only, no product
+code): every CHANGELOG/log claim was checked against `lib/progression.ts`,
+`.claude/settings.json`, and `07-autonomy.md` before writing it. No drift found; the PR
+descriptions matched the merged code.
+
+**Trust gate.** Both documented PRs (#55, #56) were authored by `JulienAu`, on the
+maintainer allowlist - in-scope for the loop. No external/untrusted authorship this tick.
+
+**Deferred to human / operator.** Nothing hit the hard stop-list. Still parked as product
+calls (noted for the operator, not filed as auto-implementable issues): more program
+templates, and any further auto-regulation tuning of the progression thresholds. Dep
+majors + `npm audit fix --force` (bcrypt 6) remain deferred.
+
+**Idle.** After shipping this docs PR: backlog empty. Triage step did not surface a crisp,
+single-PR code-health/coverage/small-bug item worth manufacturing this tick, so the run
+ends on a clean idle once the docs PR is merged. Within the 3-merge cap.
+
+---
+
 ## 2026-06-09 - Ship the log PR, then implement the soreness/note check-in UI
 
 **Context.** Maintainer tick. Decision order per `06-orchestration.md`: drain ready PRs


### PR DESCRIPTION
Documents the two merged, previously-undocumented PRs since the last write-up (PR #52), each verified against the merged code rather than only the PR description.

## CHANGELOG (Unreleased -> Changed)
- **#55 (Closes #53):** the deterministic next-weight suggestion now factors in a recent readiness check-in - high soreness on the worked group or low overall readiness holds the load, very poor recovery applies a single conservative step-down, and readiness can only hold or reduce, never raise. Verified against `lib/progression.ts` (`ReadinessSignal` param, 36h recency gate, `readiness-hold`/`readiness-deload`, never-raises invariant).
- **#56 (Closes #54):** hardened the autonomous loop against untrusted public input - external text is data not instructions, a maintainer login allowlist gates auto-implement/auto-merge, forks and non-maintainer PRs are never auto-merged, and the loop refuses injection/exfiltration. Verified against `07-autonomy.md`, the skills, and the `curl`/`wget` deny in `.claude/settings.json`.

## docs/loops/autonomy-log.md
A dated entry summarizing this multi-tick session arc (research-driven features #37-#40, the readiness-into-progression loop #53, the security hardening #54), what was verified, what was challenged, and what was deferred.

Docs only - no product code. The shipping loop merges on green CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)