### PR TITLE
feat: preference to enable/disable readiness-based weight auto-regulation (default on)

### DIFF
--- a/components/session/session-runner.tsx
+++ b/components/session/session-runner.tsx
@@ -24,7 +24,8 @@ import {
   getDB,
   type PendingSet,
 } from '@/lib/indexeddb';
-import type { ReadinessSignal } from '@/lib/progression';
+import { readinessForSuggestion, type ReadinessSignal } from '@/lib/progression';
+import { isReadinessAutoRegulationEnabled } from '@/lib/preferences';
 import { bindAutoSync, flushPendingSets, queueSet } from '@/lib/sync';
 import { hydrateFromServerSets } from '@/lib/sync-hydration';
 import { ExerciseCard } from '@/components/session/exercise-card';
@@ -73,11 +74,20 @@ export function SessionRunner({ session, lastPerformances, readiness, unit }: Se
   const [currentIdx, setCurrentIdx] = useState(0);
   const [mode, setMode] = useState<Mode>({ kind: 'input' });
   const [closing, setClosing] = useState(false);
+  // Readiness auto-regulation can be turned off in settings (issue #61). The
+  // preference lives in localStorage, so it is read after mount; until then we
+  // assume the default (on) so the first render matches the server output.
+  const [autoRegulate, setAutoRegulate] = useState(true);
 
   const currentPE = programExercises[currentIdx];
 
+  // When auto-regulation is off, the readiness signal is dropped entirely, so
+  // the suggestion falls back to pure programmed progression (pre-#55 behavior).
+  const effectiveReadiness = readinessForSuggestion(readiness, autoRegulate);
+
   // Hydrate IndexedDB with the server sets, then enable auto-sync.
   useEffect(() => {
+    setAutoRegulate(isReadinessAutoRegulationEnabled());
     void (async () => {
       await hydrateFromServerSets(session.id, session.sets);
       setHydrated(true);
@@ -303,7 +313,7 @@ export function SessionRunner({ session, lastPerformances, readiness, unit }: Se
         <ExerciseCard
           programExercise={currentPE}
           lastPerformance={lastPerf}
-          readiness={readiness}
+          readiness={effectiveReadiness}
           unit={unit}
         />
 
@@ -319,7 +329,7 @@ export function SessionRunner({ session, lastPerformances, readiness, unit }: Se
             programExercise={currentPE}
             existingSets={currentSets}
             lastPerformance={lastPerf}
-            readiness={readiness}
+            readiness={effectiveReadiness}
             unit={unit}
             onSubmit={handleValidate}
           />

--- a/components/settings/settings-client.tsx
+++ b/components/settings/settings-client.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useTheme } from 'next-themes';
-import { Moon, Smartphone, Sun, Volume2, Monitor } from 'lucide-react';
+import { Activity, Moon, Smartphone, Sun, Volume2, Monitor } from 'lucide-react';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
@@ -89,6 +89,14 @@ export function SettingsClient() {
             description="Plays a short 880 Hz beep at the end of the rest."
             checked={prefs.restTimerSound}
             onChange={(v) => update('restTimerSound', v)}
+            disabled={!hydrated}
+          />
+          <PrefRow
+            icon={<Activity className="size-4" />}
+            label="Let readiness/soreness adjust my suggested weights"
+            description="When on, a recent readiness check-in can hold or lower the suggested load. When off, suggestions follow pure programmed progression."
+            checked={prefs.readinessAutoRegulation}
+            onChange={(v) => update('readinessAutoRegulation', v)}
             disabled={!hydrated}
           />
         </CardContent>

--- a/lib/preferences.test.ts
+++ b/lib/preferences.test.ts
@@ -5,6 +5,7 @@ import {
   savePreferences,
   isVibrationEnabled,
   isRestTimerSoundEnabled,
+  isReadinessAutoRegulationEnabled,
   plateConfigForUnit,
 } from './preferences';
 
@@ -17,6 +18,26 @@ describe('preferences', () => {
 
   it('returns the defaults when nothing is stored', () => {
     expect(loadPreferences()).toEqual(DEFAULT_PREFERENCES);
+  });
+
+  it('defaults readiness auto-regulation to on (issue #61)', () => {
+    expect(DEFAULT_PREFERENCES.readinessAutoRegulation).toBe(true);
+    expect(loadPreferences().readinessAutoRegulation).toBe(true);
+    expect(isReadinessAutoRegulationEnabled()).toBe(true);
+  });
+
+  it('keeps readiness auto-regulation on for prefs stored before the field existed', () => {
+    // A pref blob from before #61 has no readinessAutoRegulation key; the merge
+    // over the defaults must keep it enabled (backward compatible, opt-out).
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ vibration: false }));
+    expect(loadPreferences().readinessAutoRegulation).toBe(true);
+    expect(isReadinessAutoRegulationEnabled()).toBe(true);
+  });
+
+  it('reflects readiness auto-regulation turned off', () => {
+    savePreferences({ ...DEFAULT_PREFERENCES, readinessAutoRegulation: false });
+    expect(loadPreferences().readinessAutoRegulation).toBe(false);
+    expect(isReadinessAutoRegulationEnabled()).toBe(false);
   });
 
   it('merges a partial stored object over the defaults', () => {

--- a/lib/preferences.ts
+++ b/lib/preferences.ts
@@ -8,6 +8,11 @@ const STORAGE_KEY = 'gymcoach.prefs.v1';
 export interface UserPreferences {
   vibration: boolean;
   restTimerSound: boolean;
+  // Auto-regulation (issue #61). When on (default), a recent readiness/soreness
+  // check-in can make the deterministic next-weight suggestion more conservative
+  // (hold the load or step it down). When off, readiness is ignored entirely and
+  // the suggestion follows pure programmed progression (pre-#55 behavior).
+  readinessAutoRegulation: boolean;
   // Plate-loading calculator (issue #39). Bar weight and available plate
   // denominations are stored per unit, since a kg gym and a lb gym stock
   // different plates. Values are in the matching display unit.
@@ -20,6 +25,7 @@ export interface UserPreferences {
 export const DEFAULT_PREFERENCES: UserPreferences = {
   vibration: true,
   restTimerSound: false,
+  readinessAutoRegulation: true,
   barWeightKg: 20,
   barWeightLb: 45,
   platesKg: [25, 20, 15, 10, 5, 2.5, 1.25],
@@ -54,6 +60,12 @@ export function isVibrationEnabled(): boolean {
 
 export function isRestTimerSoundEnabled(): boolean {
   return loadPreferences().restTimerSound;
+}
+
+// Whether a recent readiness/soreness check-in is allowed to adjust the
+// deterministic next-weight suggestion (issue #61). Defaults to true.
+export function isReadinessAutoRegulationEnabled(): boolean {
+  return loadPreferences().readinessAutoRegulation;
 }
 
 // The plate-loading config (bar weight + available plates) for the active unit.

--- a/lib/progression.test.ts
+++ b/lib/progression.test.ts
@@ -3,6 +3,7 @@ import type { Exercise, ProgramExercise } from '@prisma/client';
 import {
   READINESS_DELOAD_FRACTION,
   READINESS_RECENCY_HOURS,
+  readinessForSuggestion,
   suggestNextWeight,
   weightIncrement,
   type ReadinessSignal,
@@ -271,5 +272,50 @@ describe('suggestNextWeight - readiness auto-regulation (issue #53)', () => {
     const res = suggestNextWeight(makePe(compoundExo), holdingSets, deloadSignal);
     expect(res.weight as number).toBeLessThanOrEqual(baseline);
     expect(res.reason).toBe('readiness-deload');
+  });
+});
+
+describe('readinessForSuggestion - auto-regulation preference gate (issue #61)', () => {
+  const progressingSets = [
+    { weight: 80, reps: 10, rir: 2 },
+    { weight: 80, reps: 10, rir: 2 },
+    { weight: 80, reps: 10, rir: 2 },
+  ];
+  // A worst-case in-window check-in: with #55 on, this forces a step-down.
+  const drained: ReadinessSignal = { readiness: 1, soreness: { QUADS: 5 }, ageHours: 1 };
+
+  it('passes the signal through unchanged when the preference is on', () => {
+    expect(readinessForSuggestion(drained, true)).toBe(drained);
+    expect(readinessForSuggestion(null, true)).toBeNull();
+  });
+
+  it('drops the signal entirely when the preference is off', () => {
+    expect(readinessForSuggestion(drained, false)).toBeNull();
+    expect(readinessForSuggestion(null, false)).toBeNull();
+  });
+
+  it('OFF: readiness has no effect, identical to the pre-#55 (no-signal) suggestion', () => {
+    // Pre-#55 behavior is exactly "no readiness arg": pure programmed progression.
+    const pre55 = suggestNextWeight(makePe(compoundExo), progressingSets);
+    const gatedOff = suggestNextWeight(
+      makePe(compoundExo),
+      progressingSets,
+      readinessForSuggestion(drained, false),
+    );
+    expect(gatedOff).toEqual(pre55);
+    expect(gatedOff.reason).toBe('progression');
+    expect(gatedOff.weight).toBe(82.5);
+  });
+
+  it('ON: readiness applies the #55 step-down for the same drained check-in', () => {
+    const gatedOn = suggestNextWeight(
+      makePe(compoundExo),
+      progressingSets,
+      readinessForSuggestion(drained, true),
+    );
+    const direct = suggestNextWeight(makePe(compoundExo), progressingSets, drained);
+    expect(gatedOn).toEqual(direct);
+    expect(gatedOn.reason).toBe('readiness-deload');
+    expect(gatedOn.weight).toBe(+(80 * (1 - READINESS_DELOAD_FRACTION)).toFixed(2));
   });
 });

--- a/lib/progression.ts
+++ b/lib/progression.ts
@@ -67,6 +67,18 @@ export interface ReadinessSignal {
   ageHours: number;
 }
 
+// Applies the user's auto-regulation preference (issue #61) to a readiness
+// signal before it reaches suggestNextWeight. When the preference is off, the
+// signal is dropped (returns null), so the suggestion follows pure programmed
+// progression - identical to the pre-#55 behavior. When on, the signal passes
+// through unchanged. Kept pure so the gate is unit-testable on its own.
+export function readinessForSuggestion(
+  readiness: ReadinessSignal | null,
+  autoRegulationEnabled: boolean,
+): ReadinessSignal | null {
+  return autoRegulationEnabled ? readiness : null;
+}
+
 export function suggestNextWeight(
   programExercise: ProgramExercise & { exercise: Exercise },
   lastSets: Pick<Set, 'weight' | 'reps' | 'rir'>[],


### PR DESCRIPTION
Adds a user preference "Let readiness/soreness adjust my suggested weights" (default ON, preserving current behavior). When OFF, the readiness signal is dropped before it reaches `suggestNextWeight`, so the load suggestion follows pure programmed progression - identical to the pre-#55 behavior.

## What changed
- New boolean preference `readinessAutoRegulation` in `lib/preferences.ts`, default ON, persisted via the existing localStorage mechanism (additive, no Prisma migration) + `isReadinessAutoRegulationEnabled()` helper.
- Pure gate `readinessForSuggestion(readiness, enabled)` in `lib/progression.ts`, applied in `SessionRunner` so both `ExerciseCard` and `SetInput` receive the gated signal.
- Settings toggle reusing the existing `PrefRow` / `Switch` primitives.
- Tests: preferences default / backward-compat (missing key -> ON) / OFF; gate OFF -> identical to the pre-#55 no-signal suggestion, ON -> the #55 step-down.

Closes #61

scripts/verify.sh passed; skeptic review clean.