### PR TITLE
feat: MEV/MRV volume landmarks on the per-muscle volume view

### DIFF
--- a/app/(app)/progress/page.tsx
+++ b/app/(app)/progress/page.tsx
@@ -5,9 +5,14 @@ import { EmptyState } from '@/components/ui/empty-state';
 import { MUSCLE_GROUP_LABELS } from '@/lib/schemas/exercise';
 import {
   applyBodyweight,
+  classifyWeeklySets,
   exerciseProgress,
+  isoWeekKey,
   trainingConsistency,
+  weeklySetsByMuscleGroup,
   weeklyVolumeByMuscleGroup,
+  WEEKLY_SETS_MEV,
+  WEEKLY_SETS_MRV,
 } from '@/lib/stats';
 import { ProgressDashboard } from '@/components/progress/progress-dashboard';
 import { ConsistencyCard } from '@/components/progress/consistency-card';
@@ -141,6 +146,42 @@ export default async function ProgressPage({
     ),
   );
 
+  // Weekly working-set count per muscle group, for the MEV/MRV reference band.
+  // Set counts are load-agnostic, so no bodyweight adjustment is needed.
+  const weeklySetsPoints = weeklySetsByMuscleGroup(
+    weeklySetsRaw.map((s) => ({
+      isWarmup: s.isWarmup,
+      muscleGroup: s.exercise.muscleGroup,
+      sessionStartedAt: s.session.startedAt,
+    })),
+  );
+
+  // Classify the most recent completed (non-current) week against the band so
+  // the dashboard can flag below MEV / within / above MRV per muscle group.
+  // Falling back to the latest available week keeps a signal when only the
+  // current week has data.
+  const currentWeekKey = isoWeekKey(new Date());
+  const latestCompletedWeek =
+    [...weeklySetsPoints]
+      .reverse()
+      .find((w) => w.weekKey !== currentWeekKey) ??
+    weeklySetsPoints[weeklySetsPoints.length - 1];
+  const volumeLandmarks = latestCompletedWeek
+    ? {
+        weekKey: latestCompletedWeek.weekKey,
+        mev: WEEKLY_SETS_MEV,
+        mrv: WEEKLY_SETS_MRV,
+        byMuscleGroup: Object.fromEntries(
+          Object.entries(latestCompletedWeek.byMuscleGroup).map(
+            ([group, sets]) => [
+              group,
+              { sets, zone: classifyWeeklySets(sets) },
+            ],
+          ),
+        ),
+      }
+    : null;
+
   // Recap table: per exercise, first and last session in the period,
   // delta of the max load and the 1RM.
   const recapRows = await Promise.all(
@@ -233,6 +274,7 @@ export default async function ProgressPage({
                 byMuscleGroup: w.byMuscleGroup,
                 total: w.total,
               }))}
+              volumeLandmarks={volumeLandmarks}
               recap={recap}
               unit={unit}
             />

--- a/components/progress/progress-dashboard.tsx
+++ b/components/progress/progress-dashboard.tsx
@@ -14,7 +14,11 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
+import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { MUSCLE_GROUP_LABELS } from '@/lib/schemas/exercise';
+import type { MuscleGroup } from '@prisma/client';
+import type { VolumeLandmarkZone } from '@/lib/stats';
 import {
   Select,
   SelectContent,
@@ -48,13 +52,38 @@ interface SerializedWeeklyPoint {
   total: number;
 }
 
+// Per-muscle-group classification of the latest completed week against the
+// MEV/MRV band. Display-only; computed server-side in lib/stats.
+interface VolumeLandmarks {
+  weekKey: string;
+  mev: number;
+  mrv: number;
+  byMuscleGroup: Record<string, { sets: number; zone: VolumeLandmarkZone }>;
+}
+
 interface Props {
   exercises: { id: string; name: string; muscleGroup: string }[];
   selectedExerciseId: string | undefined;
   exercisePoints: ExerciseChartPoint[];
   weeklyPoints: SerializedWeeklyPoint[];
+  volumeLandmarks: VolumeLandmarks | null;
   recap: RecapRow[];
   unit: WeightUnit;
+}
+
+// Badge variant + short label per zone. Below MEV and above MRV are both
+// "off-target" (secondary/destructive); within the band reads as on-target.
+const ZONE_META: Record<
+  VolumeLandmarkZone,
+  { label: string; variant: 'default' | 'secondary' | 'destructive' }
+> = {
+  BELOW_MEV: { label: 'Below MEV', variant: 'secondary' },
+  WITHIN: { label: 'In range', variant: 'default' },
+  ABOVE_MRV: { label: 'Above MRV', variant: 'destructive' },
+};
+
+function muscleGroupLabel(group: string) {
+  return MUSCLE_GROUP_LABELS[group as MuscleGroup] ?? group;
 }
 
 // Stable palette for muscle groups (distinct HSL, accessible LCH).
@@ -89,6 +118,7 @@ export function ProgressDashboard({
   selectedExerciseId,
   exercisePoints,
   weeklyPoints,
+  volumeLandmarks,
   recap,
   unit,
 }: Props) {
@@ -138,6 +168,14 @@ export function ProgressDashboard({
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [weeklyPoints, unit]);
+
+  // Sort the landmark rows by descending set count for a readable list.
+  const landmarkRows = useMemo(() => {
+    if (!volumeLandmarks) return [];
+    return Object.entries(volumeLandmarks.byMuscleGroup)
+      .map(([group, info]) => ({ group, ...info }))
+      .sort((a, b) => b.sets - a.sets);
+  }, [volumeLandmarks]);
 
   const exerciseChartData = exercisePoints.map((p) => ({
     ...p,
@@ -265,6 +303,44 @@ export function ProgressDashboard({
           )}
         </CardContent>
       </Card>
+
+      {/* Volume landmarks: latest week vs the MEV/MRV band */}
+      {volumeLandmarks && landmarkRows.length > 0 && (
+        <Card>
+          <CardHeader className="pb-3">
+            <h2 className="text-base font-semibold">Volume landmarks</h2>
+            <p className="text-xs text-muted-foreground">
+              Working sets in {shortLabelFromWeekKey(volumeLandmarks.weekKey)}{' '}
+              vs a reference band of {volumeLandmarks.mev}-{volumeLandmarks.mrv}{' '}
+              sets/week per muscle group (MEV-MRV). General hypertrophy
+              defaults, not a prescription.
+            </p>
+          </CardHeader>
+          <CardContent>
+            <ul className="flex flex-col gap-2">
+              {landmarkRows.map((row) => {
+                const meta = ZONE_META[row.zone];
+                return (
+                  <li
+                    key={row.group}
+                    className="flex items-center justify-between gap-3 text-sm"
+                  >
+                    <span className="font-medium">
+                      {muscleGroupLabel(row.group)}
+                    </span>
+                    <span className="flex items-center gap-2">
+                      <span className="text-muted-foreground">
+                        {row.sets} {row.sets === 1 ? 'set' : 'sets'}
+                      </span>
+                      <Badge variant={meta.variant}>{meta.label}</Badge>
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Progress recap table */}
       <Card>

--- a/lib/stats.test.ts
+++ b/lib/stats.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   applyBodyweight,
   best1RM,
+  classifyWeeklySets,
   effectiveWeight,
   estimate1RM,
   exerciseProgress,
@@ -10,7 +11,10 @@ import {
   setVolume,
   totalVolume,
   trainingConsistency,
+  weeklySetsByMuscleGroup,
   weeklyVolumeByMuscleGroup,
+  WEEKLY_SETS_MEV,
+  WEEKLY_SETS_MRV,
 } from './stats';
 
 describe('setVolume / totalVolume', () => {
@@ -175,6 +179,85 @@ describe('weeklyVolumeByMuscleGroup', () => {
     expect(w18.total).toBe(80 * 10 + 60 * 12 + 100 * 8);
     expect(w19.weekKey).toBe('2026-W19');
     expect(w19.byMuscleGroup.CHEST).toBe(82.5 * 10);
+  });
+});
+
+describe('weeklySetsByMuscleGroup', () => {
+  it('counts working sets per ISO week and muscle group', () => {
+    const sets = [
+      // week 18 (Monday 2026-04-27): 2 chest + 1 back
+      {
+        isWarmup: false,
+        muscleGroup: 'CHEST',
+        sessionStartedAt: new Date('2026-04-27T10:00:00Z'),
+      },
+      {
+        isWarmup: false,
+        muscleGroup: 'CHEST',
+        sessionStartedAt: new Date('2026-04-29T10:00:00Z'),
+      },
+      {
+        isWarmup: false,
+        muscleGroup: 'BACK_WIDTH',
+        sessionStartedAt: new Date('2026-04-29T10:00:00Z'),
+      },
+      // week 19 (Monday 2026-05-04): 1 chest working + 1 warmup ignored
+      {
+        isWarmup: false,
+        muscleGroup: 'CHEST',
+        sessionStartedAt: new Date('2026-05-04T10:00:00Z'),
+      },
+      {
+        isWarmup: true,
+        muscleGroup: 'CHEST',
+        sessionStartedAt: new Date('2026-05-04T10:00:00Z'),
+      },
+    ];
+    const points = weeklySetsByMuscleGroup(sets);
+    expect(points).toHaveLength(2);
+    const w18 = points[0]!;
+    const w19 = points[1]!;
+    expect(w18.weekKey).toBe('2026-W18');
+    expect(w18.byMuscleGroup.CHEST).toBe(2);
+    expect(w18.byMuscleGroup.BACK_WIDTH).toBe(1);
+    expect(w18.total).toBe(3);
+    expect(w19.weekKey).toBe('2026-W19');
+    expect(w19.byMuscleGroup.CHEST).toBe(1);
+    expect(w19.total).toBe(1);
+  });
+
+  it('returns an empty list when there are no working sets', () => {
+    expect(
+      weeklySetsByMuscleGroup([
+        {
+          isWarmup: true,
+          muscleGroup: 'CHEST',
+          sessionStartedAt: new Date('2026-05-04T10:00:00Z'),
+        },
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe('classifyWeeklySets (MEV/MRV band)', () => {
+  it('uses the documented defaults of 10 (MEV) and 20 (MRV)', () => {
+    expect(WEEKLY_SETS_MEV).toBe(10);
+    expect(WEEKLY_SETS_MRV).toBe(20);
+  });
+
+  it('classifies at the band boundaries', () => {
+    expect(classifyWeeklySets(0)).toBe('BELOW_MEV');
+    expect(classifyWeeklySets(9)).toBe('BELOW_MEV');
+    expect(classifyWeeklySets(10)).toBe('WITHIN'); // MEV inclusive
+    expect(classifyWeeklySets(15)).toBe('WITHIN');
+    expect(classifyWeeklySets(20)).toBe('WITHIN'); // MRV inclusive
+    expect(classifyWeeklySets(21)).toBe('ABOVE_MRV');
+  });
+
+  it('honours overridden thresholds', () => {
+    expect(classifyWeeklySets(8, 6, 12)).toBe('WITHIN');
+    expect(classifyWeeklySets(5, 6, 12)).toBe('BELOW_MEV');
+    expect(classifyWeeklySets(13, 6, 12)).toBe('ABOVE_MRV');
   });
 });
 

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -181,6 +181,81 @@ export function weeklyVolumeByMuscleGroup(
 }
 
 // ============================================================
+// Volume landmarks (weekly working sets per muscle group)
+// ============================================================
+
+// Default volume landmarks, expressed in weekly working (non-warmup) sets per
+// muscle group. These are general hypertrophy heuristics (renaissance-
+// periodization style), not medical truth: a single conservative band applied
+// uniformly to every muscle group. They are intended as adjustable reference
+// defaults so a user can gauge whether a week sits below, within, or above the
+// productive range.
+//
+// - MEV (minimum effective volume): the floor below which growth stimulus is
+//   typically too low to drive progress.
+// - MRV (maximum recoverable volume): the ceiling above which fatigue tends to
+//   outpace recovery.
+export const WEEKLY_SETS_MEV = 10;
+export const WEEKLY_SETS_MRV = 20;
+
+// Where a weekly working-set count falls relative to the MEV/MRV band.
+export type VolumeLandmarkZone = 'BELOW_MEV' | 'WITHIN' | 'ABOVE_MRV';
+
+// Classifies a weekly working-set count against the band. The band is inclusive
+// at both bounds: counts < MEV are below, counts > MRV are above, and the
+// MEV..MRV range (endpoints included) is within. Defaults are overridable.
+export function classifyWeeklySets(
+  sets: number,
+  mev: number = WEEKLY_SETS_MEV,
+  mrv: number = WEEKLY_SETS_MRV,
+): VolumeLandmarkZone {
+  if (sets < mev) return 'BELOW_MEV';
+  if (sets > mrv) return 'ABOVE_MRV';
+  return 'WITHIN';
+}
+
+export interface WeeklySetsPoint {
+  weekKey: string; // YYYY-Www
+  weekStart: Date; // Monday 00:00 UTC
+  // Working-set count per muscle group. Absent groups count as 0.
+  byMuscleGroup: Record<string, number>;
+  total: number;
+}
+
+// Aggregates the weekly working-set count by muscle group. Mirrors
+// `weeklyVolumeByMuscleGroup` (same ISO-week bucketing and non-warmup filter),
+// but counts sets instead of summing load × reps. Display-only: this feeds the
+// MEV/MRV reference band and does not influence progression or coach logic.
+export function weeklySetsByMuscleGroup(
+  sets: (Pick<Set, 'isWarmup'> & {
+    muscleGroup: string;
+    sessionStartedAt: Date;
+  })[],
+): WeeklySetsPoint[] {
+  const byWeek = new Map<string, WeeklySetsPoint>();
+  for (const s of sets) {
+    if (s.isWarmup) continue;
+    const key = isoWeekKey(s.sessionStartedAt);
+    let entry = byWeek.get(key);
+    if (!entry) {
+      entry = {
+        weekKey: key,
+        weekStart: isoWeekStart(s.sessionStartedAt),
+        byMuscleGroup: {},
+        total: 0,
+      };
+      byWeek.set(key, entry);
+    }
+    entry.byMuscleGroup[s.muscleGroup] =
+      (entry.byMuscleGroup[s.muscleGroup] ?? 0) + 1;
+    entry.total += 1;
+  }
+  return [...byWeek.values()].sort(
+    (a, b) => a.weekStart.getTime() - b.weekStart.getTime(),
+  );
+}
+
+// ============================================================
 // Training consistency (per-week trained days + current streak)
 // ============================================================
 


### PR DESCRIPTION
Adds MEV/MRV volume landmarks to the per-muscle weekly volume view.

- `lib/stats.ts`: `WEEKLY_SETS_MEV` (10) / `WEEKLY_SETS_MRV` (20) constants (documented adjustable defaults, not medical truth), `weeklySetsByMuscleGroup` (weekly working-set counts, mirrors `weeklyVolumeByMuscleGroup`), and `classifyWeeklySets` (below MEV / within / above MRV, inclusive bounds).
- Progress page derives the latest completed week's per-muscle zone and passes it to the dashboard. Read-only: no schema, route, progression, or coach change.
- Dashboard renders a "Volume landmarks" card with a badge per muscle group, reusing the existing Badge/Card primitives.
- Unit tests cover the set aggregation and the band boundaries (9/10/20/21) plus overridden thresholds.

Closes #81

scripts/verify.sh passed; skeptic review clean.