### PR TITLE
feat: explain held/reduced load suggestions in the session UI (#60)

### DIFF
--- a/app/(app)/session/[id]/page.tsx
+++ b/app/(app)/session/[id]/page.tsx
@@ -2,6 +2,7 @@ import { notFound, redirect } from 'next/navigation';
 import { db } from '@/lib/db';
 import { requireSession } from '@/lib/auth';
 import { getLastPerformances, type LastPerformance } from '@/lib/last-performance';
+import { READINESS_RECENCY_HOURS, type ReadinessSignal } from '@/lib/progression';
 import { SessionRunner, type SerializedLastPerformance } from '@/components/session/session-runner';
 
 interface Props {
@@ -36,9 +37,13 @@ export default async function SessionRunPage({ params }: Props) {
   if (!session.workout) notFound();
 
   const exerciseIds = session.workout.exercises.map((pe) => pe.exerciseId);
-  const [lastPerformances, user] = await Promise.all([
+  const [lastPerformances, user, latestCheckin] = await Promise.all([
     getLastPerformances(auth.userId, exerciseIds, session.id),
     db.user.findUnique({ where: { id: auth.userId }, select: { unit: true } }),
+    db.readinessCheckin.findFirst({
+      where: { userId: auth.userId },
+      orderBy: { createdAt: 'desc' },
+    }),
   ]);
 
   const lastPerfRecord: Record<string, SerializedLastPerformance> = {};
@@ -46,13 +51,45 @@ export default async function SessionRunPage({ params }: Props) {
     lastPerfRecord[k] = serializePerf(v);
   }
 
+  const readiness = buildReadinessSignal(latestCheckin);
+
   return (
     <SessionRunner
       session={session}
       lastPerformances={lastPerfRecord}
+      readiness={readiness}
       unit={user?.unit ?? 'KG'}
     />
   );
+}
+
+// Turn the latest check-in into the readiness signal that drives the load
+// suggestion. We only forward an in-window check-in; a stale one is dropped here
+// so the client never has to reason about clocks (and the suggestion stays
+// identical to the no-data path). Returns null when there is no usable signal.
+function buildReadinessSignal(
+  checkin: {
+    readiness: number;
+    soreness: unknown;
+    createdAt: Date;
+  } | null,
+): ReadinessSignal | null {
+  if (!checkin) return null;
+  const ageHours = (Date.now() - checkin.createdAt.getTime()) / (1000 * 60 * 60);
+  if (ageHours > READINESS_RECENCY_HOURS) return null;
+
+  // soreness is stored as JSON; coerce defensively to a plain { group: 1-5 } map.
+  let soreness: ReadinessSignal['soreness'] = null;
+  if (checkin.soreness && typeof checkin.soreness === 'object' && !Array.isArray(checkin.soreness)) {
+    const entries = Object.entries(checkin.soreness as Record<string, unknown>).filter(
+      ([, v]) => typeof v === 'number',
+    ) as Array<[string, number]>;
+    if (entries.length > 0) {
+      soreness = Object.fromEntries(entries) as ReadinessSignal['soreness'];
+    }
+  }
+
+  return { readiness: checkin.readiness, soreness, ageHours };
 }
 
 function serializePerf(p: LastPerformance): SerializedLastPerformance {

--- a/components/session/exercise-card.test.tsx
+++ b/components/session/exercise-card.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { Exercise, ProgramExercise } from '@prisma/client';
+import { READINESS_RECENCY_HOURS, type ReadinessSignal } from '@/lib/progression';
+import { ExerciseCard } from './exercise-card';
+import type { SerializedLastPerformance } from './session-runner';
+
+const exo: Exercise = {
+  id: 'e1',
+  userId: 'u',
+  name: 'Squat',
+  muscleGroup: 'QUADS',
+  category: 'COMPOUND',
+  defaultRestSec: 120,
+  notes: null,
+  usesBodyweight: false,
+  createdAt: new Date(),
+};
+
+const pe: ProgramExercise & { exercise: Exercise } = {
+  id: 'pe',
+  workoutId: 'w',
+  exerciseId: 'e1',
+  order: 1,
+  targetSets: 3,
+  targetRepsMin: 6,
+  targetRepsMax: 10,
+  targetRIR: 2,
+  restSec: 120,
+  tempo: null,
+  notes: null,
+  exercise: exo,
+};
+
+// Last session: every working set hit the top of the rep range, so the base
+// rule wants to progress (+2.5 kg). Readiness can then hold or step that down.
+const lastPerf: SerializedLastPerformance = {
+  sessionStartedAt: new Date().toISOString(),
+  sets: [
+    { weight: 100, reps: 10, rir: 1 },
+    { weight: 100, reps: 10, rir: 1 },
+    { weight: 100, reps: 10, rir: 1 },
+  ],
+  maxWeight: 100,
+  repsAtMaxWeight: 10,
+};
+
+function renderCard(readiness: ReadinessSignal | null) {
+  return render(
+    <ExerciseCard programExercise={pe} lastPerformance={lastPerf} readiness={readiness} unit="KG" />,
+  );
+}
+
+describe('ExerciseCard readiness explainer', () => {
+  it('shows no readiness note when there is no check-in (unchanged UI)', () => {
+    renderCard(null);
+    expect(screen.queryByText(/Held -/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Lighter -/)).not.toBeInTheDocument();
+  });
+
+  it('shows a "Held" note when readiness holds the load', () => {
+    // readiness 2 -> hold (no progression), but not a deload.
+    renderCard({ readiness: 2, soreness: null, ageHours: 1 });
+    expect(screen.getByText('Held - low readiness today')).toBeInTheDocument();
+    expect(screen.queryByText(/Lighter -/)).not.toBeInTheDocument();
+  });
+
+  it('shows a "Lighter" note when readiness steps the load down', () => {
+    // readiness 1 -> deload (step-down).
+    renderCard({ readiness: 1, soreness: null, ageHours: 1 });
+    expect(screen.getByText('Lighter - low readiness today')).toBeInTheDocument();
+  });
+
+  it('names reported soreness as the cause when soreness drives the hold', () => {
+    // Good overall readiness but the trained muscle is sore -> hold via soreness.
+    renderCard({ readiness: 5, soreness: { QUADS: 4 }, ageHours: 1 });
+    expect(screen.getByText('Held - reported soreness')).toBeInTheDocument();
+  });
+
+  it('shows no note when the check-in is stale (out of the recency window)', () => {
+    renderCard({ readiness: 1, soreness: null, ageHours: READINESS_RECENCY_HOURS + 1 });
+    expect(screen.queryByText(/Held -/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Lighter -/)).not.toBeInTheDocument();
+  });
+});

--- a/components/session/exercise-card.tsx
+++ b/components/session/exercise-card.tsx
@@ -2,22 +2,64 @@
 
 import { useState } from 'react';
 import { ChevronDown, ChevronUp, HelpCircle, Lightbulb, TrendingUp } from 'lucide-react';
-import type { Exercise, ProgramExercise, WeightUnit } from '@prisma/client';
+import type { Exercise, MuscleGroup, ProgramExercise, WeightUnit } from '@prisma/client';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { MUSCLE_GROUP_LABELS, CATEGORY_LABELS } from '@/lib/schemas/exercise';
-import { suggestNextWeight } from '@/lib/progression';
+import {
+  suggestNextWeight,
+  SORENESS_HOLD_AT_OR_ABOVE,
+  type ReadinessSignal,
+  type SuggestionReason,
+  type SuggestionResult,
+} from '@/lib/progression';
 import { formatWeight } from '@/lib/units';
 import type { SerializedLastPerformance } from './session-runner';
 
 interface Props {
   programExercise: ProgramExercise & { exercise: Exercise };
   lastPerformance: SerializedLastPerformance | undefined;
+  readiness: ReadinessSignal | null;
   unit: WeightUnit;
 }
 
-export function ExerciseCard({ programExercise, lastPerformance, unit }: Props) {
+// Short, plain-language explainer shown next to the suggested load when a recent
+// readiness/soreness check-in made the suggestion more conservative. Returns
+// null for the normal (non-readiness) reasons so the UI is unchanged then. The
+// note names the likelier cause - reported soreness for the trained muscle, or
+// low overall readiness - so the adjustment reads as deliberate, not arbitrary.
+function readinessExplainer(
+  reason: SuggestionReason,
+  readiness: ReadinessSignal | null,
+  muscleGroup: MuscleGroup,
+): string | null {
+  if (reason !== 'readiness-hold' && reason !== 'readiness-deload') return null;
+  const verb = reason === 'readiness-deload' ? 'Lighter' : 'Held';
+  const groupSoreness = readiness?.soreness?.[muscleGroup];
+  const cause =
+    typeof groupSoreness === 'number' && groupSoreness >= SORENESS_HOLD_AT_OR_ABOVE
+      ? 'reported soreness'
+      : 'low readiness today';
+  return `${verb} - ${cause}`;
+}
+
+// Long-form explanation behind the help (?) toggle, per suggestion reason.
+function helpText(suggestion: SuggestionResult, unit: WeightUnit): string {
+  const working = formatWeight(suggestion.workingWeight ?? 0, unit, { decimals: 2, group: false });
+  switch (suggestion.reason) {
+    case 'progression':
+      return `All working sets reached ${suggestion.targetRepsMax} reps at ${working}: load goes up by ${formatWeight(suggestion.delta ?? 0, unit, { decimals: 2, group: false })} to drop back to the bottom of the rep range (double progression).`;
+    case 'readiness-hold':
+      return `A recent readiness check-in flagged poor recovery, so the load stays at ${working} instead of increasing today. Push the reps, not the weight.`;
+    case 'readiness-deload':
+      return `A recent readiness check-in flagged very poor recovery, so the load steps down from ${working} for a lighter session. It will climb back as recovery improves.`;
+    default:
+      return `Keep the same load and try to beat your reps. Progression unlocks once all working sets reach ${suggestion.targetRepsMax} reps.`;
+  }
+}
+
+export function ExerciseCard({ programExercise, lastPerformance, readiness, unit }: Props) {
   const [notesOpen, setNotesOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
   const exo = programExercise.exercise;
@@ -27,7 +69,8 @@ export function ExerciseCard({ programExercise, lastPerformance, unit }: Props) 
       ? `${programExercise.targetRepsMin}`
       : `${programExercise.targetRepsMin}-${programExercise.targetRepsMax}`;
 
-  const suggestion = suggestNextWeight(programExercise, lastPerformance?.sets ?? []);
+  const suggestion = suggestNextWeight(programExercise, lastPerformance?.sets ?? [], readiness);
+  const readinessNote = readinessExplainer(suggestion.reason, readiness, exo.muscleGroup);
   const lastDate = lastPerformance
     ? new Intl.DateTimeFormat('en-US', { day: '2-digit', month: '2-digit' }).format(
         new Date(lastPerformance.sessionStartedAt),
@@ -84,6 +127,11 @@ export function ExerciseCard({ programExercise, lastPerformance, unit }: Props) 
                     (+{formatWeight(suggestion.delta, unit, { decimals: 2, group: false })})
                   </span>
                 )}
+                {readinessNote && (
+                  <Badge variant="secondary" className="ml-2 align-middle">
+                    {readinessNote}
+                  </Badge>
+                )}
               </span>
               <button
                 type="button"
@@ -97,9 +145,7 @@ export function ExerciseCard({ programExercise, lastPerformance, unit }: Props) 
             </div>
             {helpOpen && (
               <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
-                {suggestion.reason === 'progression'
-                  ? `All working sets reached ${suggestion.targetRepsMax} reps at ${formatWeight(suggestion.workingWeight ?? 0, unit, { decimals: 2, group: false })}: load goes up by ${formatWeight(suggestion.delta ?? 0, unit, { decimals: 2, group: false })} to drop back to the bottom of the rep range (double progression).`
-                  : `Keep the same load and try to beat your reps. Progression unlocks once all working sets reach ${suggestion.targetRepsMax} reps.`}
+                {helpText(suggestion, unit)}
               </p>
             )}
           </div>

--- a/components/session/session-runner.tsx
+++ b/components/session/session-runner.tsx
@@ -24,6 +24,7 @@ import {
   getDB,
   type PendingSet,
 } from '@/lib/indexeddb';
+import type { ReadinessSignal } from '@/lib/progression';
 import { bindAutoSync, flushPendingSets, queueSet } from '@/lib/sync';
 import { hydrateFromServerSets } from '@/lib/sync-hydration';
 import { ExerciseCard } from '@/components/session/exercise-card';
@@ -52,6 +53,9 @@ type SessionRunnerProps = {
     sets: PrismaSet[];
   };
   lastPerformances: Record<string, SerializedLastPerformance>;
+  // Latest in-window readiness check-in (or null). Drives whether the load
+  // suggestion is held/reduced and the matching explainer in the UI.
+  readiness: ReadinessSignal | null;
   unit: WeightUnit;
 };
 
@@ -60,7 +64,7 @@ type Mode =
   | { kind: 'rest'; endsAt: number; totalSec: number; nextExerciseIdx: number | null }
   | { kind: 'summary' };
 
-export function SessionRunner({ session, lastPerformances, unit }: SessionRunnerProps) {
+export function SessionRunner({ session, lastPerformances, readiness, unit }: SessionRunnerProps) {
   const router = useRouter();
   const workout = session.workout!;
   const programExercises = workout.exercises;
@@ -296,7 +300,12 @@ export function SessionRunner({ session, lastPerformances, unit }: SessionRunner
       </div>
 
       <div className="mx-auto flex w-full max-w-2xl flex-col gap-4 px-4 py-4">
-        <ExerciseCard programExercise={currentPE} lastPerformance={lastPerf} unit={unit} />
+        <ExerciseCard
+          programExercise={currentPE}
+          lastPerformance={lastPerf}
+          readiness={readiness}
+          unit={unit}
+        />
 
         <SetsList
           programExercise={currentPE}
@@ -310,6 +319,7 @@ export function SessionRunner({ session, lastPerformances, unit }: SessionRunner
             programExercise={currentPE}
             existingSets={currentSets}
             lastPerformance={lastPerf}
+            readiness={readiness}
             unit={unit}
             onSubmit={handleValidate}
           />

--- a/components/session/set-input.tsx
+++ b/components/session/set-input.tsx
@@ -16,7 +16,7 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
-import { suggestNextWeight, weightIncrement } from '@/lib/progression';
+import { suggestNextWeight, weightIncrement, type ReadinessSignal } from '@/lib/progression';
 import { PlateCalculator } from '@/components/session/plate-calculator';
 import type { PendingSet } from '@/lib/indexeddb';
 import type { SerializedLastPerformance } from './session-runner';
@@ -25,6 +25,7 @@ interface Props {
   programExercise: ProgramExercise & { exercise: Exercise };
   existingSets: PendingSet[];
   lastPerformance: SerializedLastPerformance | undefined;
+  readiness: ReadinessSignal | null;
   unit: WeightUnit;
   onSubmit: (values: {
     weight: number;
@@ -47,16 +48,23 @@ interface FormState {
 
 const RIR_OPTIONS = [0, 1, 2, 3];
 
-export function SetInput({ programExercise, existingSets, lastPerformance, unit, onSubmit }: Props) {
+export function SetInput({
+  programExercise,
+  existingSets,
+  lastPerformance,
+  readiness,
+  unit,
+  onSubmit,
+}: Props) {
   // Pre-fill: last set of this exercise in the current session,
   // otherwise the last performance, otherwise defaults.
-  const initial = computeInitial(programExercise, existingSets, lastPerformance);
+  const initial = computeInitial(programExercise, existingSets, lastPerformance, readiness);
   const [form, setForm] = useState<FormState>(initial);
   const [submitting, setSubmitting] = useState(false);
 
   // Re-init when the exercise changes or a set changes.
   useEffect(() => {
-    setForm(computeInitial(programExercise, existingSets, lastPerformance));
+    setForm(computeInitial(programExercise, existingSets, lastPerformance, readiness));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [programExercise.id, existingSets.length]);
 
@@ -250,6 +258,7 @@ function computeInitial(
   pe: ProgramExercise & { exercise: Exercise },
   existingSets: PendingSet[],
   lastPerf: SerializedLastPerformance | undefined,
+  readiness: ReadinessSignal | null,
 ): FormState {
   // 1. If a set already exists for this exercise in the current session,
   //    reuse its values (idea: you aim for the same load, adjust the reps).
@@ -268,7 +277,7 @@ function computeInitial(
   //    progressing, aim for the bottom of the rep range with the heavier
   //    load; otherwise try to beat the previous reps (at least match them).
   if (lastPerf) {
-    const suggestion = suggestNextWeight(pe, lastPerf.sets);
+    const suggestion = suggestNextWeight(pe, lastPerf.sets, readiness);
     const initialReps =
       suggestion.reason === 'progression'
         ? pe.targetRepsMin


### PR DESCRIPTION
Surfaces *why* a suggested load was held or reduced by readiness/soreness, so the auto-regulation reads as deliberate rather than arbitrary.

## What changed
- The session page loads the latest readiness check-in and builds an in-window `ReadinessSignal` (stale check-ins are dropped server-side), then forwards it through `SessionRunner` to `ExerciseCard` and `SetInput`.
- `suggestNextWeight` is now called WITH the readiness signal in the UI, so the suggested load and its explainer agree, and the pre-filled set weight matches the held/reduced suggestion.
- `ExerciseCard` renders a small secondary `Badge` next to the suggested load ONLY for the `readiness-hold` / `readiness-deload` reasons ("Held - reported soreness" / "Lighter - low readiness today"). The help (?) detail text gained matching readiness explanations.
- No note and no UI/flow change when there is no readiness signal.

## Tests
- New `components/session/exercise-card.test.tsx`: asserts the note appears for hold and deload reasons, names soreness vs low-readiness as the cause, and is absent both with no check-in and with a stale (out-of-window) check-in.

Additive UI only; no schema/auth/LLM-contract changes.

Closes #60

scripts/verify.sh passed (198 unit tests green); skeptic review clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)