### PR TITLE
feat(loops): comprehension digest - a per-batch human reading list

### DIFF
--- a/.claude/skills/write-up/SKILL.md
+++ b/.claude/skills/write-up/SKILL.md
@@ -35,6 +35,14 @@ commit on an existing docs branch.
    behavior changes next time, then record the entry pointing at that change; otherwise mark
    it accepted risk. Do not just append prose - an un-acted lesson is noise. Prune/dedupe so
    the file stays high-signal. See `docs/loops/09-memory-and-learning.md`.
+5. **docs/loops/review-digest.md** - append a dated **comprehension digest**: the antidote to
+   comprehension debt (the loop ships faster than the human reads). For the batch, list what
+   merged, then call out the **few diffs the human should read FIRST**, ranked by risk x
+   impact - auth/security, schema/migrations, core behavior (progression/stats), LLM prompts,
+   and CI/pipeline rank highest; additive UI, tests, and docs rank lowest (the skeptic + the
+   gate cover those). Give each priority item a `gh pr diff <n>` pointer and a one-line "why
+   read this". Keep it short - a reading list, not a re-summary; "reviewed by a sub-agent" is
+   not "understood by the human".
 
 ## Procedure
 

--- a/.claude/skills/write-up/SKILL.md
+++ b/.claude/skills/write-up/SKILL.md
@@ -52,8 +52,10 @@ commit on an existing docs branch.
    group and decide if it warrants a playbook/README change. **Verify each claim against
    the code or the merged diff** - never document a feature that is not actually there
    (this skill exists partly because a changelog drifts otherwise).
-3. **Write** the smallest accurate edits. English only, regular hyphens (no em/en-dash),
-   Keep a Changelog format.
+3. **Write** the smallest accurate edits - and do not skip items 4 and 5 of "What to keep
+   current": harvest/graduate any lesson into `lessons.md` (+ the skill/charter it changes),
+   and append the prioritized **comprehension digest** to `review-digest.md`. English only,
+   regular hyphens (no em/en-dash), Keep a Changelog format.
 4. **Green-gate** (`bash scripts/verify.sh`) - docs-only, but the working agreement is
    the working agreement.
 5. **Commit, push, PR** with `Closes #<n>` if a content issue exists, else a plain docs

--- a/docs/loops/09-memory-and-learning.md
+++ b/docs/loops/09-memory-and-learning.md
@@ -125,6 +125,13 @@ cybernetics paper + Anthropic's long-running-harness guidance):
   green-gate / CI / issue output and state what it says before deciding the next step. Do
   not plan past a failure signal.
 
+The same grounding principle applies to the **human**: the loop ships faster than anyone
+reads, so `docs/loops/review-digest.md` is a per-batch prioritized reading list (auth /
+security / schema / core behavior / prompts / CI first) that `write-up` appends to. It is
+the antidote to *comprehension debt* - the skeptic sub-agents gate correctness, but
+"reviewed by an agent" is not "understood by the human", and a smooth loop widens that gap
+unless the human reads the diffs that matter.
+
 ## 4. What we deliberately do NOT build (anti-hype)
 
 Capability we considered and rejected *at this scale*, with the trigger that would change

--- a/docs/loops/README.md
+++ b/docs/loops/README.md
@@ -31,7 +31,8 @@ This folder is the reproducible playbook. Read in order:
 - [`09-memory-and-learning.md`](09-memory-and-learning.md) - the loop as a control system:
   how it manages/compresses context (state in git, not the session), learns (layered
   filesystem memory + lessons that **graduate** into skills - no vector RAG), and regrounds
-  on its purpose. Staging area in [`lessons.md`](lessons.md).
+  on its purpose. Staging area in [`lessons.md`](lessons.md); the per-batch human reading
+  list (comprehension-debt antidote) in [`review-digest.md`](review-digest.md).
 
 ## The system at a glance
 

--- a/docs/loops/review-digest.md
+++ b/docs/loops/review-digest.md
@@ -1,0 +1,56 @@
+# Review digest (read this, so your understanding does not rot)
+
+The loop ships faster than any human reads. That gap is **comprehension debt**: the more the
+loop merges that you did not read, the less you actually understand your own product. This
+file is the antidote - after each batch, `write-up` appends a short, **prioritized reading
+list**: what merged, and which few diffs are worth your eyes *first*, ranked by risk x
+impact. The skeptic sub-agents already gate correctness; this keeps the *human* in the loop.
+
+Priority rule: **auth/security, schema/migrations, core behavior (progression/stats), LLM
+prompts, and CI/pipeline rank highest** (a wrong call there is expensive and quiet).
+Additive UI, tests, and docs rank lowest (a reviewer/skeptic + the gate catch most of it).
+Read a diff with `gh pr diff <n>`.
+
+---
+
+## 2026-06-09 - the big autonomous session (~27 merges)
+
+A lot shipped today. You do not need to read all of it. Read these **six first** - they
+touch auth, the security model, what weights users are told to lift, the AI's behavior, the
+database, and the pipeline:
+
+1. **#66 - bcrypt 5 -> 6 (auth).** `gh pr diff 66`. Password hashing for register/login. The
+   bcrypt API is unchanged and the auth E2E passed, but this is the one change that can lock
+   every user out if wrong. Confirm `bcrypt.hash`/`bcrypt.compare` usage is intact.
+2. **#56 - public-repo guardrail (security/trust model).** `gh pr diff 56`. Defines *who the
+   loop trusts* (login allowlist `{JulienAu, Julien-Au}`), prompt-injection refusal, and the
+   `curl`/`wget` deny. This is the boundary that keeps an open repo from steering the loop.
+   Make sure the trust model is the one you want.
+3. **#55 - readiness -> deterministic progression.** `gh pr diff 55`. `lib/progression.ts`
+   now lets soreness/readiness *hold or reduce* the suggested weight (never raise it),
+   backward-compatible. This changes the actual numbers a user is told to lift - read the
+   thresholds and the never-raises invariant.
+4. **#44 - coach prompt positioning.** `gh pr diff 44`. `lib/prompts/*`: the AI coach is
+   instructed to advise *within* the user's program and explain why, never silently rewrite.
+   Prompt wording is product behavior; read what the model is now told to do.
+5. **#43 - readiness/soreness check-in (schema + API).** `gh pr diff 43`. New
+   `ReadinessCheckin` Prisma model + `/api/readiness` (Zod-validated). The only new
+   data/table this session - confirm the model and validation.
+6. **#67 - CI modernization.** `gh pr diff 67`. `.github/workflows/ci.yml`: actions ->@v5
+   (Node 24 runtime), node-version 20->22, Postgres from the ECR Public mirror. Pipeline
+   changes affect every future merge's trust gate.
+
+**Skim (additive features - logic + UI + tests, lower risk):** #41 plate calculator, #42 &
+#62 program templates, #51 soreness/note UI, #63 readiness explainability badge, #64
+readiness opt-out preference, #75 warm-up calculator, #76 personal-record badge, #77
+training-consistency card. Each is additive, tested, and skeptic-reviewed; read the `lib/*`
+helper if the behavior matters to you, skip the wiring.
+
+**Trust the gate (docs / tests / in-range deps - no close read needed):** the loop-infra
+docs #68 (ideation loop) and #74 (memory/learning architecture) are worth reading as
+*narrative* if you want to understand how the loop now works; the changelog/log docs
+(#46/#50/#52/#58/#65/#73/#78), the readiness route tests #49, and the in-range dep bumps #45
+are safe to skip.
+
+> Honest note: the skeptics reviewed all of the above, but "reviewed by another agent" is
+> not "understood by you". If you read only six diffs from today, read the six above.


### PR DESCRIPTION
## Why

Acting on the "loop engineering" canon (Steinberger / Cherny) and our own `09-memory-and-learning.md`: the loop ships faster than a human reads, so **comprehension debt** grows - the gap between what the repo contains and what the maintainer actually understands. The skeptic sub-agents gate *correctness*, but "reviewed by an agent" is not "understood by the human". This adds the human-side antidote.

## What

- **`docs/loops/review-digest.md`** (new): after each batch, a short **prioritized reading list** - what merged, and the few diffs to read FIRST, ranked by risk x impact (auth/security, schema/migrations, core behavior like progression/stats, LLM prompts, and CI/pipeline rank highest; additive UI/tests/docs lowest). Seeded with today's ~27-merge session, naming the **six diffs to read first** (#66 bcrypt/auth, #56 trust model, #55 progression behavior, #44 coach prompts, #43 schema, #67 CI) and what is safe to skim.
- **`write-up` skill**: new step 5 appends the digest each run (a reading list, not a re-summary).
- **`09-memory-and-learning.md` + README**: link it as the human-side regrounding mechanism.

Docs + skill only; no app code, schema, or dependency change. CI gates it.