### PR TITLE
feat: detect personal records (heaviest set + best e1RM) and surface a badge

### DIFF
--- a/components/session/session-runner.tsx
+++ b/components/session/session-runner.tsx
@@ -322,6 +322,7 @@ export function SessionRunner({ session, lastPerformances, readiness, unit }: Se
           sets={currentSets}
           isInputActive={mode.kind === 'input'}
           onDeleteSet={handleDeleteSet}
+          priorSets={lastPerf?.sets}
         />
 
         {!hydrated ? null : mode.kind === 'input' ? (

--- a/components/session/sets-list.test.tsx
+++ b/components/session/sets-list.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { Exercise, ProgramExercise } from '@prisma/client';
+import type { PendingSet } from '@/lib/indexeddb';
+import { SetsList } from './sets-list';
+
+const exo: Exercise = {
+  id: 'e1',
+  userId: 'u',
+  name: 'Squat',
+  muscleGroup: 'QUADS',
+  category: 'COMPOUND',
+  defaultRestSec: 120,
+  notes: null,
+  usesBodyweight: false,
+  createdAt: new Date(),
+};
+
+const pe: ProgramExercise & { exercise: Exercise } = {
+  id: 'pe',
+  workoutId: 'w',
+  exerciseId: 'e1',
+  order: 1,
+  targetSets: 3,
+  targetRepsMin: 6,
+  targetRepsMax: 10,
+  targetRIR: 2,
+  restSec: 120,
+  tempo: null,
+  notes: null,
+  exercise: exo,
+};
+
+function pendingSet(over: Partial<PendingSet>): PendingSet {
+  return {
+    localId: over.localId ?? 'l1',
+    sessionId: 's1',
+    exerciseId: 'e1',
+    setNumber: over.setNumber ?? 1,
+    weight: over.weight ?? 100,
+    reps: over.reps ?? 5,
+    rir: null,
+    notes: null,
+    isWarmup: over.isWarmup ?? false,
+    isDropSet: false,
+    createdAt: 0,
+    status: 'synced',
+    serverId: 'srv1',
+    syncedAt: 0,
+    attempts: 0,
+    lastError: null,
+    ...over,
+  };
+}
+
+describe('SetsList PR badge', () => {
+  it('shows a weight PR badge when a logged set beats the prior best load', () => {
+    render(
+      <SetsList
+        programExercise={pe}
+        sets={[pendingSet({ localId: 'a', setNumber: 1, weight: 110, reps: 5 })]}
+        isInputActive={false}
+        onDeleteSet={() => {}}
+        priorSets={[{ weight: 100, reps: 5 }]}
+      />,
+    );
+    expect(screen.getByText('Weight PR')).toBeTruthy();
+  });
+
+  it('does not show a PR badge when the set ties the prior best', () => {
+    render(
+      <SetsList
+        programExercise={pe}
+        sets={[pendingSet({ localId: 'a', setNumber: 1, weight: 100, reps: 5 })]}
+        isInputActive={false}
+        onDeleteSet={() => {}}
+        priorSets={[{ weight: 100, reps: 5 }]}
+      />,
+    );
+    expect(screen.queryByText('Weight PR')).toBeNull();
+    expect(screen.queryByText('e1RM PR')).toBeNull();
+  });
+});

--- a/components/session/sets-list.tsx
+++ b/components/session/sets-list.tsx
@@ -1,27 +1,58 @@
 'use client';
 
-import { Check, Circle, CircleDot, CloudOff, Loader2, Trash2 } from 'lucide-react';
+import { Check, Circle, CircleDot, CloudOff, Loader2, Trash2, Trophy } from 'lucide-react';
 import type { Exercise, ProgramExercise } from '@prisma/client';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import type { PendingSet } from '@/lib/indexeddb';
+import { detectPRs, type PRType } from '@/lib/records';
 
 interface Props {
   programExercise: ProgramExercise & { exercise: Exercise };
   sets: PendingSet[];
   isInputActive: boolean;
   onDeleteSet: (set: PendingSet) => void;
+  // Prior (previous-session) non-warmup sets for this exercise, used as the
+  // baseline for PR detection. Optional: absent on the very first session.
+  // This is the most recent session's data (from getLastPerformances), so a
+  // badge means "beats your last session" rather than an all-time record - an
+  // all-time baseline would need a separate query and is out of scope here.
+  priorSets?: { weight: number; reps: number }[];
 }
 
-export function SetsList({ programExercise, sets, isInputActive, onDeleteSet }: Props) {
+const PR_LABEL: Record<PRType, string> = {
+  weight: 'Weight PR',
+  e1rm: 'e1RM PR',
+};
+
+const PR_TITLE: Record<PRType, string> = {
+  weight: 'Heaviest load since your last session',
+  e1rm: 'Best estimated 1RM since your last session',
+};
+
+export function SetsList({ programExercise, sets, isInputActive, onDeleteSet, priorSets }: Props) {
   const completedNonWarmup = sets.filter((s) => !s.isWarmup);
   const totalRows = Math.max(programExercise.targetSets, completedNonWarmup.length + 1);
   const currentSetNumber = completedNonWarmup.length + 1;
 
+  // PR detection runs on read against a baseline of the previous session plus
+  // any earlier sets already logged in this session, so a second set only
+  // counts as a PR if it beats the first one too.
+  const baseline = (priorSets ?? []).map((s) => ({ ...s, isWarmup: false }));
+
+  function prsFor(set: PendingSet, index: number): PRType[] {
+    if (set.isWarmup) return [];
+    const earlierThisSession = sets
+      .slice(0, index)
+      .filter((s) => !s.isWarmup)
+      .map((s) => ({ weight: s.weight, reps: s.reps, isWarmup: false }));
+    return detectPRs(set, [...baseline, ...earlierThisSession]);
+  }
+
   return (
     <div className="rounded-lg border border-border">
-      {sets.map((s) => (
-        <RowDone key={s.localId} set={s} onDelete={() => onDeleteSet(s)} />
+      {sets.map((s, i) => (
+        <RowDone key={s.localId} set={s} prs={prsFor(s, i)} onDelete={() => onDeleteSet(s)} />
       ))}
 
       {Array.from({ length: totalRows - sets.length }, (_, i) => {
@@ -40,7 +71,15 @@ export function SetsList({ programExercise, sets, isInputActive, onDeleteSet }: 
   );
 }
 
-function RowDone({ set, onDelete }: { set: PendingSet; onDelete: () => void }) {
+function RowDone({
+  set,
+  prs,
+  onDelete,
+}: {
+  set: PendingSet;
+  prs: PRType[];
+  onDelete: () => void;
+}) {
   const weightLabel = set.weight === 0 ? 'BW' : `${set.weight} kg`;
   return (
     <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2 last:border-b-0">
@@ -55,6 +94,12 @@ function RowDone({ set, onDelete }: { set: PendingSet; onDelete: () => void }) {
           {weightLabel} × {set.reps}
           {set.rir != null && ` · RIR ${set.rir}`}
         </span>
+        {prs.map((pr) => (
+          <Badge key={pr} className="gap-1 text-xs" title={PR_TITLE[pr]}>
+            <Trophy className="size-3" />
+            {PR_LABEL[pr]}
+          </Badge>
+        ))}
         {set.notes && (
           <Badge variant="secondary" className="text-xs">
             note

--- a/lib/records.test.ts
+++ b/lib/records.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { detectPRs, isPR } from './records';
+
+// Minimal set factory: only the fields the PR detector reads.
+function set(weight: number, reps: number, isWarmup = false) {
+  return { weight, reps, isWarmup };
+}
+
+describe('detectPRs', () => {
+  it('flags a clear new heaviest set as both a weight and e1RM PR', () => {
+    const history = [set(100, 5), set(95, 8)];
+    // 110 kg is heavier than the 100 kg prior best, and its e1RM beats them all.
+    expect(detectPRs(set(110, 5), history)).toEqual(['weight', 'e1rm']);
+  });
+
+  it('does not flag a tie with the prior best (strict comparison)', () => {
+    const history = [set(100, 5)];
+    // Same load and reps -> same weight and same e1RM -> no PR.
+    expect(detectPRs(set(100, 5), history)).toEqual([]);
+  });
+
+  it('does not flag a set below the prior best', () => {
+    const history = [set(100, 5)];
+    expect(detectPRs(set(90, 5), history)).toEqual([]);
+  });
+
+  it('treats the first working set as a PR when there is no prior history', () => {
+    expect(detectPRs(set(80, 5), [])).toEqual(['weight', 'e1rm']);
+    // History made only of warm-ups counts as no working baseline.
+    expect(detectPRs(set(80, 5), [set(40, 10, true)])).toEqual(['weight', 'e1rm']);
+  });
+
+  it('flags an e1RM PR for a higher-rep set that does not beat max weight', () => {
+    // Prior best: 100 kg x 5 -> e1RM ~ 116.7. Candidate 95 kg x 10 -> e1RM ~ 126.7.
+    // Lighter load (no weight PR) but a clear estimated-1RM PR.
+    const history = [set(100, 5)];
+    expect(detectPRs(set(95, 10), history)).toEqual(['e1rm']);
+  });
+
+  it('flags only a weight PR when the load is a record but the e1RM is not', () => {
+    // Prior best e1RM comes from 90 kg x 12 (~126). A heavy low-rep single at
+    // 105 kg sets a weight PR but its e1RM (~108.5) does not beat 126.
+    const history = [set(90, 12), set(100, 1)];
+    expect(detectPRs(set(105, 1), history)).toEqual(['weight']);
+  });
+
+  it('never flags a warm-up candidate', () => {
+    expect(detectPRs(set(200, 5, true), [set(100, 5)])).toEqual([]);
+  });
+
+  it('ignores warm-ups in the history baseline', () => {
+    // The only heavy set in history is a warm-up, so a 90 kg working set is a PR.
+    const history = [set(150, 3, true), set(80, 5)];
+    expect(detectPRs(set(90, 5), history)).toEqual(['weight', 'e1rm']);
+  });
+
+  it('isPR mirrors detectPRs as a boolean', () => {
+    expect(isPR(set(110, 5), [set(100, 5)])).toBe(true);
+    expect(isPR(set(90, 5), [set(100, 5)])).toBe(false);
+  });
+});

--- a/lib/records.ts
+++ b/lib/records.ts
@@ -1,0 +1,61 @@
+import type { Set } from '@prisma/client';
+import { estimate1RM, best1RM } from '@/lib/stats';
+
+// ============================================================
+// Personal records (PRs) - derived on read from existing set
+// history. There is no records table and no migration: a PR is
+// computed by comparing a candidate working set against the
+// lifter's prior non-warmup sets for the same exercise.
+//
+// Two PR types are detected:
+//  - 'weight': the candidate moves a heavier load than ever before.
+//  - 'e1rm':   the candidate's estimated 1RM (Epley) beats the best
+//              estimated 1RM in prior history (catches higher-rep
+//              sets that imply more strength without more load).
+//
+// Warm-up sets are excluded from both the candidate and the history
+// baseline, consistent with `best1RM` / `setVolume` in lib/stats.
+// All comparisons are strict, so a tie with the prior best is never
+// flagged as a PR.
+// ============================================================
+
+export type PRType = 'weight' | 'e1rm';
+
+type SetLike = Pick<Set, 'weight' | 'reps' | 'isWarmup'>;
+
+// Heaviest non-warmup load in a list of sets (0 if none).
+function maxWorkingWeight(sets: SetLike[]): number {
+  let max = 0;
+  for (const s of sets) {
+    if (s.isWarmup) continue;
+    if (s.weight > max) max = s.weight;
+  }
+  return max;
+}
+
+// Returns the PR types a candidate set achieves versus the prior
+// history for the same exercise. The candidate is ignored if it is a
+// warm-up (or has a non-positive load) - it can never set a PR. With
+// no prior working history, the first valid working set sets both PRs.
+export function detectPRs(candidate: SetLike, history: SetLike[]): PRType[] {
+  if (candidate.isWarmup || candidate.weight <= 0 || candidate.reps <= 0) {
+    return [];
+  }
+
+  const prs: PRType[] = [];
+
+  if (candidate.weight > maxWorkingWeight(history)) {
+    prs.push('weight');
+  }
+
+  if (estimate1RM(candidate.weight, candidate.reps) > best1RM(history)) {
+    prs.push('e1rm');
+  }
+
+  return prs;
+}
+
+// Convenience predicate: does the candidate set any PR at all?
+export function isPR(candidate: SetLike, history: SetLike[]): boolean {
+  return detectPRs(candidate, history).length > 0;
+}


### PR DESCRIPTION
Implements #70.

## What
- New pure `lib/records.ts`: `detectPRs(candidate, history)` returns the PR types a working set achieves vs prior history - `weight` (heaviest load) and `e1rm` (best estimated 1RM, reusing `estimate1RM`/`best1RM` from `lib/stats.ts`). Strict comparisons (ties are not PRs); warm-ups and non-positive loads excluded from both candidate and baseline. Plus an `isPR` boolean helper.
- Surface a small Trophy `Badge` per logged set in `components/session/sets-list.tsx`. Baseline is the previous session (`getLastPerformances`) plus earlier non-warmup sets in the current session.

## Scope / limitations
- Derived on read from existing `Set` rows. No records table, no migration, no LLM-contract change, no new dependency.
- The baseline is the most recent prior session (the data already wired into the runner), so a badge means "beats your last session", not an all-time record. The tooltip is honest about this; an all-time baseline would need a separate query and is out of scope.

## Tests
- `lib/records.test.ts`: clear new PR, tie (not a PR), below-best (not a PR), no prior history (first working set is a PR), higher-rep e1RM-only, weight-only, warm-up exclusion in candidate and baseline.
- `components/session/sets-list.test.tsx`: badge shown on a weight PR, hidden on a tie.

Closes #70

scripts/verify.sh passed; skeptic review clean.