### PR TITLE
docs: write up the second ideate batch (#84/#85/#86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on read from finished sessions (no new model). A week is on streak when it has at
   least one trained day, or meets your weekly-frequency target when one is set; the
   partial current week does not break the streak.
+- Personal records on the post-session summary: a "Personal records this session"
+  card flags exercises that beat your last session, reusing the in-session PR math
+  (`detectPRs`) against a "since last session" baseline so a set is never compared
+  with itself. Heaviest load and best estimated 1RM are shown as separate badges;
+  warm-up sets are excluded.
+- Volume landmarks card on the progress page: weekly working-set counts per muscle
+  group classified against a default MEV/MRV band (10-20 sets/week) as below,
+  within, or above the productive range. Display-only reference defaults, derived
+  on read; warm-up sets are excluded and the band does not affect progression.
+- Stalled-lift detection on the progress page: a "Stalled lifts" card flags
+  exercises whose best estimated 1RM has not improved (beyond a 0.5 percent
+  tolerance) over the last three sessions. Pure derivation over existing set
+  history; needs at least three sessions before it can flag.
 - Test pyramid (unit, integration, E2E) with CI running lint, typecheck, unit,
   integration, build, and E2E on every pull request.
 - Docker and Docker Compose setup for local development and production.

--- a/docs/loops/06-orchestration.md
+++ b/docs/loops/06-orchestration.md
@@ -32,7 +32,10 @@ decides what to do next**. The maintainer loop's decision each tick:
    caps: <= 3 issues, no run while >= 3 idea issues are open, never the heavy
    deep-research workflow.)
 4. **Is there an actionable issue?** -> implement the next one (-> a PR, which next tick's
-   step 1 will ship).
+   step 1 will ship). If two queued issues touch the **same file(s)**, serialize: implement
+   one, wait for its PR to actually **merge**, then implement the next from the updated `main`.
+   Do not overlap same-file tasks, or the second branch cuts from a stale base and hits a merge
+   conflict (lesson L7). Unrelated tasks may still overlap at the stage level (see `09`).
 5. **Did things merge since the last write-up?** -> run the content loop.
 6. **Nothing to do on any of the above?** -> stop. A clean idle is success, not failure.
 

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -6,6 +6,49 @@ by the charter in [`07-autonomy.md`](07-autonomy.md).
 
 ---
 
+## 2026-06-09 - Second ideate batch (#80/#81/#82 via #84/#85/#86)
+
+**Context.** The second batch of ideate-produced product features shipped autonomously; this
+docs run is the content-loop tail that records it.
+
+**Shipped this batch.** Three additive, derived-on-read features, no schema/migration:
+- **#84 / #80 - personal records on the post-session summary.** Confirmed against
+  `components/session/session-summary.tsx`: `computeSessionPRs` reuses `lib/records` `detectPRs`
+  against a "since last session" baseline (prior-session sets + earlier sets this session), so a
+  set is never compared with itself; warm-ups excluded; renders a "Personal records this session"
+  card with heaviest-load / best-e1RM badges.
+- **#85 / #81 - MEV/MRV volume landmarks.** Confirmed against `lib/stats.ts`:
+  `WEEKLY_SETS_MEV=10`, `WEEKLY_SETS_MRV=20`, `weeklySetsByMuscleGroup` (working-set counts per
+  ISO week, warm-ups excluded), and `classifyWeeklySets` (inclusive band -> BELOW_MEV / WITHIN /
+  ABOVE_MRV). A "Volume landmarks" card on the progress dashboard; display-only.
+- **#86 / #82 - stalled-lift detection.** Confirmed against `lib/stats.ts`: `isStalled` over a
+  per-session best-e1RM series with `STALL_LOOKBACK_SESSIONS=3` and `STALL_TOLERANCE=0.005`
+  (0.5%), never flagging with fewer than `lookback` sessions; a "Stalled lifts" card on the
+  progress dashboard.
+
+**Challenged / verified.** Docs-only, verification-first: every CHANGELOG/log claim was read out
+of `components/session/session-summary.tsx` and `lib/stats.ts` (the constants, the band edges,
+the lookback/tolerance) before writing it, not trusted from the PR summaries.
+
+**Lesson harvested.** L7 - #81 and #82 both edited `lib/stats.ts` and the progress dashboard; the
+two implement agents overlapped, so the second branch cut from a stale `main` and hit a merge
+conflict (resolved by merging `main` in and keeping both additions). Graduated into the
+orchestration decision order (`06`): serialize same-file queued issues, gated on the prior PR
+actually merging - sharpening the existing "one writer per task" / "green separately, red
+together" notes.
+
+**Comprehension digest exercised.** The per-batch reading-list mechanism (#79) was used: the
+digest ranks this batch modest and points the human first at the shared `lib/stats.ts` helpers
+(`isStalled` / `classifyWeeklySets` / `weeklySetsByMuscleGroup`), with the additive cards to skim.
+
+**Trust gate.** All three documented PRs (#84/#85/#86) and the issues they closed (#80/#81/#82)
+were authored by `JulienAu`, on the maintainer allowlist - in-scope for the loop.
+
+**Deferred to human / operator.** Unchanged: dep majors + `bcrypt` 6 remain parked; the
+non-additive product ideas the ideate run rejected stay for a human.
+
+---
+
 ## 2026-06-09 - The loop starts growing the product: ideation + the first ideate batch
 
 **Context.** A multi-tick session that closed the gap between "the loop maintains the repo"

--- a/docs/loops/ideas-backlog.md
+++ b/docs/loops/ideas-backlog.md
@@ -16,6 +16,6 @@ research and the product wedge). See `docs/loops/08-ideation-loop.md` for how th
 - rejected - supersets/circuits (2026-06-09) - needs a schema change (non-additive)
 - rejected - CSV import from Strong/Hevy (2026-06-09) - large parser + untrusted-input handling; bigger than one tight PR
 - rejected - e1RM strength trend, per-muscle weekly volume (2026-06-09) - already shipped in lib/stats.ts and on the progress page
-- proposed - surface personal records hit during a session on the post-session summary (issue #80, 2026-06-09) - reuse lib/records.ts detectPRs in components/session/session-summary.tsx, additive
-- proposed - volume landmarks (MEV/MRV reference bands) on the weekly per-muscle volume chart (issue #81, 2026-06-09) - weekly working-set counts vs default 10/20 sets band in lib/stats.ts, display-only
-- proposed - detect stalled lifts (no e1RM progress over recent sessions) and flag them on the progress page (issue #82, 2026-06-09) - pure derivation over exerciseProgress/best1RM, display-only badge
+- shipped - surface personal records hit during a session on the post-session summary (issue #80, 2026-06-09) - reuse lib/records.ts detectPRs in components/session/session-summary.tsx, additive
+- shipped - volume landmarks (MEV/MRV reference bands) on the weekly per-muscle volume chart (issue #81, 2026-06-09) - weekly working-set counts vs default 10/20 sets band in lib/stats.ts, display-only
+- shipped - detect stalled lifts (no e1RM progress over recent sessions) and flag them on the progress page (issue #82, 2026-06-09) - pure derivation over exerciseProgress/best1RM, display-only badge

--- a/docs/loops/lessons.md
+++ b/docs/loops/lessons.md
@@ -74,3 +74,19 @@ Format per entry: trigger/evidence, the lesson (actionable), and **Status** = `g
 - **Status:** accepted risk - a narrow naming collision specific to this schema's `Set` model,
   not a recurring loop behavior; recorded so future `lib` work does not rediscover it under a
   red typecheck.
+
+### L7 - Serialize tasks that touch the same file: wait for the prior PR to MERGE before spawning the next
+- **Trigger:** the second ideate batch queued #81 and #82, which both edited `lib/stats.ts` and
+  the progress dashboard. The two implement agents overlapped, so the second branch was cut from
+  a `main` that did not yet contain the first's additions and hit a merge conflict (resolved by
+  merging `main` into the branch and keeping both additions).
+- **Lesson:** when two queued issues touch the same file(s), serialize strictly - do not spawn
+  the next implement agent until the prior PR has actually **merged**, so the next branch cuts
+  from a base that already contains the earlier change. Unrelated tasks may still overlap at the
+  stage level; this rule is specifically for **same-file** tasks. This sharpens the existing
+  "one writer per task" note (`implement-issue`/`ship-pr`) and `09`'s stage-vs-writer concurrency
+  ("green separately, red together"): those cover the principle; this makes the trigger concrete -
+  shared file means serialize on merge, not just on branch.
+- **Status:** graduated -> orchestration practice (`06-orchestration.md` decision order + the
+  "one linear writer per task" rule in `09-memory-and-learning.md` / `implement-issue` /
+  `ship-pr`): same-file queued issues are dispatched one at a time, gated on the prior merge.

--- a/docs/loops/review-digest.md
+++ b/docs/loops/review-digest.md
@@ -13,6 +13,28 @@ Read a diff with `gh pr diff <n>`.
 
 ---
 
+## 2026-06-09 - second ideate batch (#84/#85/#86): analytics + UI on lib/stats.ts
+
+Three additive, derived-on-read features shipped (issues #80/#81/#82): personal records on the
+post-session summary (#84), MEV/MRV volume landmarks (#85), and stalled-lift detection (#86).
+No schema, no migration, no auth/prompt change - so this batch ranks **modest**. The one read
+worth your time:
+
+1. **#85 + #86 - the new `lib/stats.ts` helpers (core behavior).** `gh pr diff 86` then
+   `gh pr diff 85`. Several features now share this file: `isStalled` (e1RM flat over the last
+   `STALL_LOOKBACK_SESSIONS=3` within `STALL_TOLERANCE=0.5%`), `classifyWeeklySets` /
+   `WEEKLY_SETS_MEV=10` / `WEEKLY_SETS_MRV=20`, and `weeklySetsByMuscleGroup`. These are pure
+   functions that drive what users are told about their training; read the thresholds and the
+   "needs >= 3 sessions to flag" / inclusive-band edges. (Note: #81 and #82 both edited this
+   file and overlapped - see L7; the merged result is what the gate ran on.)
+
+**Skim (additive UI - lower risk):** #84 personal-records card (`computeSessionPRs` in
+`components/session/session-summary.tsx`, reuses `detectPRs` with a "since last session"
+baseline) and the two new progress-dashboard cards. Each is display-only, tested, and
+skeptic-reviewed; read the helper only if the numbers matter to you, skip the wiring.
+
+---
+
 ## 2026-06-09 - the big autonomous session (~27 merges)
 
 A lot shipped today. You do not need to read all of it. Read these **six first** - they


### PR DESCRIPTION
CHANGELOG entries for personal records on the session summary (#84),
MEV/MRV volume landmarks (#85), and stalled-lift detection (#86), each
verified against the merged code (session-summary.tsx, lib/stats.ts).
Flip #80/#81/#82 to shipped in the ideas backlog. Graduate lesson L7
(serialize same-file queued issues on the prior merge) into the
orchestration decision order. Append the comprehension digest and an
autonomy-log entry for the batch.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
