### PR TITLE
feat: training consistency card (sessions-per-week + current streak) on the progress page

### DIFF
--- a/app/(app)/progress/page.tsx
+++ b/app/(app)/progress/page.tsx
@@ -6,9 +6,11 @@ import { MUSCLE_GROUP_LABELS } from '@/lib/schemas/exercise';
 import {
   applyBodyweight,
   exerciseProgress,
+  trainingConsistency,
   weeklyVolumeByMuscleGroup,
 } from '@/lib/stats';
 import { ProgressDashboard } from '@/components/progress/progress-dashboard';
+import { ConsistencyCard } from '@/components/progress/consistency-card';
 
 interface SearchParams {
   exerciseId?: string;
@@ -46,13 +48,27 @@ export default async function ProgressPage({
     }),
     db.user.findUnique({
       where: { id: auth.userId },
-      select: { bodyweight: true, unit: true },
+      select: { bodyweight: true, unit: true, weeklyFrequency: true },
     }),
   ]);
   const bodyweight = user?.bodyweight ?? null;
   const unit = user?.unit ?? 'KG';
   const usesBodyweightById = new Map(
     exercisesWithSets.map((e) => [e.id, e.usesBodyweight]),
+  );
+
+  // Finished sessions over the window, for the consistency card.
+  const finishedSessions = await db.session.findMany({
+    where: {
+      userId: auth.userId,
+      finishedAt: { not: null },
+      startedAt: { gte: since },
+    },
+    select: { startedAt: true },
+  });
+  const consistency = trainingConsistency(
+    finishedSessions.map((s) => s.startedAt),
+    { weeklyFrequency: user?.weeklyFrequency ?? null, windowWeeks: RECENT_WEEKS },
   );
 
   const selectedExerciseId =
@@ -197,23 +213,30 @@ export default async function ProgressPage({
             action={{ label: 'Log your first session', href: '/session/new' }}
           />
         ) : (
-          <ProgressDashboard
-            exercises={exercisesWithSets.map((e) => ({
-              id: e.id,
-              name: e.name,
-              muscleGroup: MUSCLE_GROUP_LABELS[e.muscleGroup],
-            }))}
-            selectedExerciseId={selectedExerciseId}
-            exercisePoints={exercisePoints}
-            weeklyPoints={weeklyPoints.map((w) => ({
-              weekKey: w.weekKey,
-              weekStartIso: w.weekStart.toISOString(),
-              byMuscleGroup: w.byMuscleGroup,
-              total: w.total,
-            }))}
-            recap={recap}
-            unit={unit}
-          />
+          <>
+            <ConsistencyCard
+              weeks={consistency.weeks}
+              currentStreak={consistency.currentStreak}
+              weeklyFrequency={consistency.weeklyFrequency}
+            />
+            <ProgressDashboard
+              exercises={exercisesWithSets.map((e) => ({
+                id: e.id,
+                name: e.name,
+                muscleGroup: MUSCLE_GROUP_LABELS[e.muscleGroup],
+              }))}
+              selectedExerciseId={selectedExerciseId}
+              exercisePoints={exercisePoints}
+              weeklyPoints={weeklyPoints.map((w) => ({
+                weekKey: w.weekKey,
+                weekStartIso: w.weekStart.toISOString(),
+                byMuscleGroup: w.byMuscleGroup,
+                total: w.total,
+              }))}
+              recap={recap}
+              unit={unit}
+            />
+          </>
         )}
       </div>
     </main>

--- a/components/progress/consistency-card.tsx
+++ b/components/progress/consistency-card.tsx
@@ -1,0 +1,75 @@
+import { CalendarCheck, Flame } from 'lucide-react';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import type { ConsistencyWeek } from '@/lib/stats';
+
+interface Props {
+  weeks: ConsistencyWeek[];
+  currentStreak: number;
+  weeklyFrequency: number | null;
+}
+
+function shortLabelFromWeekKey(weekKey: string) {
+  // "2026-W18" -> "W18"
+  const parts = weekKey.split('-W');
+  return parts[1] ? `W${parts[1]}` : weekKey;
+}
+
+// Read-only consistency card: current streak plus a compact per-week bar of
+// trained days over the window. On-streak weeks are filled, off weeks muted.
+export function ConsistencyCard({ weeks, currentStreak, weeklyFrequency }: Props) {
+  const maxTrained = Math.max(1, ...weeks.map((w) => w.trainedDays));
+  const streakLabel = currentStreak === 1 ? '1 week' : `${currentStreak} weeks`;
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center gap-2">
+          <CalendarCheck className="size-4 text-muted-foreground" />
+          <h2 className="text-base font-semibold">Training consistency</h2>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {weeklyFrequency
+            ? `Trained days per week over the last ${weeks.length} weeks (target ${weeklyFrequency}/week).`
+            : `Trained days per week over the last ${weeks.length} weeks.`}
+        </p>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <div className="flex items-center gap-2">
+          <Flame
+            className={`size-5 ${currentStreak > 0 ? 'text-orange-500' : 'text-muted-foreground'}`}
+          />
+          <span className="text-2xl font-bold tabular-nums">{currentStreak}</span>
+          <span className="text-sm text-muted-foreground">
+            current streak ({streakLabel})
+          </span>
+        </div>
+
+        <div className="flex items-end gap-1" role="list" aria-label="Trained days per week">
+          {weeks.map((w) => {
+            const heightPct = Math.round((w.trainedDays / maxTrained) * 100);
+            return (
+              <div
+                key={w.weekKey}
+                role="listitem"
+                className="flex flex-1 flex-col items-center gap-1"
+                title={`${shortLabelFromWeekKey(w.weekKey)}: ${w.trainedDays} trained ${w.trainedDays === 1 ? 'day' : 'days'}`}
+              >
+                <div className="flex h-16 w-full items-end">
+                  <div
+                    className={`w-full rounded-sm ${
+                      w.onStreak ? 'bg-primary' : 'bg-muted'
+                    } ${w.isCurrent ? 'ring-2 ring-primary/40' : ''}`}
+                    style={{ height: `${Math.max(heightPct, w.trainedDays > 0 ? 8 : 4)}%` }}
+                  />
+                </div>
+                <span className="text-[10px] tabular-nums text-muted-foreground">
+                  {w.trainedDays}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/lib/stats.test.ts
+++ b/lib/stats.test.ts
@@ -9,6 +9,7 @@ import {
   isoWeekStart,
   setVolume,
   totalVolume,
+  trainingConsistency,
   weeklyVolumeByMuscleGroup,
 } from './stats';
 
@@ -218,5 +219,102 @@ describe('applyBodyweight', () => {
       { weight: 0, reps: 8, isWarmup: false, usesBodyweight: true }, // 70 × 8
     ];
     expect(totalVolume(applyBodyweight(sets, 70))).toBe(70 * 10 + 70 * 8);
+  });
+});
+
+describe('trainingConsistency', () => {
+  // Fixed reference point: Wednesday 2026-06-10, 12:00 UTC.
+  const now = new Date('2026-06-10T12:00:00Z');
+  // Monday 00:00 UTC of the ISO week containing `now`.
+  const currentMonday = isoWeekStart(now);
+
+  // A date inside the ISO week that is `weeksAgo` weeks before the current week,
+  // offset by `dayOffset` days from that week's Monday.
+  function dayInWeek(weeksAgo: number, dayOffset = 0): Date {
+    const d = new Date(currentMonday);
+    d.setUTCDate(d.getUTCDate() - weeksAgo * 7 + dayOffset);
+    d.setUTCHours(10, 0, 0, 0);
+    return d;
+  }
+
+  it('returns a zero streak and no crash for empty history', () => {
+    const out = trainingConsistency([], { now, windowWeeks: 12 });
+    expect(out.currentStreak).toBe(0);
+    expect(out.weeks).toHaveLength(12);
+    expect(out.weeks.every((w) => w.trainedDays === 0)).toBe(true);
+    expect(out.weeks[out.weeks.length - 1]?.isCurrent).toBe(true);
+  });
+
+  it('counts an unbroken run of weeks (one session per week)', () => {
+    const dates = [
+      dayInWeek(0), // current week
+      dayInWeek(1),
+      dayInWeek(2),
+      dayInWeek(3),
+    ];
+    const out = trainingConsistency(dates, { now, windowWeeks: 12 });
+    expect(out.currentStreak).toBe(4);
+  });
+
+  it('breaks the streak on a missed week', () => {
+    const dates = [
+      dayInWeek(0),
+      dayInWeek(1),
+      // week 2 missed
+      dayInWeek(3),
+    ];
+    const out = trainingConsistency(dates, { now, windowWeeks: 12 });
+    expect(out.currentStreak).toBe(2);
+  });
+
+  it('de-duplicates multiple sessions on the same calendar day', () => {
+    const sameDay = dayInWeek(0, 1);
+    const sameDayLater = new Date(sameDay);
+    sameDayLater.setUTCHours(18, 0, 0, 0);
+    const out = trainingConsistency([sameDay, sameDayLater], { now, windowWeeks: 12 });
+    const current = out.weeks[out.weeks.length - 1];
+    expect(current?.trainedDays).toBe(1);
+  });
+
+  it('does not break the streak when the current week is still empty', () => {
+    // No session this week, but a solid run in the prior two weeks.
+    const dates = [dayInWeek(1), dayInWeek(2)];
+    const out = trainingConsistency(dates, { now, windowWeeks: 12 });
+    expect(out.weeks[out.weeks.length - 1]?.trainedDays).toBe(0);
+    expect(out.currentStreak).toBe(2);
+  });
+
+  it('respects the weeklyFrequency target when present', () => {
+    // Two trained days in the current and previous week, one in the week before.
+    const dates = [
+      dayInWeek(0, 0),
+      dayInWeek(0, 2),
+      dayInWeek(1, 0),
+      dayInWeek(1, 3),
+      dayInWeek(2, 0), // only one day this week -> below target of 2
+    ];
+    const out = trainingConsistency(dates, {
+      now,
+      windowWeeks: 12,
+      weeklyFrequency: 2,
+    });
+    expect(out.weeklyFrequency).toBe(2);
+    // current + previous meet the target; the one-day week does not.
+    expect(out.currentStreak).toBe(2);
+  });
+
+  it('ignores a target of zero or negative and falls back to >=1 day', () => {
+    const out = trainingConsistency([dayInWeek(0), dayInWeek(1)], {
+      now,
+      windowWeeks: 12,
+      weeklyFrequency: 0,
+    });
+    expect(out.weeklyFrequency).toBeNull();
+    expect(out.currentStreak).toBe(2);
+  });
+
+  it('clamps the window to the requested number of weeks', () => {
+    const out = trainingConsistency([], { now, windowWeeks: 4 });
+    expect(out.weeks).toHaveLength(4);
   });
 });

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -179,3 +179,96 @@ export function weeklyVolumeByMuscleGroup(
     (a, b) => a.weekStart.getTime() - b.weekStart.getTime(),
   );
 }
+
+// ============================================================
+// Training consistency (per-week trained days + current streak)
+// ============================================================
+
+export interface ConsistencyWeek {
+  weekKey: string; // YYYY-Www
+  weekStartIso: string; // Monday 00:00 UTC, ISO string
+  trainedDays: number; // distinct calendar days with >=1 finished session
+  onStreak: boolean; // meets the streak rule (>=1 day, or the target when set)
+  isCurrent: boolean; // the ISO week that contains `now`
+}
+
+export interface ConsistencySummary {
+  weeks: ConsistencyWeek[]; // oldest -> newest, exactly `windowWeeks` entries
+  currentStreak: number; // consecutive on-streak weeks ending at the current week
+  weeklyFrequency: number | null; // the target used (echoed back), null when none
+}
+
+// Pure derivation of training consistency from finished sessions.
+//
+// - Buckets the `windowWeeks` most recent ISO weeks (ending at the week of
+//   `now`), counting distinct calendar days that have at least one finished
+//   session (multiple sessions on the same day count once).
+// - A week is "on streak" when it has at least one trained day, or meets the
+//   `weeklyFrequency` target when one is provided.
+// - `currentStreak` is the run of consecutive on-streak weeks ending at the
+//   current week. The current week is partial: if it has not yet met the rule,
+//   it does not break the streak (it simply does not extend it), so the streak
+//   is measured from the most recent completed-or-met week backwards.
+export function trainingConsistency(
+  finishedSessionDates: Date[],
+  options: { weeklyFrequency?: number | null; windowWeeks?: number; now?: Date } = {},
+): ConsistencySummary {
+  const windowWeeks = options.windowWeeks ?? 12;
+  const now = options.now ?? new Date();
+  const weeklyFrequency =
+    options.weeklyFrequency != null && options.weeklyFrequency > 0
+      ? options.weeklyFrequency
+      : null;
+
+  // Distinct trained calendar days per ISO week key. (`Set` from @prisma/client
+  // shadows the global Set type here, so reference it via globalThis.)
+  const daysByWeek = new Map<string, globalThis.Set<string>>();
+  for (const date of finishedSessionDates) {
+    const weekKey = isoWeekKey(date);
+    const dayKey = date.toISOString().slice(0, 10);
+    let days = daysByWeek.get(weekKey);
+    if (!days) {
+      days = new globalThis.Set<string>();
+      daysByWeek.set(weekKey, days);
+    }
+    days.add(dayKey);
+  }
+
+  // Build the window: the current ISO week and the (windowWeeks - 1) before it.
+  const currentWeekStart = isoWeekStart(now);
+  const currentWeekKey = isoWeekKey(now);
+  const weeks: ConsistencyWeek[] = [];
+  for (let i = windowWeeks - 1; i >= 0; i--) {
+    const weekStart = new Date(currentWeekStart);
+    weekStart.setUTCDate(weekStart.getUTCDate() - i * 7);
+    const weekKey = isoWeekKey(weekStart);
+    const trainedDays = daysByWeek.get(weekKey)?.size ?? 0;
+    const onStreak = weeklyFrequency
+      ? trainedDays >= weeklyFrequency
+      : trainedDays >= 1;
+    weeks.push({
+      weekKey,
+      weekStartIso: weekStart.toISOString(),
+      trainedDays,
+      onStreak,
+      isCurrent: weekKey === currentWeekKey,
+    });
+  }
+
+  // Count the streak backwards from the newest week. The current (partial) week
+  // not yet on streak is skipped rather than breaking the run.
+  let currentStreak = 0;
+  for (let i = weeks.length - 1; i >= 0; i--) {
+    const week = weeks[i]!;
+    if (week.onStreak) {
+      currentStreak++;
+    } else if (week.isCurrent) {
+      // Partial current week with no qualifying training yet: do not break.
+      continue;
+    } else {
+      break;
+    }
+  }
+
+  return { weeks, currentStreak, weeklyFrequency };
+}


### PR DESCRIPTION
Adds a read-only training-consistency card to the progress page, derived entirely from existing finished `Session` data.

## What
- New pure helper `trainingConsistency` in `lib/stats.ts`: buckets finished sessions into the last N ISO weeks (reusing `isoWeekKey`/`isoWeekStart`), counts distinct trained calendar days per week (de-duplicating multiple sessions on the same day), and computes the current consecutive-weeks streak.
- Streak rule: a week is on-streak with >=1 trained day, or when it meets the user's `weeklyFrequency` target if one is set (a non-positive target is ignored). The partial current week never breaks the streak.
- New `components/progress/consistency-card.tsx`: compact card showing the current streak plus a per-week trained-days bar, reusing the existing `Card` primitive. Empty history still uses the existing `EmptyState`.
- Unit tests cover: empty history (zero streak, no crash), unbroken run, gap breaking the streak, same-day de-dup, partial current week, `weeklyFrequency` target, ignored zero target, and window clamping.

## Constraints
Additive only: no schema/migration, no new API route, no LLM-contract or dependency change.

Closes #71

`scripts/verify.sh` passed; skeptic code-review (high) clean.