### PR TITLE
feat: warm-up set calculator from the working weight (#69)

### DIFF
--- a/components/session/set-input.tsx
+++ b/components/session/set-input.tsx
@@ -18,6 +18,7 @@ import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { suggestNextWeight, weightIncrement, type ReadinessSignal } from '@/lib/progression';
 import { PlateCalculator } from '@/components/session/plate-calculator';
+import { WarmupCalculator } from '@/components/session/warmup-calculator';
 import type { PendingSet } from '@/lib/indexeddb';
 import type { SerializedLastPerformance } from './session-runner';
 
@@ -111,7 +112,10 @@ export function SetInput({
             <Label className="text-xs uppercase tracking-wide text-muted-foreground">
               Load ({unitLabel(unit)})
             </Label>
-            <PlateCalculator weightKg={form.weight} unit={unit} />
+            <div className="flex items-center gap-1">
+              <WarmupCalculator weightKg={form.weight} unit={unit} />
+              <PlateCalculator weightKg={form.weight} unit={unit} />
+            </div>
           </div>
           <div className="flex items-center gap-2">
             <Button

--- a/components/session/warmup-calculator.test.tsx
+++ b/components/session/warmup-calculator.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { WarmupCalculator } from './warmup-calculator';
+
+describe('WarmupCalculator', () => {
+  it('shows the ramp for the working weight when opened (kg)', async () => {
+    const user = userEvent.setup();
+    // 100 kg working weight, default 20 kg bar -> empty bar + 40/60/80 kg.
+    render(<WarmupCalculator weightKg={100} unit="KG" />);
+
+    await user.click(screen.getByRole('button', { name: /warm-up calculator/i }));
+
+    const list = await screen.findByRole('list', { name: /warm-up sets/i });
+    expect(list).toBeInTheDocument();
+    expect(screen.getByText(/40 kg/)).toBeInTheDocument();
+    expect(screen.getByText(/60 kg/)).toBeInTheDocument();
+    expect(screen.getByText(/80 kg/)).toBeInTheDocument();
+    expect(screen.getByText(/working weight of 100 kg/i)).toBeInTheDocument();
+  });
+
+  it('shows the at-or-below-the-bar message for a sub-bar weight', async () => {
+    const user = userEvent.setup();
+    // 15 kg is below the default 20 kg bar -> no ramp.
+    render(<WarmupCalculator weightKg={15} unit="KG" />);
+
+    await user.click(screen.getByRole('button', { name: /warm-up calculator/i }));
+
+    expect(
+      await screen.findByText(/at or below the bar/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('list', { name: /warm-up sets/i })).toBeNull();
+  });
+});

--- a/components/session/warmup-calculator.tsx
+++ b/components/session/warmup-calculator.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Flame } from 'lucide-react';
+import type { WeightUnit } from '@prisma/client';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { computeWarmupRamp } from '@/lib/warmup';
+import { plateConfigForUnit } from '@/lib/preferences';
+import { roundWeight, toDisplayWeight, unitLabel } from '@/lib/units';
+
+interface Props {
+  // The current working load, stored in kg (the app's storage unit).
+  weightKg: number;
+  unit: WeightUnit;
+}
+
+// In-workout warm-up ramp calculator (issue #69). Given the working weight, it
+// suggests a short ramp of warm-up sets at ascending percentages with
+// descending reps, in the user's display unit and rounded to loadable plates.
+// Display-only; it never creates or mutates a set (mirrors the plate calculator).
+export function WarmupCalculator({ weightKg, unit }: Props) {
+  const [open, setOpen] = useState(false);
+
+  // Compute lazily when the dialog opens so the bar weight is only read from
+  // localStorage on the client, and only when the user wants the calculator.
+  const ramp = useMemo(() => {
+    if (!open) return null;
+    const { barWeight } = plateConfigForUnit(unit);
+    const working = roundWeight(toDisplayWeight(weightKg, unit), 2);
+    return computeWarmupRamp(working, unit, barWeight);
+  }, [open, weightKg, unit]);
+
+  const label = unitLabel(unit);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1 px-2 text-xs text-muted-foreground"
+          aria-label="Open the warm-up calculator"
+        >
+          <Flame className="size-4" />
+          Warm-up
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Warm-up ramp</DialogTitle>
+          <DialogDescription>
+            Suggested warm-up sets up to a working weight of{' '}
+            {ramp ? `${ramp.workingWeight} ${label}` : 'the current weight'}.
+          </DialogDescription>
+        </DialogHeader>
+
+        {ramp && (
+          <div className="space-y-4">
+            {ramp.sets.length > 0 ? (
+              <ol className="space-y-2" aria-label="Warm-up sets">
+                {ramp.sets.map((set, index) => (
+                  <li
+                    key={`${set.weight}-${index}`}
+                    className="flex items-center justify-between gap-2 rounded-md border px-3 py-2"
+                  >
+                    <span className="text-base font-semibold">
+                      {set.weight} {label}
+                      <span className="ml-2 text-xs font-normal text-muted-foreground">
+                        {set.percent}%
+                      </span>
+                    </span>
+                    <Badge variant="secondary" className="text-sm font-semibold">
+                      {set.reps} reps
+                    </Badge>
+                  </li>
+                ))}
+              </ol>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                This load is at or below the bar - no warm-up ramp needed.
+              </p>
+            )}
+
+            <p className="text-xs text-muted-foreground">
+              Suggestions only - log your warm-ups with the Warmup toggle. Weights
+              are rounded down to loadable plates.
+            </p>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/lib/warmup.test.ts
+++ b/lib/warmup.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { computeWarmupRamp } from './warmup';
+
+describe('computeWarmupRamp', () => {
+  it('builds an ascending ramp for a typical kg working weight', () => {
+    // 100 kg working weight, 20 kg bar. Stages: 40/60/80% -> 40/60/80 kg,
+    // all clean 2.5 kg multiples; an empty-bar set leads them off.
+    const ramp = computeWarmupRamp(100, 'KG', 20);
+
+    expect(ramp.workingWeight).toBe(100);
+    expect(ramp.barWeight).toBe(20);
+    expect(ramp.sets.map((s) => s.weight)).toEqual([20, 40, 60, 80]);
+    // Reps descend after the empty-bar primer.
+    expect(ramp.sets.map((s) => s.reps)).toEqual([8, 5, 3, 2]);
+    // Every warm-up stays strictly below the working weight.
+    for (const set of ramp.sets) {
+      expect(set.weight).toBeLessThan(100);
+    }
+  });
+
+  it('rounds warm-up weights down to a loadable increment (kg)', () => {
+    // 102.5 kg -> 40% = 41 -> 40, 60% = 61.5 -> 60, 80% = 82 -> 80.
+    const ramp = computeWarmupRamp(102.5, 'KG', 20);
+    expect(ramp.sets.map((s) => s.weight)).toEqual([20, 40, 60, 80]);
+    // Each percentage weight is a multiple of the 2.5 kg increment.
+    for (const set of ramp.sets) {
+      expect((set.weight * 10) % 25).toBe(0);
+    }
+  });
+
+  it('rounds to a 5 lb increment for the lb display unit', () => {
+    // 225 lb working weight, 45 lb bar. 40% = 90, 60% = 135, 80% = 180 - all
+    // clean 5 lb multiples.
+    const ramp = computeWarmupRamp(225, 'LB', 45);
+    expect(ramp.sets.map((s) => s.weight)).toEqual([45, 90, 135, 180]);
+    for (const set of ramp.sets) {
+      expect(set.weight % 5).toBe(0);
+    }
+  });
+
+  it('rounds an awkward lb working weight down to 5 lb steps', () => {
+    // 187 lb -> 40% = 74.8 -> 70, 60% = 112.2 -> 110, 80% = 149.6 -> 145.
+    const ramp = computeWarmupRamp(187, 'LB', 45);
+    expect(ramp.sets.map((s) => s.weight)).toEqual([45, 70, 110, 145]);
+    for (const set of ramp.sets) {
+      expect(set.weight % 5).toBe(0);
+      expect(set.weight).toBeLessThan(187);
+    }
+  });
+
+  it('reports the percentage of the working weight for each stage', () => {
+    const ramp = computeWarmupRamp(100, 'KG', 20);
+    // Empty bar is 20% of 100; then the standard 40/60/80.
+    expect(ramp.sets.map((s) => s.percent)).toEqual([20, 40, 60, 80]);
+  });
+
+  it('returns an empty ramp for a zero working weight', () => {
+    expect(computeWarmupRamp(0, 'KG', 20).sets).toEqual([]);
+  });
+
+  it('returns an empty ramp for a negative working weight', () => {
+    expect(computeWarmupRamp(-50, 'KG', 20).sets).toEqual([]);
+  });
+
+  it('returns an empty ramp for a non-finite working weight', () => {
+    expect(computeWarmupRamp(NaN, 'KG', 20).sets).toEqual([]);
+    expect(computeWarmupRamp(Infinity, 'KG', 20).sets).toEqual([]);
+  });
+
+  it('returns an empty ramp when the working weight is at or below the bar', () => {
+    // Nothing to warm up to: the bar already is the load.
+    expect(computeWarmupRamp(20, 'KG', 20).sets).toEqual([]);
+    expect(computeWarmupRamp(15, 'KG', 20).sets).toEqual([]);
+  });
+
+  it('handles a light working weight just above the bar without duplicates', () => {
+    // 25 kg working weight, 20 kg bar. The bar is not below 40% (=10), so no
+    // empty-bar primer; the percentage stages all round down toward the bar
+    // and de-duplicate rather than repeating the same weight.
+    const ramp = computeWarmupRamp(25, 'KG', 20);
+    const weights = ramp.sets.map((s) => s.weight);
+    // No duplicate weights.
+    expect(new Set(weights).size).toBe(weights.length);
+    // All warm-ups stay below the working weight and at/above the bar.
+    for (const set of ramp.sets) {
+      expect(set.weight).toBeLessThan(25);
+      expect(set.weight).toBeGreaterThanOrEqual(20);
+    }
+  });
+
+  it('treats a zero bar weight (e.g. dumbbell/machine) as no empty-bar primer', () => {
+    const ramp = computeWarmupRamp(100, 'KG', 0);
+    // No empty-bar (0 kg) set; the ramp is the percentage stages only.
+    expect(ramp.sets.map((s) => s.weight)).toEqual([40, 60, 80]);
+    expect(ramp.sets.map((s) => s.reps)).toEqual([5, 3, 2]);
+  });
+
+  it('returns an empty ramp for a negative bar weight', () => {
+    expect(computeWarmupRamp(100, 'KG', -5).sets).toEqual([]);
+  });
+});

--- a/lib/warmup.ts
+++ b/lib/warmup.ts
@@ -1,0 +1,134 @@
+// Pure warm-up ramp math for the in-workout calculator (issue #69).
+//
+// Given a working weight, this suggests a short ramp of warm-up sets at
+// ascending percentages of that weight with descending reps, so a lifter eases
+// up to a heavy top set instead of jumping straight onto it. Like the plate
+// calculator (lib/plates.ts), it is a pure function with exported types and is
+// fully unit-tested. It is display-only: it never creates or mutates a Set.
+//
+// The ramp is computed in the user's *display* unit (kg or lb) so the suggested
+// weights round to a loadable increment in that unit. The session UI converts
+// the kg-stored working weight to the display unit before calling in here.
+
+import { WeightUnit } from '@prisma/client';
+import { roundWeight } from '@/lib/units';
+
+// One step of the ramp: a fraction of the working weight and the reps to do at
+// it. Fractions ascend, reps descend - a standard hypertrophy/strength warm-up.
+interface RampStage {
+  // Fraction of the working weight (0..1). The empty-bar stage uses 0 and is
+  // handled separately so it is only shown when the bar is below the first
+  // percentage stage.
+  fraction: number;
+  reps: number;
+}
+
+// The percentage stages of the ramp, lightest first. Kept small and standard:
+// 40% x 5, 60% x 3, 80% x 2 up to the working set.
+const RAMP_STAGES: readonly RampStage[] = [
+  { fraction: 0.4, reps: 5 },
+  { fraction: 0.6, reps: 3 },
+  { fraction: 0.8, reps: 2 },
+];
+
+// The lightest stage's fraction, used to decide whether the empty bar leads off
+// the ramp. Kept as a named constant so the empty-bar check does not index into
+// RAMP_STAGES (which the strict-mode noUncheckedIndexedAccess would widen).
+const FIRST_STAGE_FRACTION = 0.4;
+
+export interface WarmupSet {
+  // The suggested warm-up weight in the display unit, rounded to a loadable
+  // increment and never above the working weight.
+  weight: number;
+  // Suggested reps for this warm-up set.
+  reps: number;
+  // The actual share of the working weight this set represents, as a whole
+  // percent (for display, e.g. "40%"). Computed from the rounded weight so it
+  // stays truthful even when a stage clamped to the bar.
+  percent: number;
+}
+
+export interface WarmupRamp {
+  // The working weight the ramp was built from, in the display unit.
+  workingWeight: number;
+  // The bar weight used as the floor of the ramp, in the display unit.
+  barWeight: number;
+  // The warm-up sets, lightest first. Empty when there is nothing sensible to
+  // suggest (zero/negative working weight, or working weight at/below the bar).
+  sets: WarmupSet[];
+}
+
+// Standard increment to round warm-up weights to, per unit. A warm-up does not
+// need to be loaded as precisely as a working set, so we round to a clean plate
+// jump (2.5 kg / 5 lb) - landing on plates the lifter actually has, without the
+// fiddly micro-plates a true working weight might need.
+const WARMUP_INCREMENT: Record<WeightUnit, number> = {
+  KG: 2.5,
+  LB: 5,
+};
+
+// Round a weight down to the nearest loadable increment for the unit. Rounding
+// down (not nearest) guarantees a warm-up never creeps above its target stage.
+function roundToIncrement(weight: number, unit: WeightUnit): number {
+  const step = WARMUP_INCREMENT[unit];
+  return roundWeight(Math.floor(weight / step) * step, 2);
+}
+
+// Build a warm-up ramp for a working weight expressed in the display unit.
+//
+// - Empty/zero/negative or non-finite working weight -> empty ramp (no crash).
+// - Working weight at or below the bar -> empty ramp (nothing to warm up to;
+//   the bar itself is the load).
+// - Otherwise: an empty-bar set, then the percentage stages, each rounded down
+//   to a loadable increment, clamped to never exceed the working weight, and
+//   de-duplicated so two stages that round to the same weight are not repeated.
+export function computeWarmupRamp(
+  workingWeight: number,
+  unit: WeightUnit,
+  barWeight: number,
+): WarmupRamp {
+  const result: WarmupRamp = { workingWeight, barWeight, sets: [] };
+
+  if (!Number.isFinite(workingWeight) || workingWeight <= 0) return result;
+  if (!Number.isFinite(barWeight) || barWeight < 0) return result;
+  // At/below the bar there is no ramp to build - the bar is already the load.
+  if (workingWeight <= barWeight) return result;
+
+  const sets: WarmupSet[] = [];
+
+  // Start with the empty bar when the bar is below the lightest percentage
+  // stage (the usual case): it is the natural first warm-up.
+  const firstStageWeight = workingWeight * FIRST_STAGE_FRACTION;
+  if (barWeight > 0 && barWeight < firstStageWeight) {
+    sets.push({
+      weight: roundWeight(barWeight, 2),
+      reps: 8,
+      percent: Math.round((barWeight / workingWeight) * 100),
+    });
+  }
+
+  for (const stage of RAMP_STAGES) {
+    let weight = roundToIncrement(workingWeight * stage.fraction, unit);
+    // Never exceed the working weight; never drop below the bar.
+    if (weight > workingWeight) weight = roundToIncrement(workingWeight, unit);
+    if (weight < barWeight) weight = roundWeight(barWeight, 2);
+
+    // Skip a stage that rounds to the working weight (that is the working set,
+    // not a warm-up) or that duplicates the previous stage's weight.
+    if (weight >= workingWeight) continue;
+    const previous = sets[sets.length - 1];
+    if (previous && previous.weight === weight) continue;
+
+    sets.push({
+      weight,
+      reps: stage.reps,
+      // Percent reflects the actual (rounded/clamped) weight, not the nominal
+      // stage fraction, so a stage that clamped up to the bar is labeled with
+      // its true share of the working weight rather than a misleading 40/60/80.
+      percent: Math.round((weight / workingWeight) * 100),
+    });
+  }
+
+  result.sets = sets;
+  return result;
+}


### PR DESCRIPTION
Adds an in-session warm-up set calculator.

- `lib/warmup.ts`: pure `computeWarmupRamp(workingWeight, unit, barWeight)` returning an ordered ramp (empty bar then 40/60/80% with descending reps). Weights are rounded down to a loadable increment (2.5 kg / 5 lb) via `roundWeight` from `lib/units.ts`, never exceed the working weight, and de-duplicate. Empty/zero/negative/non-finite working weight or a working weight at/below the bar returns an empty ramp (no crash). `percent` reflects the actual rounded weight so labels stay truthful when a stage clamps to the bar.
- `lib/warmup.test.ts`: typical kg/lb weights, awkward weights rounded down, percentages, zero/negative/non-finite, at/below-bar, light-near-bar (no duplicates), zero/negative bar.
- `components/session/warmup-calculator.tsx`: display-only `Dialog` (reusing `components/ui`) launched from the set logger next to the plate calculator. Reads the per-unit bar weight from preferences, converts the kg-stored working weight to display unit. Never creates or mutates a set.
- Wired into `components/session/set-input.tsx`; light component test added.

Additive only: no schema/migration, no API change, no LLM-contract change, no new dependency.

Closes #69

scripts/verify.sh passed; skeptic review clean (one quality finding on percent labels was fixed and re-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)