### PR TITLE
ci: modernize actions for Node 24 and harden the Postgres image pull

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     name: Lint, typecheck, unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - run: npx prisma generate
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:16-alpine
+        image: public.ecr.aws/docker/library/postgres:16-alpine
         env:
           POSTGRES_USER: gymcoach_test
           POSTGRES_PASSWORD: gymcoach_test
@@ -40,10 +40,10 @@ jobs:
           --health-cmd "pg_isready -U gymcoach_test"
           --health-interval 5s --health-timeout 5s --health-retries 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - run: npx prisma generate
@@ -56,10 +56,10 @@ jobs:
     name: Production build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - run: npx prisma generate
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:16-alpine
+        image: public.ecr.aws/docker/library/postgres:16-alpine
         env:
           POSTGRES_USER: gymcoach_test
           POSTGRES_PASSWORD: gymcoach_test
@@ -87,10 +87,10 @@ jobs:
       DATABASE_URL: postgresql://gymcoach_test:gymcoach_test@localhost:5434/gymcoach_test
       JWT_SECRET: e2e-test-secret-at-least-32-characters
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - run: npx prisma generate


### PR DESCRIPTION
## What

Two CI-reliability fixes (operator-directed; CI/pipeline is normally stop-for-human).

1. **Node 24 deprecation (time-sensitive).** `actions/checkout@v4` and `actions/setup-node@v4` run on Node.js 20, which GitHub deprecates and **force-migrates to Node 24 on 2026-06-16**. Bumped both to `@v5` (Node 24 runtimes). Also bumped the CI `node-version` 20 -> 22 to match the repo's documented working toolchain (nvm v22.17.1).
2. **Postgres pull flakiness.** Two post-merge `main` runs (~11:34Z and 11:41Z) red-failed at the integration job's "Initialize containers" step with `Docker pull failed with exit code 1` (transient Docker Hub issue; the tests never ran). Switched the Postgres service image to the rate-limit-free **AWS ECR Public** mirror of the official image (`public.ecr.aws/docker/library/postgres:16-alpine`).

## Verification

A workflow change is validated by running it: this PR is on a same-repo branch, so its CI run uses the **modified** workflow (new actions, new image, Node 22). A green run on this PR is direct end-to-end validation. Merging only on green.

No application code, schema, or dependency change.