### PR TITLE
docs: changelog the template catalog, readiness explainability, and opt-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   plate inventory per unit, and an honest note when a weight cannot be loaded
   exactly.
 - Built-in program templates (5/3/1 Boring But Big, GZCLP, nSuns, Push/Pull/Legs,
-  Upper/Lower): start a program from a template through the same generation path
-  the AI uses, then edit it like any program.
+  Upper/Lower, plus Starting Strength, StrongLifts 5x5, Madcow 5x5, PHUL, PHAT,
+  and a beginner Full Body 3x): start a program from a template through the same
+  generation path the AI uses, then edit it like any program.
+- Readiness explainability in the session UI: when a recent readiness/soreness
+  check-in holds or steps down a suggested load, a short badge next to the
+  suggestion says why ("Held - reported soreness" / "Lighter - low readiness
+  today"). Nothing is shown when there is no readiness signal.
 - Optional pre-session readiness check-in (overall readiness and sleep quality on
   1-5 scales, plus optional per-muscle-group soreness and a short note): skippable,
   never blocks starting a session, and feeds the AI coach as one more
@@ -62,7 +67,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   check-in: high soreness on the worked muscle group or low overall readiness
   holds the load (no increment), and very poor recovery applies a single
   conservative step-down. Readiness can only hold or reduce the suggestion, never
-  raise it, and with no recent check-in the suggestion is unchanged.
+  raise it, and with no recent check-in the suggestion is unchanged. A user
+  preference "Let readiness/soreness adjust my suggested weights" (default on)
+  governs this: turning it off drops the readiness signal before it reaches the
+  suggestion, reproducing the pure programmed-progression behavior from before
+  the readiness integration.
 - Hardened the autonomous maintenance loop against untrusted external input now
   that the repo is public: external issues, PRs, comments, diffs, and CI logs are
   treated as data and never as instructions; only issues/PRs authored by the

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -6,6 +6,52 @@ by the charter in [`07-autonomy.md`](07-autonomy.md).
 
 ---
 
+## 2026-06-09 - Chain everything: templates, readiness explainability + opt-out
+
+**Context.** Operator said "chain everything": run the full pipeline unsupervised under the
+charter. Three product bets (issues #59/#60/#61) were scoped, implemented, and merged
+autonomously this session; this docs run is the content-loop tail that records them. Three
+PRs had merged since the last write-up (PR #58) and were undocumented.
+
+**Decided / shipped (this PR, docs only).** Documented the three merged PRs, each verified
+against the merged code, not just the PR description:
+- **PR #62 / issue #59 (expanded template catalog).** Confirmed against
+  `lib/programs/templates.ts`: six new `ProgramTemplate` entries (slugs
+  `starting-strength-3day`, `stronglifts-5x5-3day`, `madcow-5x5-3day`, `phul-4day`,
+  `phat-5day`, `full-body-3day`) added additively next to the original five, each
+  schema-validated at module load and asserted to materialize into a runnable program by
+  `templates.test.ts`. CHANGELOG: extended the existing `Added` templates line.
+- **PR #63 / issue #60 (readiness explainability).** Confirmed against
+  `components/session/exercise-card.tsx`: the `readiness-hold` / `readiness-deload` reason
+  from `suggestNextWeight` is plumbed to the set UI and rendered as a badge composed from a
+  verb ("Held" / "Lighter") and a cause ("reported soreness" / "low readiness today"), with
+  no UI when there is no readiness signal. CHANGELOG: a new `Added` line.
+- **PR #64 / issue #61 (readiness auto-regulation opt-out).** Confirmed against
+  `lib/preferences.ts` (`readinessAutoRegulation: true` in `DEFAULT_PREFERENCES`, additive,
+  no Prisma migration) and `lib/progression.ts` (`readinessForSuggestion` gate, applied in
+  `SessionRunner`): default on; off reproduces pre-readiness pure programmed progression.
+  CHANGELOG: folded into the existing `Changed` readiness-progression line.
+
+**Challenged.** Verification-first (docs-only, no product code): each CHANGELOG/log claim was
+checked against `lib/programs/templates.ts`, `components/session/exercise-card.tsx`,
+`lib/preferences.ts`, and `lib/progression.ts` before writing it. The badge wording in the
+PR summary matched the code (verb + cause composition).
+
+**Trust gate.** All three documented PRs (#62/#63/#64) and the product issues they closed
+(#59/#60/#61) were authored by `JulienAu`, on the maintainer allowlist - in-scope for the
+loop. External issue #57 was closed as not-planned by the trust gate (untrusted external
+authorship; never promoted into auto-implementable work).
+
+**Deferred to human / operator.** Dependency major bumps and `bcrypt` 6 remain parked as a
+separate human-reviewed draft, not actioned here. Further product calls (still more
+templates, progression-threshold tuning) noted for the operator rather than filed as
+auto-implementable issues.
+
+**Idle.** After this docs PR the product backlog is empty; a triage sweep follows to decide
+whether a crisp, single-PR code-health item is worth manufacturing, else a clean idle.
+
+---
+
 ## 2026-06-09 - Write up the readiness-progression loop and the public-repo hardening
 
 **Context.** Maintainer tick. Decision order per `06-orchestration.md`: drain ready PRs,


### PR DESCRIPTION
Documents the three product PRs merged since the last write-up (PR #58), each verified against the merged code:

- #62 (closed #59): expanded the built-in program template catalog (Starting Strength, StrongLifts 5x5, Madcow 5x5, PHUL, PHAT, Full Body 3x).
- #63 (closed #60): readiness explainability badge in the session UI ("Held - reported soreness" / "Lighter - low readiness today").
- #64 (closed #61): default-on preference to enable/disable readiness-based weight auto-regulation; off reproduces pre-readiness progression.

Also appends one dated entry to docs/loops/autonomy-log.md for this run.

verify.sh passed.