### PR TITLE
docs: widen the autonomy charter to complex features with reinforced non-regression controls

### DIFF
--- a/.claude/skills/ideate/SKILL.md
+++ b/.claude/skills/ideate/SKILL.md
@@ -60,9 +60,12 @@ ideas on top of unstarted ones.
   product call". Turning ambiguity into a defensible spec is the job.
 - Title + **Context** (the user value and where it lives, with file paths) + **Acceptance
   criteria** (a checkable list).
-- **Backward-compatible.** If the full idea would need a non-additive migration, an
-  auth/security change, an LLM-output-contract change, or a major dep bump, say so and scope
-  only the safe first slice; the rest is stop-for-human.
+- **Risk-scaled, not additive-only** (operator directive 2026-06-10). Complex ideas - new
+  tables, data-safe migrations, LLM-output-contract changes, multi-surface features - are
+  in scope when they are a clear product plus; the issue must then name the reinforced
+  non-regression controls that apply (full gate, tests at every touched layer, contract
+  tests, multi-lens review - see the charter's "Complex features" section). Still
+  stop-for-human: destructive data migrations, auth/security changes, major dep bumps.
 - Labels: `enhancement` and `idea`.
 - **De-dupe** against open AND recently-closed issues and `docs/loops/ideas-backlog.md`.
   Never re-file a shipped or rejected idea.
@@ -74,7 +77,8 @@ ideas on top of unstarted ones.
 2. **Ground.** Skim the current features, the research memory, the roadmap. Optionally one
    small web check within the budget.
 3. **Brainstorm** a short candidate list; rank by `(user value x fit-with-vision) /
-   implementation size`. Prefer high-value, low-risk, additive, single-PR slices.
+   implementation size`. Prefer high-value single-PR slices; complexity is acceptable when
+   the value justifies it and the controls scale with it.
 4. **File** the top up-to-3 non-duplicate, single-PR candidates as crisp issues with a
    sensible default spec + acceptance criteria:
    `gh issue create --label enhancement --label idea --title "..." --body "..."`.

--- a/docs/loops/07-autonomy.md
+++ b/docs/loops/07-autonomy.md
@@ -38,17 +38,47 @@ These are absolute. Crossing one is a failure of the experiment, not a judgment 
 When a task falls into one of these, do the safe part, open a **draft** PR or a comment
 explaining the blocker, and move on to other work. Do not force it through.
 
-- **Schema/data migrations** that could lose or rewrite user data (Prisma migrations
-  beyond additive, backfills, destructive column changes).
+- **Destructive data migrations**: anything that could lose or rewrite existing user data
+  with no recovery path (dropping or retyping populated columns/tables, backfills that
+  overwrite values). Additive migrations and data-safe structural ones are fair game under
+  the reinforced controls below.
 - **Auth, security, rate-limiting, or permission** logic changes.
-- **Public API or LLM output-contract** changes that could break callers.
 - **Dependency major-version** bumps, or anything touching the build/release pipeline in a
   non-obvious way.
 - Anything **ambiguous or needing a product decision** - file a crisp issue instead of
   guessing.
 
-These are not forbidden; they just require a human in the loop. Everything else (bug
-fixes, tests, docs, additive features, UX polish, safe minor/patch deps) is fair game.
+These are not forbidden; they just require a human in the loop. Everything else - bug
+fixes, tests, docs, features (including complex, multi-surface ones), UX polish, safe
+minor/patch deps - is fair game, provided the controls below scale with the risk.
+
+## Complex features: reinforced non-regression controls (operator directive 2026-06-10)
+
+The operator widened the feature mandate: if a feature is a clear plus for the product, the
+loop ships it without human review even when it is complex - the compensation is **more
+non-regression control, not more human approval**. Concretely, a PR that touches a schema,
+an API contract, the LLM output contract, or several surfaces at once must carry ALL of:
+
+1. **Full local gate before the PR**: `bash scripts/verify.sh --full` (integration + E2E),
+   not just the fast tier. Green CI remains the merge boundary, but a complex change must
+   not discover its integration failures in CI.
+2. **Tests shipped with the change, at every touched layer**: unit tests for new logic,
+   integration tests for new/changed API routes, and an E2E step for a new user-visible
+   flow. A complex feature PR with no new tests is not ready by definition.
+3. **Migrations**: prefer additive; a non-additive but data-safe migration is allowed if it
+   is reversible and verified against a seeded database locally. Tag a fresh rollback
+   baseline (`autonomy-baseline-<date>`) before merging any PR with a migration.
+4. **LLM output-contract changes**: allowed, but the Zod schema, the demo provider's canned
+   responses, and every consumer must be updated in the same PR, with contract tests
+   exercising the demo provider so CI catches drift.
+5. **Multi-lens subagent challenge**: complex PRs get at least two independent review
+   lenses (correctness + does-it-actually-work; add security when input handling or data
+   exposure changes). One generic skeptic is enough only for simple additive changes.
+6. **Run it**: for a user-visible feature, verify the flow in the running app (the `verify`
+   skill) before merge, not only through tests.
+
+The hard guardrails and the untrusted-input rules below are unchanged by this directive:
+security boundaries are never traded for product velocity.
 
 ## Untrusted external input (public repo)
 

--- a/docs/loops/08-ideation-loop.md
+++ b/docs/loops/08-ideation-loop.md
@@ -59,10 +59,12 @@ concrete, single-PR work rather than "needs a product call".
 Ideation only *files issues* - it never writes product code or merges. The issues it files
 are authored by the loop's own trusted account, so they are auto-actionable, but they are
 still subject to everything downstream: the green-gate, the subagent challenge, and the
-stop-for-human list (a filed idea whose safe slice turns out to need a non-additive
-migration, an auth change, an LLM-output-contract change, or a major dep bump gets a draft
-PR for a human). `docs/loops/ideas-backlog.md` is the durable log of proposed / shipped /
-rejected ideas, so the loop never repeats itself.
+stop-for-human list. Since the 2026-06-10 operator directive, complex ideas (data-safe
+migrations, LLM-output-contract changes, multi-surface features) are implementable without
+human review under the charter's reinforced non-regression controls; only destructive data
+migrations, auth/security changes, and major dep bumps still get a draft PR for a human.
+`docs/loops/ideas-backlog.md` is the durable log of proposed / shipped / rejected ideas, so
+the loop never repeats itself.
 
 ## The four rules, here
 

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -6,6 +6,32 @@ by the charter in [`07-autonomy.md`](07-autonomy.md).
 
 ---
 
+## 2026-06-10 - Operator directive: complex features with reinforced controls; third ideate batch
+
+**Context.** The operator widened the feature mandate in-session: complex features (data-safe
+migrations, LLM output-contract changes, multi-surface work) may now ship without human
+review when they are a clear product plus - compensated by MORE non-regression control, not
+more approval. Codified in the charter's new "Complex features" section; the ideate skill
+and `08-ideation-loop.md` updated to match. Unchanged: hard guardrails, untrusted-input
+rules, and stop-for-human for destructive data migrations, auth/security, major dep bumps.
+
+**Decided / shipped.**
+- Closed external test issue #57 (already triaged "not planned" in-thread, left open by
+  mistake).
+- Third ideate batch filed: #88 deload-week recommendation (display-only derivation), #89
+  set-logging shorthand parser (roadmap's natural-language logging, deterministic slice),
+  #90 per-exercise target goals (additive ExerciseGoal table + Zod API + progress UI).
+  Backlog logged via PR #91 (merged on green).
+- Charter amendment shipped via PR (this entry rides along).
+
+**Challenged.** Docs-only changes; the gate + a re-read of the security sections stood in
+for a code skeptic. The trust-model sections were verified unchanged.
+
+**Deferred to human.** Nothing; the directive explicitly removes the human from complex
+feature review while keeping the security stop-list.
+
+---
+
 ## 2026-06-09 - Second ideate batch (#80/#81/#82 via #84/#85/#86)
 
 **Context.** The second batch of ideate-produced product features shipped autonomously; this


### PR DESCRIPTION
Codifies the 2026-06-10 operator directive: the loop may ship complex features (data-safe migrations, LLM output-contract changes, multi-surface work) without human review when they are a clear product plus. The trade is more non-regression control, not more approval:

- full local gate (verify.sh --full) before opening a complex PR
- tests shipped at every touched layer (unit / integration / E2E)
- migrations: additive preferred, data-safe + reversible otherwise, fresh rollback tag before merge
- LLM contract changes carry Zod schema + demo-provider contract tests + all consumers in the same PR
- multi-lens subagent challenge and verify-in-app before merge

Stop-for-human narrows to: destructive data migrations, auth/security/permission changes, major dep bumps. Hard guardrails and the untrusted-input trust model are untouched.

Touches: docs/loops/07-autonomy.md, docs/loops/08-ideation-loop.md, .claude/skills/ideate/SKILL.md, docs/loops/autonomy-log.md (journal entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)