### PR TITLE
feat: surface personal records on the post-session summary

### DIFF
--- a/components/session/session-runner.tsx
+++ b/components/session/session-runner.tsx
@@ -129,6 +129,16 @@ export function SessionRunner({ session, lastPerformances, readiness, unit }: Se
     return out;
   }, [liveSets]);
 
+  // Prior-session sets per exercise, the PR baseline for the post-session
+  // summary (same source as the in-session badge: getLastPerformances).
+  const priorSetsByExercise = useMemo(() => {
+    const out: Record<string, { weight: number; reps: number }[]> = {};
+    for (const [exerciseId, perf] of Object.entries(lastPerformances)) {
+      out[exerciseId] = perf.sets.map((s) => ({ weight: s.weight, reps: s.reps }));
+    }
+    return out;
+  }, [lastPerformances]);
+
   const completedExerciseCount = useMemo(() => {
     let count = 0;
     for (const pe of programExercises) {
@@ -265,6 +275,7 @@ export function SessionRunner({ session, lastPerformances, readiness, unit }: Se
         sets={liveSets}
         programExercises={programExercises}
         unit={unit}
+        priorSets={priorSetsByExercise}
         onBack={() => setMode({ kind: 'input' })}
         onFinish={handleFinishSession}
         finishing={closing}

--- a/components/session/session-summary.test.tsx
+++ b/components/session/session-summary.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { Exercise, ProgramExercise, Session } from '@prisma/client';
+import type { PendingSet } from '@/lib/indexeddb';
+import { SessionSummary, computeSessionPRs } from './session-summary';
+
+const exo: Exercise = {
+  id: 'e1',
+  userId: 'u',
+  name: 'Squat',
+  muscleGroup: 'QUADS',
+  category: 'COMPOUND',
+  defaultRestSec: 120,
+  notes: null,
+  usesBodyweight: false,
+  createdAt: new Date(),
+};
+
+const pe: ProgramExercise & { exercise: Exercise } = {
+  id: 'pe',
+  workoutId: 'w',
+  exerciseId: 'e1',
+  order: 1,
+  targetSets: 3,
+  targetRepsMin: 6,
+  targetRepsMax: 10,
+  targetRIR: 2,
+  restSec: 120,
+  tempo: null,
+  notes: null,
+  exercise: exo,
+};
+
+function pendingSet(over: Partial<PendingSet>): PendingSet {
+  return {
+    localId: over.localId ?? 'l1',
+    sessionId: 's1',
+    exerciseId: 'e1',
+    setNumber: over.setNumber ?? 1,
+    weight: over.weight ?? 100,
+    reps: over.reps ?? 5,
+    rir: null,
+    notes: null,
+    isWarmup: over.isWarmup ?? false,
+    isDropSet: false,
+    createdAt: 0,
+    status: 'synced',
+    serverId: 'srv1',
+    syncedAt: 0,
+    attempts: 0,
+    lastError: null,
+    ...over,
+  };
+}
+
+const session = { id: 's1', startedAt: new Date(), notes: null } as unknown as Session;
+
+describe('computeSessionPRs', () => {
+  it('flags a weight PR when a working set beats the prior heaviest load', () => {
+    const prs = computeSessionPRs(
+      [pendingSet({ weight: 110, reps: 5 })],
+      [pe],
+      { e1: [{ weight: 100, reps: 5 }] },
+    );
+    expect(prs).toHaveLength(1);
+    const [first] = prs;
+    expect(first?.exerciseName).toBe('Squat');
+    expect(first?.types).toEqual(['weight', 'e1rm']);
+  });
+
+  it('flags an e1RM-only PR when more reps at the same load beat the best estimated 1RM', () => {
+    // Same load (no weight PR) but more reps -> higher Epley e1RM.
+    const prs = computeSessionPRs(
+      [pendingSet({ weight: 100, reps: 8 })],
+      [pe],
+      { e1: [{ weight: 100, reps: 5 }] },
+    );
+    expect(prs).toHaveLength(1);
+    expect(prs[0]?.types).toEqual(['e1rm']);
+  });
+
+  it('returns nothing when no set beats the prior session', () => {
+    const prs = computeSessionPRs(
+      [pendingSet({ weight: 100, reps: 5 })],
+      [pe],
+      { e1: [{ weight: 100, reps: 5 }] },
+    );
+    expect(prs).toHaveLength(0);
+  });
+
+  it('ignores warmup sets and never compares a set against itself', () => {
+    // First working set sets the bar; the second (lighter) one must not PR.
+    const prs = computeSessionPRs(
+      [
+        pendingSet({ localId: 'w', weight: 120, reps: 5, isWarmup: true }),
+        pendingSet({ localId: 'a', setNumber: 1, weight: 110, reps: 5 }),
+        pendingSet({ localId: 'b', setNumber: 2, weight: 105, reps: 5 }),
+      ],
+      [pe],
+      { e1: [{ weight: 100, reps: 5 }] },
+    );
+    expect(prs).toHaveLength(1);
+    // Only the heaviest-load type from the first set; the warmup at 120 is ignored.
+    expect(prs[0]?.types).toContain('weight');
+    expect(prs[0]?.bestWeight).toBe(110);
+  });
+});
+
+describe('SessionSummary PR section', () => {
+  it('renders the PR section when a record was set this session', () => {
+    render(
+      <SessionSummary
+        session={session}
+        sets={[pendingSet({ weight: 110, reps: 5 })]}
+        programExercises={[pe]}
+        unit="KG"
+        priorSets={{ e1: [{ weight: 100, reps: 5 }] }}
+        onBack={() => {}}
+        onFinish={() => {}}
+        finishing={false}
+      />,
+    );
+    expect(screen.getByText('Personal records this session')).toBeTruthy();
+    expect(screen.getByText('heaviest load')).toBeTruthy();
+  });
+
+  it('omits the PR section entirely when no record was set', () => {
+    render(
+      <SessionSummary
+        session={session}
+        sets={[pendingSet({ weight: 100, reps: 5 })]}
+        programExercises={[pe]}
+        unit="KG"
+        priorSets={{ e1: [{ weight: 100, reps: 5 }] }}
+        onBack={() => {}}
+        onFinish={() => {}}
+        finishing={false}
+      />,
+    );
+    expect(screen.queryByText('Personal records this session')).toBeNull();
+  });
+});

--- a/components/session/session-summary.tsx
+++ b/components/session/session-summary.tsx
@@ -1,28 +1,111 @@
 'use client';
 
 import { useState } from 'react';
-import { ChevronLeft, Check } from 'lucide-react';
+import { ChevronLeft, Check, Trophy } from 'lucide-react';
 import type { Exercise, ProgramExercise, Session, WeightUnit } from '@prisma/client';
 import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 import { toast } from 'sonner';
 import type { PendingSet } from '@/lib/indexeddb';
 import { formatWeight } from '@/lib/units';
+import { detectPRs, type PRType } from '@/lib/records';
+
+// Prior (previous-session) non-warmup sets per exerciseId, used as the PR
+// baseline. Same source as the in-session badge (getLastPerformances): a PR
+// here means "beats your last session", not an all-time record.
+type PriorSets = Record<string, { weight: number; reps: number }[]>;
 
 interface Props {
   session: Session;
   sets: PendingSet[];
   programExercises: (ProgramExercise & { exercise: Exercise })[];
   unit: WeightUnit;
+  // Previous-session sets per exercise; absent entries mean no prior history.
+  priorSets?: PriorSets;
   onBack: () => void;
   onFinish: () => Promise<void> | void;
   finishing: boolean;
 }
 
-export function SessionSummary({ session, sets, programExercises, unit, onBack, onFinish, finishing }: Props) {
+export interface SessionPR {
+  exerciseId: string;
+  exerciseName: string;
+  // The PR types achieved by any working set of this exercise this session.
+  types: PRType[];
+  // The heaviest working load of this session for the exercise (for display).
+  bestWeight: number;
+}
+
+const PR_TYPE_LABEL: Record<PRType, string> = {
+  weight: 'heaviest load',
+  e1rm: 'best est. 1RM',
+};
+
+// Computes which exercises set a personal record during this session. PR math
+// is reused from lib/records (detectPRs); the comparison baseline is the prior
+// session's sets plus any earlier working set of the same exercise this
+// session, so a set is never compared against itself.
+export function computeSessionPRs(
+  sets: PendingSet[],
+  programExercises: (ProgramExercise & { exercise: Exercise })[],
+  priorSets: PriorSets,
+): SessionPR[] {
+  const prs: SessionPR[] = [];
+  const seen = new Set<string>();
+
+  for (const pe of programExercises) {
+    // A workout may list the same exercise more than once; the PR is per
+    // exercise, so process each exerciseId at most once (also keeps React keys
+    // unique below).
+    if (seen.has(pe.exerciseId)) continue;
+    seen.add(pe.exerciseId);
+
+    const exoSets = sets.filter((s) => s.exerciseId === pe.exerciseId && !s.isWarmup);
+    if (exoSets.length === 0) continue;
+
+    const baseline = (priorSets[pe.exerciseId] ?? []).map((s) => ({ ...s, isWarmup: false }));
+    const achieved = new Set<PRType>();
+    const earlier: { weight: number; reps: number; isWarmup: boolean }[] = [];
+
+    for (const set of exoSets) {
+      const candidate = { weight: set.weight, reps: set.reps, isWarmup: false };
+      for (const type of detectPRs(candidate, [...baseline, ...earlier])) {
+        achieved.add(type);
+      }
+      earlier.push(candidate);
+    }
+
+    if (achieved.size === 0) continue;
+
+    // Preserve a stable type order: weight before e1rm.
+    const types: PRType[] = (['weight', 'e1rm'] as PRType[]).filter((t) => achieved.has(t));
+    prs.push({
+      exerciseId: pe.exerciseId,
+      exerciseName: pe.exercise.name,
+      types,
+      bestWeight: Math.max(...exoSets.map((s) => s.weight)),
+    });
+  }
+
+  return prs;
+}
+
+export function SessionSummary({
+  session,
+  sets,
+  programExercises,
+  unit,
+  priorSets = {},
+  onBack,
+  onFinish,
+  finishing,
+}: Props) {
   const [notes, setNotes] = useState(session.notes ?? '');
+
+  const sessionPRs = computeSessionPRs(sets, programExercises, priorSets);
 
   const durationMin = Math.round(
     (Date.now() - new Date(session.startedAt).getTime()) / 60000,
@@ -77,6 +160,41 @@ export function SessionSummary({ session, sets, programExercises, unit, onBack, 
         <p className="text-xs text-muted-foreground">
           Volume = Σ (load × reps), {totalReps} reps total.
         </p>
+
+        {sessionPRs.length > 0 && (
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="flex items-center gap-2 text-base">
+                <Trophy className="size-4 text-primary" />
+                Personal records this session
+              </CardTitle>
+              <CardDescription>New bests versus your last session</CardDescription>
+            </CardHeader>
+            <CardContent className="pt-0">
+              <ul className="divide-y divide-border">
+                {sessionPRs.map((pr) => (
+                  <li
+                    key={pr.exerciseId}
+                    className="flex items-center justify-between gap-2 py-2 text-sm"
+                  >
+                    <span className="min-w-0 truncate font-medium">{pr.exerciseName}</span>
+                    <div className="flex flex-shrink-0 items-center gap-1.5">
+                      {pr.types.map((type) => (
+                        <Badge key={type} className="gap-1 text-xs">
+                          <Trophy className="size-3" />
+                          {PR_TYPE_LABEL[type]}
+                        </Badge>
+                      ))}
+                      <span className="text-xs text-muted-foreground">
+                        {formatWeight(pr.bestWeight, unit, { decimals: 2, group: false })}
+                      </span>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        )}
 
         <Card>
           <CardHeader className="pb-2">


### PR DESCRIPTION
Reuse `lib/records` `detectPRs` (shipped in #76) to surface the personal records hit during a just-finished session on the post-session summary (`components/session/session-summary.tsx`), which previously showed only volume + per-exercise max.

## What

- New "Personal records this session" section listing each exercise where a working (non-warmup) set this session was a PR; each entry shows whether it was a heaviest-load PR, a best estimated-1RM PR, or both.
- PR math is reused from `lib/records` (`detectPRs`) - no duplicated PR logic in the component.
- Baseline = the previous session's sets (`getLastPerformances`, same source as the in-session badge) plus the earlier working sets of the same exercise this session, so a set is never compared against itself.
- Section is omitted entirely when no PR was set; weights respect the user's unit via `formatWeight`.
- Defensive dedup so a workout listing the same exercise twice does not double-list a PR or collide React keys.

## Honest baseline

This is a since-last-session comparison (like #76's badge), not an all-time record. A PR badge means "beats your last session for this exercise."

## Scope

Additive and derived-on-read: no schema, route, migration, auth, or LLM-contract change.

## Tests

New `components/session/session-summary.test.tsx` covers the derivation (weight PR, e1RM-only PR, no-PR case, warmup-ignored / not-self-compared) and the render (section shown when a PR exists, omitted when none).

Closes #80

scripts/verify.sh passed; skeptic review clean (one real finding - duplicate-exerciseId React key collision - fixed and re-verified).