### PR TITLE
feat: recommend a deload week when lifts stall or readiness is chronically low

### DIFF
--- a/app/(app)/progress/page.tsx
+++ b/app/(app)/progress/page.tsx
@@ -15,8 +15,14 @@ import {
   WEEKLY_SETS_MEV,
   WEEKLY_SETS_MRV,
 } from '@/lib/stats';
+import {
+  DELOAD_READINESS_LOOKBACK,
+  DELOAD_READINESS_MAX_AGE_DAYS,
+  recommendDeload,
+} from '@/lib/deload';
 import { ProgressDashboard } from '@/components/progress/progress-dashboard';
 import { ConsistencyCard } from '@/components/progress/consistency-card';
+import { DeloadBanner } from '@/components/progress/deload-banner';
 
 interface SearchParams {
   exerciseId?: string;
@@ -241,6 +247,26 @@ export default async function ProgressPage({
     (r): r is NonNullable<typeof r> => r !== null,
   );
 
+  // Program-level deload recommendation: aggregates the stalled flags above
+  // with the most recent readiness check-ins. Display-only. Stale check-ins
+  // are excluded so the trigger reflects the current block, not dead data.
+  const readinessSince = new Date();
+  readinessSince.setUTCDate(
+    readinessSince.getUTCDate() - DELOAD_READINESS_MAX_AGE_DAYS,
+  );
+  const recentCheckins = await db.readinessCheckin.findMany({
+    where: { userId: auth.userId, createdAt: { gte: readinessSince } },
+    orderBy: { createdAt: 'desc' },
+    take: DELOAD_READINESS_LOOKBACK,
+    select: { readiness: true },
+  });
+  const deload = recommendDeload({
+    stalledExerciseNames: recap
+      .filter((r) => r.stalled)
+      .map((r) => r.exerciseName),
+    recentReadiness: recentCheckins.map((c) => c.readiness),
+  });
+
   return (
     <main className="flex-1 px-4 py-6">
       <div className="mx-auto flex max-w-3xl flex-col gap-6">
@@ -258,6 +284,7 @@ export default async function ProgressPage({
           />
         ) : (
           <>
+            {deload.recommended && <DeloadBanner reasons={deload.reasons} />}
             <ConsistencyCard
               weeks={consistency.weeks}
               currentStreak={consistency.currentStreak}

--- a/components/progress/deload-banner.test.tsx
+++ b/components/progress/deload-banner.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DeloadBanner } from './deload-banner';
+
+describe('DeloadBanner', () => {
+  it('renders nothing without reasons', () => {
+    const { container } = render(<DeloadBanner reasons={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('lists the stalled lifts by name', () => {
+    render(
+      <DeloadBanner
+        reasons={[
+          { kind: 'stalled-lifts', exerciseNames: ['Bench press', 'Squat'] },
+        ]}
+      />,
+    );
+    expect(screen.getByText('A deload week looks due')).toBeInTheDocument();
+    expect(
+      screen.getByText('2 lifts have stalled: Bench press, Squat.'),
+    ).toBeInTheDocument();
+  });
+
+  it('explains a chronically low readiness average', () => {
+    render(
+      <DeloadBanner
+        reasons={[
+          { kind: 'low-readiness', averageReadiness: 1.7, checkins: 5 },
+        ]}
+      />,
+    );
+    expect(
+      screen.getByText(
+        'Your readiness has averaged 1.7/5 over your last 5 check-ins.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('shows one line per reason when both triggers hold', () => {
+    render(
+      <DeloadBanner
+        reasons={[
+          { kind: 'stalled-lifts', exerciseNames: ['Squat', 'Deadlift'] },
+          { kind: 'low-readiness', averageReadiness: 2, checkins: 4 },
+        ]}
+      />,
+    );
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+  });
+});

--- a/components/progress/deload-banner.tsx
+++ b/components/progress/deload-banner.tsx
@@ -1,0 +1,54 @@
+import { BatteryLow } from 'lucide-react';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import type { DeloadReason } from '@/lib/deload';
+
+interface Props {
+  reasons: DeloadReason[];
+}
+
+function reasonLine(reason: DeloadReason): string {
+  switch (reason.kind) {
+    case 'stalled-lifts': {
+      const count = reason.exerciseNames.length;
+      const names = reason.exerciseNames.join(', ');
+      return count === 1
+        ? `1 lift has stalled: ${names}.`
+        : `${count} lifts have stalled: ${names}.`;
+    }
+    case 'low-readiness':
+      return `Your readiness has averaged ${reason.averageReadiness}/5 over your last ${reason.checkins} check-ins.`;
+  }
+}
+
+// Display-only banner shown on the progress page when recommendDeload fires.
+// Lists the concrete reasons and explains what a deload week is; it changes
+// nothing in the program or the suggestions.
+export function DeloadBanner({ reasons }: Props) {
+  if (reasons.length === 0) return null;
+
+  return (
+    <Card className="border-amber-500/50 bg-amber-500/5">
+      <CardHeader className="pb-3">
+        <div className="flex items-center gap-2">
+          <BatteryLow className="size-4 text-amber-600" />
+          <h2 className="text-base font-semibold">
+            A deload week looks due
+          </h2>
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-2 text-sm">
+        <ul className="list-disc space-y-1 pl-5">
+          {reasons.map((reason) => (
+            <li key={reason.kind}>{reasonLine(reason)}</li>
+          ))}
+        </ul>
+        <p className="text-xs text-muted-foreground">
+          Accumulated fatigue can mask progress. For one week, roughly halve
+          your working sets or reduce the load by about 10%, keep moving, then
+          resume your normal program. Your plan and suggestions are unchanged;
+          this is only a recommendation.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/lib/deload.test.ts
+++ b/lib/deload.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DELOAD_READINESS_LOOKBACK,
+  DELOAD_READINESS_MIN_CHECKINS,
+  DELOAD_READINESS_THRESHOLD,
+  DELOAD_STALLED_LIFTS_MIN,
+  recommendDeload,
+} from './deload';
+
+describe('recommendDeload', () => {
+  it('recommends nothing when no lift is stalled and readiness is fine', () => {
+    const result = recommendDeload({
+      stalledExerciseNames: [],
+      recentReadiness: [4, 5, 4, 3, 4],
+    });
+    expect(result.recommended).toBe(false);
+    expect(result.reasons).toEqual([]);
+  });
+
+  it('triggers on enough stalled lifts', () => {
+    const result = recommendDeload({
+      stalledExerciseNames: ['Bench press', 'Squat'],
+      recentReadiness: [4, 4, 4],
+    });
+    expect(result.recommended).toBe(true);
+    expect(result.reasons).toEqual([
+      { kind: 'stalled-lifts', exerciseNames: ['Bench press', 'Squat'] },
+    ]);
+  });
+
+  it('does not trigger below the stalled-lifts minimum', () => {
+    const result = recommendDeload({
+      stalledExerciseNames: ['Bench press'],
+      recentReadiness: [],
+    });
+    expect(DELOAD_STALLED_LIFTS_MIN).toBeGreaterThan(1);
+    expect(result.recommended).toBe(false);
+  });
+
+  it('triggers on chronically low readiness', () => {
+    const result = recommendDeload({
+      stalledExerciseNames: [],
+      recentReadiness: [2, 1, 2, 2, 3],
+    });
+    expect(result.recommended).toBe(true);
+    expect(result.reasons).toEqual([
+      { kind: 'low-readiness', averageReadiness: 2, checkins: 5 },
+    ]);
+  });
+
+  it('averages only the most recent lookback window, newest first', () => {
+    // Five recent low scores followed by old high ones: the old scores must
+    // not dilute the average below the trigger.
+    const result = recommendDeload({
+      stalledExerciseNames: [],
+      recentReadiness: [2, 2, 2, 2, 2, 5, 5, 5, 5],
+    });
+    expect(result.reasons).toEqual([
+      {
+        kind: 'low-readiness',
+        averageReadiness: 2,
+        checkins: DELOAD_READINESS_LOOKBACK,
+      },
+    ]);
+  });
+
+  it('needs a minimum number of check-ins before the readiness trigger fires', () => {
+    const tooFew = Array(DELOAD_READINESS_MIN_CHECKINS - 1).fill(1);
+    const result = recommendDeload({
+      stalledExerciseNames: [],
+      recentReadiness: tooFew,
+    });
+    expect(result.recommended).toBe(false);
+  });
+
+  it('does not trigger when the average sits above the threshold', () => {
+    // Average 2.6 with threshold 2: close, but recovery is not chronic.
+    const result = recommendDeload({
+      stalledExerciseNames: [],
+      recentReadiness: [3, 2, 3, 2, 3],
+    });
+    expect(DELOAD_READINESS_THRESHOLD).toBe(2);
+    expect(result.recommended).toBe(false);
+  });
+
+  it('reports both reasons when both triggers hold', () => {
+    const result = recommendDeload({
+      stalledExerciseNames: ['Bench press', 'Squat', 'Deadlift'],
+      recentReadiness: [1, 2, 2],
+    });
+    expect(result.recommended).toBe(true);
+    expect(result.reasons.map((r) => r.kind)).toEqual([
+      'stalled-lifts',
+      'low-readiness',
+    ]);
+  });
+
+  it('rounds the reported average to one decimal', () => {
+    const result = recommendDeload({
+      stalledExerciseNames: [],
+      recentReadiness: [1, 2, 2],
+    });
+    expect(result.reasons).toEqual([
+      { kind: 'low-readiness', averageReadiness: 1.7, checkins: 3 },
+    ]);
+  });
+});

--- a/lib/deload.ts
+++ b/lib/deload.ts
@@ -1,0 +1,79 @@
+import { READINESS_HOLD_AT_OR_BELOW } from '@/lib/progression';
+
+// ============================================================
+// Deload-week recommendation (program-level fatigue signal)
+// ============================================================
+// lib/progression.ts already deloads a single session's load on a bad
+// readiness check-in; this module aggregates the program-level signals
+// (several stalled lifts, chronically low readiness) into one display-only
+// recommendation to take a deload week. Pure derivation - no clock, no DB.
+
+// How many stalled lifts (per lib/stats.ts isStalled) it takes to read the
+// plateau as systemic fatigue rather than a single lift needing a tweak.
+export const DELOAD_STALLED_LIFTS_MIN = 2;
+
+// How many of the most recent readiness check-ins the chronic-fatigue test
+// averages over.
+export const DELOAD_READINESS_LOOKBACK = 5;
+
+// Minimum number of check-ins in the window before the readiness trigger can
+// fire. One bad morning is noise; a short consistent run of low scores is not.
+export const DELOAD_READINESS_MIN_CHECKINS = 3;
+
+// Check-ins older than this are dead data for a "chronic, current" fatigue
+// signal: the caller must not feed them in. Two weeks keeps the trigger about
+// the present block, mirroring how lib/progression.ts bounds a single
+// check-in's relevance with READINESS_RECENCY_HOURS.
+export const DELOAD_READINESS_MAX_AGE_DAYS = 14;
+
+// Average readiness (1 drained - 5 primed) at or below which recovery counts
+// as chronically poor. Reuses the per-session "hold the load" boundary from
+// lib/progression.ts: scores that hold a single session, sustained across the
+// window, justify a planned week of reduced load instead.
+export const DELOAD_READINESS_THRESHOLD = READINESS_HOLD_AT_OR_BELOW;
+
+export type DeloadReason =
+  | { kind: 'stalled-lifts'; exerciseNames: string[] }
+  | { kind: 'low-readiness'; averageReadiness: number; checkins: number };
+
+export interface DeloadRecommendation {
+  recommended: boolean;
+  reasons: DeloadReason[];
+}
+
+export interface DeloadInput {
+  // Names of the lifts currently flagged by isStalled, any order.
+  stalledExerciseNames: string[];
+  // Readiness scores (1-5) of the user's most recent check-ins, newest first.
+  // The caller passes whatever it has; only the first
+  // DELOAD_READINESS_LOOKBACK entries are considered.
+  recentReadiness: number[];
+}
+
+// Recommends a deload week when EITHER enough lifts are stalled OR the recent
+// readiness average is chronically low. Both reasons are reported when both
+// hold, so the UI can explain the full picture.
+export function recommendDeload(input: DeloadInput): DeloadRecommendation {
+  const reasons: DeloadReason[] = [];
+
+  if (input.stalledExerciseNames.length >= DELOAD_STALLED_LIFTS_MIN) {
+    reasons.push({
+      kind: 'stalled-lifts',
+      exerciseNames: [...input.stalledExerciseNames],
+    });
+  }
+
+  const window = input.recentReadiness.slice(0, DELOAD_READINESS_LOOKBACK);
+  if (window.length >= DELOAD_READINESS_MIN_CHECKINS) {
+    const average = window.reduce((acc, r) => acc + r, 0) / window.length;
+    if (average <= DELOAD_READINESS_THRESHOLD) {
+      reasons.push({
+        kind: 'low-readiness',
+        averageReadiness: +average.toFixed(1),
+        checkins: window.length,
+      });
+    }
+  }
+
+  return { recommended: reasons.length > 0, reasons };
+}


### PR DESCRIPTION
Program-level fatigue-management advice, derived from signals the app already tracks:

- New pure module lib/deload.ts: recommendDeload(...) fires when >= 2 lifts are stalled (per the existing isStalled flags) OR the average readiness over the last 5 check-ins (max 14 days old) is at or below the existing hold boundary (2/5). All thresholds are exported named constants; the readiness threshold reuses READINESS_HOLD_AT_OR_BELOW from lib/progression.ts.
- Display-only DeloadBanner card on the progress page, shown only when recommended, listing the concrete reasons (which lifts stalled, the readiness average) and what a deload week is. No schema, API, or prompt changes.

An independent skeptic subagent reviewed the diff; its one blocking finding (no recency bound on the check-in query, so months-old check-ins could fire the trigger) is fixed with a 14-day window (DELOAD_READINESS_MAX_AGE_DAYS), plus a singular/plural copy fix.

Closes #88

## How I tested

- bash scripts/verify.sh - GREEN-GATE PASSED (prisma generate, lint, typecheck, unit incl. the 13 new tests in lib/deload.test.ts and components/progress/deload-banner.test.tsx, build)
- Unit tests cover: stall-count trigger, readiness trigger (boundary average exactly 2, rounding, newest-first window slicing), min-checkins guard, both-triggers case, and the no-recommendation case; component tests cover empty render and one line per reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)