### PR TITLE
feat(loops): ideation loop - manufacture bounded product feature ideas when the backlog is dry

### DIFF
--- a/.claude/skills/ideate/SKILL.md
+++ b/.claude/skills/ideate/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: ideate
+description: When the backlog is empty, manufacture well-scoped PRODUCT feature ideas - bounded feature research plus brainstorming grounded in the product vision and the captured competitor insights - and file them as crisp, single-PR issues so the Issue -> PR loop never starves for ideas. Use only when ship and triage have nothing and there is no open actionable issue. Strictly token-bounded; never launches the heavy multi-agent deep-research workflow.
+---
+
+# ideate
+
+triage manufactures code-health work (tests, small bugs, deps); `ideate` manufactures
+**product** work when even triage comes up dry, so the loop keeps pushing the product
+toward the goal of being the most complete self-hosted AI hypertrophy/fitness app - not
+just keeping it tidy. The output is **issues, not code**: crisp, single-PR feature ideas a
+later `implement-issue` run picks up unattended. Read `CLAUDE.md` and
+`docs/loops/07-autonomy.md` first.
+
+This is the lightweight, recurring cousin of the one-off deep-research workflow. It is
+deliberately cheap: it runs often (whenever the loop would otherwise idle), so it must
+cost a tiny fraction of that workflow.
+
+## When to run
+
+Only when the loop is genuinely starved of product work, in this order:
+- no ready PR to ship, AND
+- `triage` found no trusted code-health issue, AND
+- there is no open, actionable, trusted issue to implement.
+
+If there is already an open actionable issue, STOP - implement that first. Never pile new
+ideas on top of unstarted ones.
+
+## Hard budget (the whole point is bounded ideation)
+
+- **Never** launch the heavy deep-research workflow (the ~100-agent one) or anything close.
+- Default to brainstorming from context you already have (the repo, the research memory,
+  the roadmap). A web check is **optional** and capped at **~6 searches**, used only if it
+  adds something the captured research does not already cover.
+- Spawn at most ONE helper subagent if you need one; prefer doing it inline.
+- File **at most 3 issues** per run.
+- **Anti-flood:** do not run if there are already **>= 3 open `enhancement`/`idea`
+  issues** - the backlog is fed; let `implement-issue` drain it first. One productive run
+  per starved cycle; once you file issues, you are done until they drain.
+
+## Where ideas come from (grounded, not random)
+
+1. **The vision.** Aim: the most complete self-hosted AI hypertrophy/fitness app. Ask "what
+   would a serious lifter, a coach, or a leading competitor expect that we do not have yet?"
+2. **The captured research** (Memory: `research-product-direction.md`) and its wedge - AI
+   that advises *within* the user's program, explains why, and respects data ownership.
+   Mine it for not-yet-built items.
+3. **The current product.** Skim `app/` routes, `lib/`, `components/` to find concrete gaps
+   and the natural next slice of what already shipped (e.g. readiness now exists -> what
+   uses it next).
+4. **The README roadmap** - unchecked items.
+5. **Optional bounded web check** (<= ~6 searches) for what users want / what is missing in
+   AI hypertrophy apps lately - only if it beats the memory. No heavy fan-out.
+
+## What a good idea-issue looks like
+
+- **Single-PR-sized and additive-friendly** - scoped so `implement-issue` can finish it
+  under the green-gate. No epics: split a big idea into the smallest valuable first slice.
+- **Encodes a sensible DEFAULT product decision**, so it is concrete work, not "needs a
+  product call". Turning ambiguity into a defensible spec is the job.
+- Title + **Context** (the user value and where it lives, with file paths) + **Acceptance
+  criteria** (a checkable list).
+- **Backward-compatible.** If the full idea would need a non-additive migration, an
+  auth/security change, an LLM-output-contract change, or a major dep bump, say so and scope
+  only the safe first slice; the rest is stop-for-human.
+- Labels: `enhancement` and `idea`.
+- **De-dupe** against open AND recently-closed issues and `docs/loops/ideas-backlog.md`.
+  Never re-file a shipped or rejected idea.
+
+## Procedure
+
+1. **Confirm starvation and the anti-flood cap.** If not starved, or there are already >= 3
+   open `enhancement`/`idea` issues, STOP and report - do not generate.
+2. **Ground.** Skim the current features, the research memory, the roadmap. Optionally one
+   small web check within the budget.
+3. **Brainstorm** a short candidate list; rank by `(user value x fit-with-vision) /
+   implementation size`. Prefer high-value, low-risk, additive, single-PR slices.
+4. **File** the top up-to-3 non-duplicate, single-PR candidates as crisp issues with a
+   sensible default spec + acceptance criteria:
+   `gh issue create --label enhancement --label idea --title "..." --body "..."`.
+5. **Record** one line per idea in `docs/loops/ideas-backlog.md` (proposed / shipped /
+   rejected) so future runs do not repeat it. (This is a read/write doc edit; commit it on
+   a task branch like any change, never on `main`.)
+6. **Report** the new issue numbers + one line each, and what you deliberately did not file.
+
+## Stop conditions
+
+- Not starved, or an open actionable issue exists -> STOP (implement first).
+- >= 3 open `enhancement`/`idea` issues -> STOP (anti-flood).
+- No genuinely new, single-PR, non-duplicate idea -> file fewer or none. "Idea backlog
+  healthy" is a valid, good outcome; never invent low-value busywork to fill the tracker.
+- An idea that genuinely needs the heavy deep-research workflow -> out of scope here; note
+  it for a human instead.
+
+## What success looks like
+
+A steady trickle of crisp, vision-aligned, single-PR feature issues that appear only when
+the loop would otherwise idle, never faster than implementation drains them, at a tiny
+fraction of the one-off deep-research cost. The loop never starves for *product* direction,
+and the product keeps moving toward "the most complete AI fitness app" - while staying
+token-bounded and inside every guardrail (the filed issues are still subject to the
+green-gate, the subagent challenge, and the stop-for-human list when implemented).

--- a/docs/loops/06-orchestration.md
+++ b/docs/loops/06-orchestration.md
@@ -25,14 +25,21 @@ decides what to do next**. The maintainer loop's decision each tick:
 
 1. **Are there ready PRs?** (green or fixable CI) -> ship them first. Shipping finishes
    started work and moves `main` forward; always drain this before starting new work.
-2. **Is the backlog low** (no actionable, unclaimed issue)? -> run triage to refill.
-3. **Is there an actionable issue?** -> implement the next one (-> a PR, which next tick's
+2. **Is the backlog low** (no actionable, unclaimed issue)? -> run triage to refill it with
+   code-health work.
+3. **Still no actionable issue after triage?** -> run `ideate` (08) to manufacture bounded
+   **product** ideas, so the loop keeps improving the product, not just tidying it. (Hard
+   caps: <= 3 issues, no run while >= 3 idea issues are open, never the heavy
+   deep-research workflow.)
+4. **Is there an actionable issue?** -> implement the next one (-> a PR, which next tick's
    step 1 will ship).
-4. **Did things merge since the last write-up?** -> run the content loop.
-5. **Nothing to do on any of the above?** -> stop. A clean idle is success, not failure.
+5. **Did things merge since the last write-up?** -> run the content loop.
+6. **Nothing to do on any of the above?** -> stop. A clean idle is success, not failure.
 
 Order matters: finish before you start (ship before implement), and only manufacture work
-(triage) when genuinely starved, so the tracker and the PR queue never flood.
+(triage, then ideate) when genuinely starved, so the tracker and the PR queue never flood.
+Ideation sits below triage on purpose: ideas are made only when the loop would otherwise
+idle, and implementation drains them before more are made.
 
 ## Running it
 
@@ -40,11 +47,13 @@ Phase 1 - watched, locally:
 
 ```
 /loop You are the maintainer of this repo. Each tick: (1) ship any ready PR with ship-pr;
-(2) if the backlog is low, run triage; (3) implement the next actionable issue with
-implement-issue; (4) if work merged since the last write-up, run write-up. Respect every
-skill's own guardrails. STOP when there is nothing to ship, no actionable issue, and
-nothing to document - or after 3 merges this run. Auto-merge only on green CI; never on
-main directly.
+(2) if the backlog is low, run triage; (3) if there is still no actionable issue, run
+ideate to manufacture bounded product ideas; (4) implement the next actionable issue with
+implement-issue; (5) if work merged since the last write-up, run write-up. Respect every
+skill's own guardrails (including ideate's hard caps: <= 3 issues, no run while >= 3 idea
+issues are open, never the heavy deep-research workflow). STOP when there is nothing to
+ship, no actionable issue, ideate has nothing new to add, and nothing to document - or
+after 3 merges this run. Auto-merge only on green CI; never on main directly.
 ```
 
 Phase 2 - unattended, on infrastructure:

--- a/docs/loops/08-ideation-loop.md
+++ b/docs/loops/08-ideation-loop.md
@@ -1,0 +1,75 @@
+# 08 — Ideation loop (so the product, not just the repo, keeps growing)
+
+`triage` (03) keeps the backlog fed with **code-health** work - tests, small bugs, deps.
+But a repo that only tidies itself plateaus. The ideation loop is the head *above* triage:
+when even triage comes up dry, it manufactures **product** work - well-scoped feature ideas
+- so the Issue -> PR loop never starves for *direction*, and the product keeps moving
+toward the goal of being the most complete self-hosted AI hypertrophy/fitness app.
+
+It is the cheap, recurring cousin of the one-off deep-research workflow we ran once to seed
+the roadmap (captured in Memory `research-product-direction.md`). That workflow spent ~100
+agents in a single pass; ideation must run *every time the loop would idle*, so it is
+deliberately tiny.
+
+```
+        backlog empty?
+   triage (03) finds no code-health work
+              |
+              v
+        ideate (08) -- bounded brainstorm + optional small web check
+              |  files <= 3 crisp, single-PR feature issues (labels: enhancement, idea)
+              v
+   implement-issue (02) -> ship-pr (04) -> write-up (05)
+              |
+        drains the idea backlog; only when empty again does ideate fire
+```
+
+## Where it sits in the maintainer loop
+
+The decision order (see `06-orchestration.md`) becomes: **ship -> triage (if low) -> if
+still no actionable issue, ideate -> implement -> write-up -> stop on a clean idle.**
+Ideation fires only after ship and triage have nothing and there is no open actionable
+issue. That ordering is the rate-limiter: ideas are only manufactured when the loop would
+otherwise stop, and implementation drains them before more are made.
+
+## The budget (why it does not explode in tokens)
+
+The skill (`.claude/skills/ideate/SKILL.md`) bakes in hard limits:
+
+- **Never** the heavy deep-research workflow. Brainstorming from existing context (repo,
+  research memory, roadmap) is the default; a web check is optional and capped at ~6
+  searches.
+- **At most 3 issues per run**, and **no run at all** while there are already >= 3 open
+  `enhancement`/`idea` issues (anti-flood).
+- One productive run per starved cycle.
+
+So the cost per idle cycle is roughly one focused brainstorming pass, not a research
+campaign - and the anti-flood cap means it cannot outrun the implement/ship half.
+
+## Grounding (ideas are derived, not hallucinated)
+
+Ideas come from the product vision, the captured competitor research and its wedge (AI that
+advises within the user's program, explains why, respects ownership), the current feature
+set (find the gaps and the next slice of what shipped), the README roadmap, and an optional
+small web check. Each filed idea encodes a **sensible default product decision** so it is
+concrete, single-PR work rather than "needs a product call".
+
+## Guardrails
+
+Ideation only *files issues* - it never writes product code or merges. The issues it files
+are authored by the loop's own trusted account, so they are auto-actionable, but they are
+still subject to everything downstream: the green-gate, the subagent challenge, and the
+stop-for-human list (a filed idea whose safe slice turns out to need a non-additive
+migration, an auth change, an LLM-output-contract change, or a major dep bump gets a draft
+PR for a human). `docs/loops/ideas-backlog.md` is the durable log of proposed / shipped /
+rejected ideas, so the loop never repeats itself.
+
+## The four rules, here
+
+1. **Feedback** - a filed idea is only "good" once `implement-issue` can finish it under the
+   green-gate; vague epics fail that test and are not filed.
+2. **Skills, not prompts** - ideation is the `ideate` skill; the maintainer loop just calls
+   it when starved.
+3. **It must halt** - <= 3 issues per run, no run while >= 3 idea issues are open, one run
+   per starved cycle. Three caps.
+4. **Durability** - ideas live as GitHub issues + `ideas-backlog.md`, not in a session.

--- a/docs/loops/README.md
+++ b/docs/loops/README.md
@@ -24,20 +24,24 @@ This folder is the reproducible playbook. Read in order:
 - [`07-autonomy.md`](07-autonomy.md) - the charter for running unsupervised: mandate,
   hard guardrails, the stop-for-human list, the subagent challenge protocol, and the
   rollback baseline. Paired with the append-only [`autonomy-log.md`](autonomy-log.md).
+- [`08-ideation-loop.md`](08-ideation-loop.md) - the head above triage: when even triage
+  comes up dry, manufacture bounded **product** feature ideas (the cheap, recurring cousin
+  of the one-off deep-research workflow) so the product keeps growing, not just the test
+  suite. Logs to [`ideas-backlog.md`](ideas-backlog.md).
 
 ## The system at a glance
 
 ```
             maintainer loop (06): cron + a decision-maker each tick
                                   |
-   +----------------+------------+------------+-----------------+
-   v                v                         v                 v
- triage (03)   implement-issue (02)      ship-pr (04)      write-up (05)
- refill the    one issue -> one PR       watch CI, fix     CHANGELOG +
- backlog       (branch->code->test)      red, self-review, playbook stay
- when low                                auto-merge GREEN  true to reality
-   |                |                         |                 |
-   +----------------+------------+------------+-----------------+
+   +-------------+-------------+-----------+-----------+-------------+
+   v             v             v                       v             v
+ triage (03)  ideate (08)  implement (02)        ship-pr (04)   write-up (05)
+ refill code  refill        one issue -> one PR   watch CI, fix  CHANGELOG +
+ -health when PRODUCT       (branch->code->test)  red, review,   playbook stay
+ backlog low  ideas when                          auto-merge     true to reality
+   |          starved (bounded)  |                 GREEN  |          |
+   +-------------+-------------+-----------+-----------+-------------+
                                   |
                     scripts/verify.sh + CI = the feedback gate
                     (nothing merges on a red or pending gate)
@@ -47,6 +51,9 @@ This folder is the reproducible playbook. Read in order:
 
 The pipeline is **generate work -> do work -> verify in CI -> ship -> tell the story**.
 Each stage is a small loop calling one tested skill; `06` is the loop that runs them.
+`triage` (03) generates code-health work; `ideate` (08) generates product work when even
+triage is dry, so the product grows toward "the most complete AI fitness app", not just a
+tidier repo.
 
 ## The four rules we never break
 

--- a/docs/loops/ideas-backlog.md
+++ b/docs/loops/ideas-backlog.md
@@ -1,0 +1,12 @@
+# Ideas backlog
+
+Append-only log the `ideate` loop keeps so it never re-proposes a shipped or rejected idea.
+One line per idea: `STATUS - title (issue #N, date) - one-line note`. STATUS is
+`proposed`, `shipped`, or `rejected`.
+
+Grounding for ideas lives in Memory `research-product-direction.md` (the competitor-review
+research and the product wedge). See `docs/loops/08-ideation-loop.md` for how this is used.
+
+## Log
+
+(none yet - the first `ideate` run appends here)


### PR DESCRIPTION
## What

Adds an **ideation loop** so the autonomous system improves the *product*, not just the repo's health, whenever it would otherwise idle - toward the goal of the most complete self-hosted AI fitness app.

`triage` (03) refills the backlog with code-health work. When even triage finds nothing and there is no open actionable issue, the new `ideate` skill (08) manufactures bounded **product** feature ideas and files them as crisp, single-PR issues that the existing implement -> ship loop drains.

## Token discipline (explicitly bounded)

This is the cheap, recurring cousin of the one-off ~100-agent deep-research workflow - it must run every idle cycle, so:
- **Never** launches the heavy deep-research workflow; brainstorms from existing context (repo, the captured research memory, roadmap); optional web check capped at ~6 searches.
- **<= 3 issues per run**; **no run while >= 3 open `enhancement`/`idea` issues** (anti-flood); one productive run per starved cycle.
- Sits *below* triage in the decision order, so ideas are only made when the loop would idle and implementation drains them first.

## Changes
- `.claude/skills/ideate/SKILL.md` - the skill (when-to-run, hard budget, grounding, procedure, stop conditions).
- `docs/loops/06-orchestration.md` - decision order + maintainer prompt updated to: ship -> triage -> ideate -> implement -> write-up.
- `docs/loops/08-ideation-loop.md` - new playbook chapter; `docs/loops/ideas-backlog.md` - append-only de-dup log.
- `docs/loops/README.md` - reading list + diagram.
- New `idea` GitHub label.

## Guardrails
Ideation only files issues (never code/merges). Filed ideas are authored by the loop's trusted account (auto-actionable) but remain subject to the green-gate, the subagent challenge, and the stop-for-human list when implemented.

Docs/skill only; no app code, schema, or dependency change. CI gates it.