### PR TITLE
feat: detect stalled lifts and flag them on the progress page

### DIFF
--- a/app/(app)/progress/page.tsx
+++ b/app/(app)/progress/page.tsx
@@ -6,6 +6,7 @@ import { MUSCLE_GROUP_LABELS } from '@/lib/schemas/exercise';
 import {
   applyBodyweight,
   exerciseProgress,
+  isStalled,
   trainingConsistency,
   weeklyVolumeByMuscleGroup,
 } from '@/lib/stats';
@@ -190,6 +191,8 @@ export default async function ProgressPage({
         firstE1RM: first.estimated1RM,
         lastE1RM: last.estimated1RM,
         e1rmDelta: +(last.estimated1RM - first.estimated1RM).toFixed(1),
+        // Read-only flag: e1RM has not improved over the recent sessions.
+        stalled: isStalled(points.map((p) => p.estimated1RM)),
       };
     }),
   );

--- a/components/progress/progress-dashboard.tsx
+++ b/components/progress/progress-dashboard.tsx
@@ -15,6 +15,7 @@ import {
   YAxis,
 } from 'recharts';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
 import {
   Select,
   SelectContent,
@@ -23,7 +24,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import type { WeightUnit } from '@prisma/client';
-import type { ExerciseChartPoint } from '@/lib/stats';
+import { STALL_LOOKBACK_SESSIONS, type ExerciseChartPoint } from '@/lib/stats';
 import { roundWeight, toDisplayWeight, unitLabel } from '@/lib/units';
 
 interface RecapRow {
@@ -39,6 +40,7 @@ interface RecapRow {
   firstE1RM: number;
   lastE1RM: number;
   e1rmDelta: number;
+  stalled: boolean;
 }
 
 interface SerializedWeeklyPoint {
@@ -112,6 +114,9 @@ export function ProgressDashboard({
   }
 
   const selectedExo = exercises.find((e) => e.id === selectedExerciseId);
+
+  // Read-only summary: exercises whose e1RM has plateaued recently.
+  const stalledLifts = recap.filter((r) => r.stalled);
 
   // For the stacked bar chart: collect the groups present.
   const presentMuscleGroups = useMemo(() => {
@@ -266,6 +271,34 @@ export function ProgressDashboard({
         </CardContent>
       </Card>
 
+      {/* Stalled lifts: e1RM flat over the recent sessions (read-only) */}
+      {stalledLifts.length > 0 && (
+        <Card>
+          <CardHeader className="pb-3">
+            <h2 className="text-base font-semibold">Stalled lifts</h2>
+            <p className="text-xs text-muted-foreground">
+              No estimated 1RM progress over the last {STALL_LOOKBACK_SESSIONS}{' '}
+              sessions. Consider a deload, a rep-range change, or swapping the
+              exercise.
+            </p>
+          </CardHeader>
+          <CardContent>
+            <ul className="flex flex-wrap gap-2">
+              {stalledLifts.map((r) => (
+                <li key={r.exerciseId}>
+                  <Badge
+                    variant="secondary"
+                    className="text-amber-700 dark:text-amber-400"
+                  >
+                    {r.exerciseName}
+                  </Badge>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      )}
+
       {/* Progress recap table */}
       <Card>
         <CardHeader className="pb-3">
@@ -292,7 +325,18 @@ export function ProgressDashboard({
                   {recap.map((r) => (
                     <tr key={r.exerciseId} className="border-b border-border/40">
                       <td className="py-2">
-                        <div className="font-medium">{r.exerciseName}</div>
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium">{r.exerciseName}</span>
+                          {r.stalled && (
+                            <Badge
+                              variant="secondary"
+                              className="text-[10px] font-medium uppercase tracking-wide text-amber-700 dark:text-amber-400"
+                              title={`No estimated 1RM progress over the last ${STALL_LOOKBACK_SESSIONS} sessions.`}
+                            >
+                              Stalled
+                            </Badge>
+                          )}
+                        </div>
                         <div className="text-xs text-muted-foreground">
                           {r.muscleGroup}
                         </div>

--- a/lib/stats.test.ts
+++ b/lib/stats.test.ts
@@ -7,7 +7,10 @@ import {
   exerciseProgress,
   isoWeekKey,
   isoWeekStart,
+  isStalled,
   setVolume,
+  STALL_LOOKBACK_SESSIONS,
+  STALL_TOLERANCE,
   totalVolume,
   trainingConsistency,
   weeklyVolumeByMuscleGroup,
@@ -316,5 +319,60 @@ describe('trainingConsistency', () => {
   it('clamps the window to the requested number of weeks', () => {
     const out = trainingConsistency([], { now, windowWeeks: 4 });
     expect(out.weeks).toHaveLength(4);
+  });
+});
+
+describe('isStalled', () => {
+  it('uses a default lookback of 3 sessions', () => {
+    expect(STALL_LOOKBACK_SESSIONS).toBe(3);
+  });
+
+  it('flags a flat lift over the lookback window', () => {
+    // Reached 100 earlier, then held flat: the last 3 sessions never beat the
+    // prior best of 100.
+    expect(isStalled([95, 100, 100, 100, 100])).toBe(true);
+  });
+
+  it('flags a strictly declining lift', () => {
+    expect(isStalled([110, 105, 100])).toBe(true);
+  });
+
+  it('does not flag a clearly progressing lift', () => {
+    expect(isStalled([100, 105, 110])).toBe(false);
+  });
+
+  it('does not flag when the latest session beats the prior best', () => {
+    // Prior best 100; the window dips then exceeds it -> still progressing.
+    expect(isStalled([100, 98, 102])).toBe(false);
+  });
+
+  it('does not flag with fewer than the lookback number of sessions', () => {
+    expect(isStalled([100, 100])).toBe(false);
+    expect(isStalled([100])).toBe(false);
+    expect(isStalled([])).toBe(false);
+  });
+
+  it('treats sub-tolerance growth as no improvement (still stalled)', () => {
+    // +0.4% < 0.5% tolerance -> noise, not progress.
+    const within = 100 * (1 + STALL_TOLERANCE * 0.8);
+    expect(isStalled([100, within, within])).toBe(true);
+  });
+
+  it('treats above-tolerance growth as improvement (not stalled)', () => {
+    // +0.6% > 0.5% tolerance -> a genuine gain.
+    const above = 100 * (1 + STALL_TOLERANCE * 1.2);
+    expect(isStalled([100, 100, above])).toBe(false);
+  });
+
+  it('honours a custom lookback', () => {
+    // Lookback 2: the window [100, 100] must beat the prior best (100) to count
+    // as progress; it does not, so the lift is stalled. With a higher final
+    // session it would improve and clear the flag.
+    expect(isStalled([100, 100, 100], 2)).toBe(true);
+    expect(isStalled([100, 100, 105], 2)).toBe(false);
+  });
+
+  it('never flags with a lookback below 2', () => {
+    expect(isStalled([100, 100, 100], 1)).toBe(false);
   });
 });

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -140,6 +140,54 @@ export function exerciseProgress(
   return points.sort((a, b) => a.sessionStartedAt.getTime() - b.sessionStartedAt.getTime());
 }
 
+// ============================================================
+// Stalled-lift detection (flat / declining e1RM over recent sessions)
+// ============================================================
+
+// How many of the most recent sessions to judge a stall over. A lift is
+// flagged when, across these sessions, the best estimated 1RM never improves
+// on the prior best (within tolerance). Defined once so it lives in one place.
+export const STALL_LOOKBACK_SESSIONS = 3;
+
+// Relative tolerance: an e1RM counts as an improvement only when it exceeds the
+// prior best by more than this fraction (0.5%). Keeps rounding/noise from
+// masking a genuine plateau.
+export const STALL_TOLERANCE = 0.005;
+
+// Pure stall test over an exercise's per-session best-e1RM series (oldest ->
+// newest). Returns true when, over the last `lookback` sessions, no session
+// improves on the best e1RM seen before that window (and within the window).
+// Never flags with fewer than `lookback` sessions (insufficient data).
+export function isStalled(
+  e1rmSeries: number[],
+  lookback: number = STALL_LOOKBACK_SESSIONS,
+): boolean {
+  if (lookback < 2) return false;
+  if (e1rmSeries.length < lookback) return false;
+
+  const windowStart = e1rmSeries.length - lookback;
+  // Best e1RM established strictly before the lookback window. With no prior
+  // history (window covers the whole series), the first window entry is the
+  // baseline the rest must beat.
+  let bestBefore = 0;
+  for (let i = 0; i < windowStart; i++) {
+    if (e1rmSeries[i]! > bestBefore) bestBefore = e1rmSeries[i]!;
+  }
+
+  let baseline = windowStart === 0 ? e1rmSeries[0]! : bestBefore;
+  const startIdx = windowStart === 0 ? 1 : windowStart;
+
+  for (let i = startIdx; i < e1rmSeries.length; i++) {
+    const value = e1rmSeries[i]!;
+    // Improvement = strictly above the running best, beyond tolerance.
+    if (value > baseline * (1 + STALL_TOLERANCE)) {
+      return false;
+    }
+    if (value > baseline) baseline = value;
+  }
+  return true;
+}
+
 export interface WeeklyVolumePoint {
   weekKey: string; // YYYY-Www
   weekStart: Date; // Monday 00:00 UTC


### PR DESCRIPTION
Adds a pure stalled-lift derivation and surfaces it read-only on the progress page.

## What

- `lib/stats.ts`: new pure `isStalled(e1rmSeries, lookback?)` helper plus named constants `STALL_LOOKBACK_SESSIONS` (default 3) and `STALL_TOLERANCE` (0.5%). A lift is flagged when, over its last N sessions, the best estimated 1RM never improves on the prior best beyond tolerance. Exercises with fewer than N sessions are never flagged.
- Progress page: computes the flag per recap row from the existing per-session e1RM series (no new query).
- Progress dashboard: a subtle "Stalled" badge next to flagged exercises in the recap table, plus a small "Stalled lifts" summary card. Non-stalled and low-data exercises show nothing.

Fully additive, derived-on-read: no schema change, no route change, no LLM call, no effect on progression or coach behavior.

## Tests

Unit tests cover a progressing lift (not stalled), a flat lift over the window (stalled), a declining lift (stalled), insufficient history (not flagged), and the tolerance boundary (sub- vs above-tolerance growth).

Closes #82

scripts/verify.sh passed; skeptic review (code-review, high) clean.