### PR TITLE
docs: write up the first ideate batch (warm-up, PR badge, consistency card)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   1-5 scales, plus optional per-muscle-group soreness and a short note): skippable,
   never blocks starting a session, and feeds the AI coach as one more
   auto-regulation signal when it is recent.
+- In-workout warm-up set calculator: from the set logger, suggest a short ramp of
+  warm-up sets (40/60/80 percent of the working weight, descending reps) in your
+  display unit, each rounded down to a loadable increment (2.5 kg / 5 lb) and
+  clamped to stay below the working weight, with an empty-bar lead-off set. It is
+  display-only and never creates or mutates a set.
+- Personal-record badge: a working set is flagged when it moves a heavier load than
+  ever before, or when its estimated 1RM (Epley) beats your best prior estimate, for
+  the same exercise. Records are derived on read from existing set history (no
+  records table, no migration); warm-up sets are excluded and ties never count.
+- Training consistency card on the progress page: per-week trained days over the
+  last 12 ISO weeks plus the current streak of consecutive on-streak weeks, derived
+  on read from finished sessions (no new model). A week is on streak when it has at
+  least one trained day, or meets your weekly-frequency target when one is set; the
+  partial current week does not break the streak.
 - Test pyramid (unit, integration, E2E) with CI running lint, typecheck, unit,
   integration, build, and E2E on every pull request.
 - Docker and Docker Compose setup for local development and production.
@@ -57,8 +71,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   English.
 - Grew the autonomous-loop maintenance infrastructure into a full self-maintenance
   pipeline: the green-gate (`scripts/verify.sh`); the `implement-issue`, `triage`,
-  `ship-pr`, and `write-up` skills; an autonomy charter with guardrails; and the
-  loop playbook in `docs/loops/`.
+  `ship-pr`, `ideate`, and `write-up` skills; an autonomy charter with guardrails;
+  and the loop playbook in `docs/loops/`, including the ideation loop that
+  manufactures product feature ideas so the loop grows the product (not just the
+  repo) and the memory/learning/regrounding architecture that frames the loop as a
+  feedback control system.
 - Sharpened the AI coach's positioning: it advises within your program rather than
   silently restructuring it, always explains the why behind a suggestion, and
   frames generated programs as editable drafts. The program-adjustment output

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -6,6 +6,65 @@ by the charter in [`07-autonomy.md`](07-autonomy.md).
 
 ---
 
+## 2026-06-09 - The loop starts growing the product: ideation + the first ideate batch
+
+**Context.** A multi-tick session that closed the gap between "the loop maintains the repo"
+and "the loop grows the product", then proved the public-repo guardrail under a real attack.
+This docs run is the content-loop tail that records it.
+
+**Shipped this arc.**
+- **Ideation loop (#68) + first ideate run (#73).** Added the `ideate` skill and
+  `docs/loops/08-ideation-loop.md`: when ship and triage have nothing, manufacture
+  well-scoped, single-PR product feature ideas grounded in the product vision and the
+  captured competitor research, and file them as crisp issues. The first run proposed three
+  (issues #69/#70/#71) and rejected the gaps that did not fit one tight PR (bodyweight history,
+  supersets, CSV import), logged in `ideas-backlog.md`.
+- **Memory / learning / regrounding architecture (#74).** Added
+  `docs/loops/09-memory-and-learning.md`: the loop framed as a cybernetic feedback control
+  system - setpoint (the product vision + charter), externalized durable memory (git + GitHub +
+  files, not the session), lessons that graduate into skills, and regrounding each tick. It
+  also states what we deliberately do not build (vector RAG, parallel writers, unbounded
+  memory) and why.
+- **First ideate batch shipped (issues #69/#70/#71 via PRs #75/#76/#77).** The first product
+  features the ideation loop produced, each additive, derived-on-read, no migration:
+  - **#75 / #69 - warm-up set calculator.** Confirmed against `lib/warmup.ts`: a pure
+    `computeWarmupRamp` producing 40/60/80 percent stages with descending reps in the display
+    unit, rounded down to a loadable increment (2.5 kg / 5 lb), clamped below the working
+    weight, de-duplicated, with an empty-bar lead-off; display-only, never mutates a set.
+  - **#76 / #70 - personal-record badge.** Confirmed against `lib/records.ts`: `detectPRs`
+    returns `'weight'` (heaviest non-warmup load) and/or `'e1rm'` (Epley estimate beats the
+    best prior) by comparing a candidate against prior history; warm-ups excluded, strict
+    comparisons so ties never flag, no records table.
+  - **#77 / #71 - training consistency card.** Confirmed against `lib/stats.ts`
+    `trainingConsistency`: distinct trained days per ISO week over a 12-week window plus the
+    current streak of consecutive on-streak weeks, with an optional weekly-frequency target and
+    a partial current week that does not break the streak; rendered by
+    `components/progress/consistency-card.tsx` on the progress page.
+- **Public-repo guardrail proven by the #57 red-team + CI hardening (#67).** The trust gate
+  closed external issue #57 as not-planned (untrusted authorship; never promoted to
+  auto-implementable), validating the #56 hardening under a real probe. CI was modernized for
+  Node 24 runners and the Postgres image pull hardened (#67).
+
+**Challenged / verified.** Docs-only, so verification-first rather than a code subagent: every
+CHANGELOG and log claim was read out of `lib/warmup.ts`, `lib/records.ts`, and `lib/stats.ts`
+before writing it, not trusted from the PR summaries. One correction caught this way: #71 ships
+a consistency *card*, and the `globalThis.Set` shadow workaround lives in `lib/stats.ts` (not
+`lib/records.ts`); recorded as lesson L6.
+
+**Lesson harvested.** L6 (Prisma's generated `Set` model shadows the global `Set`; use
+`globalThis.Set` in lib that touches both) - accepted risk. The mid-batch "job was not acquired
+by Runner" GitHub Actions outage reconfirmed L2 (read the failing step; infra, re-run) - noted
+under L2 rather than as a new lesson.
+
+**Trust gate.** All documented PRs (#75/#76/#77) and the issues they closed (#69/#70/#71) were
+authored by `JulienAu`, on the maintainer allowlist. External issue #57 was correctly refused.
+
+**Deferred to human / operator.** The non-additive product ideas the ideate run rejected
+(bodyweight/measurement history, supersets/circuits, CSV import) stay parked for a human; dep
+majors and `bcrypt` 6 remain deferred.
+
+---
+
 ## 2026-06-09 - Chain everything: templates, readiness explainability + opt-out
 
 **Context.** Operator said "chain everything": run the full pipeline unsupervised under the

--- a/docs/loops/ideas-backlog.md
+++ b/docs/loops/ideas-backlog.md
@@ -9,9 +9,9 @@ research and the product wedge). See `docs/loops/08-ideation-loop.md` for how th
 
 ## Log
 
-- proposed - warm-up set calculator from the working weight (issue #69, 2026-06-09) - pure lib/warmup.ts + display-only dialog, additive
-- proposed - detect personal records (heaviest set + best e1RM) and surface a badge (issue #70, 2026-06-09) - pure lib/records.ts on top of stats e1RM, derived on read, no table
-- proposed - training consistency calendar (sessions-per-week + current streak) (issue #71, 2026-06-09) - read-only derivation on the progress page, no new model
+- shipped - warm-up set calculator from the working weight (issue #69, 2026-06-09) - pure lib/warmup.ts + display-only dialog, additive
+- shipped - detect personal records (heaviest set + best e1RM) and surface a badge (issue #70, 2026-06-09) - pure lib/records.ts on top of stats e1RM, derived on read, no table
+- shipped - training consistency calendar (sessions-per-week + current streak) (issue #71, 2026-06-09) - read-only derivation on the progress page, no new model
 - rejected - bodyweight/body-measurement trend (2026-06-09) - needs a non-additive history table; no safe single-PR slice; left for a human
 - rejected - supersets/circuits (2026-06-09) - needs a schema change (non-additive)
 - rejected - CSV import from Strong/Hevy (2026-06-09) - large parser + untrusted-input handling; bigger than one tight PR

--- a/docs/loops/lessons.md
+++ b/docs/loops/lessons.md
@@ -34,6 +34,9 @@ Format per entry: trigger/evidence, the lesson (actionable), and **Status** = `g
   mirror; the action runtimes bumped `checkout@v5`/`setup-node@v5` (which run on Node 24) and
   CI `node-version` 20 -> 22 to match the nvm toolchain (#67). Re-check-merged behavior: ship
   one PR at a time and let the gate run on the merged result (accepted process, noted in `09`).
+  Reconfirmed during the first ideate batch: a "job was not acquired by Runner" failure (GitHub
+  Actions infra, not a step in our workflow) was read as infra and re-run, not treated as a
+  regression - exactly the L2 discipline.
 
 ### L3 - The orchestrator owns CI-watch and merge; subagents stop at the PR
 - **Trigger:** background maintainer-tick agents repeatedly terminated early - they ended
@@ -58,3 +61,16 @@ Format per entry: trigger/evidence, the lesson (actionable), and **Status** = `g
   (`gh issue comment` then `gh issue close`); do not assume the newest `gh` surface.
 - **Status:** accepted risk - operational quirk of this environment, not worth encoding in a
   product skill; recorded here so future runs do not rediscover it.
+
+### L6 - Prisma's generated `Set` model type shadows the global `Set`
+- **Trigger:** the consistency-card lib (#71) needed a `Set<string>` of distinct trained days,
+  but `import type { Set } from '@prisma/client'` (the workout-set model) is in scope across
+  `lib/`, so a bare `Set<string>` / `new Set()` resolves to the Prisma model and the typecheck
+  fails (`lib/stats.ts`).
+- **Lesson:** in any `lib` module that touches both the Prisma `Set` model and JS collections,
+  reference the runtime `Set` via `globalThis.Set` (type `globalThis.Set<...>`,
+  value `new globalThis.Set(...)`) rather than the bare name. See `lib/stats.ts`
+  `trainingConsistency`.
+- **Status:** accepted risk - a narrow naming collision specific to this schema's `Set` model,
+  not a recurring loop behavior; recorded so future `lib` work does not rediscover it under a
+  red typecheck.


### PR DESCRIPTION
Write-up of the first product features produced by the ideation loop, each verified against the merged code (not the PR summaries):

- **#75 (closed #69)** in-session warm-up set calculator - confirmed against `lib/warmup.ts` (40/60/80 percent ramp, descending reps, rounded to a loadable increment, clamped below the working weight, display-only).
- **#76 (closed #70)** personal-record badge - confirmed against `lib/records.ts` (`detectPRs`: heaviest load + best Epley e1RM, derived on read, warm-ups excluded, ties never flag).
- **#77 (closed #71)** training consistency card - confirmed against `lib/stats.ts` `trainingConsistency` (12-week trained-days window + current streak, optional weekly-frequency target, partial current week does not break the streak).

Docs touched:
- **CHANGELOG.md** - three Added lines; the loop-infra Changed line extended for the `ideate` skill + memory/learning playbook.
- **docs/loops/ideas-backlog.md** - the three ideas moved `proposed -> shipped`.
- **docs/loops/lessons.md** - L6 (Prisma's `Set` model shadows the global `Set`; use `globalThis.Set`) as accepted risk; L2 reconfirmed by the "job was not acquired by Runner" Actions outage.
- **docs/loops/autonomy-log.md** - one entry for the session arc (ideation loop #68, memory architecture #74, the first ideate batch, the #57 red-team + CI hardening #67).

One correction caught by verifying: #71 ships a consistency *card* and the `globalThis.Set` workaround lives in `lib/stats.ts` (not `lib/records.ts` as the brief said).

Docs only; no product code.

verify.sh passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)