### PR TITLE
feat: quick set logging via shorthand input (e.g. 100x8@9)

### DIFF
--- a/components/session/set-input.test.tsx
+++ b/components/session/set-input.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Exercise, ProgramExercise } from '@prisma/client';
+import { SetInput } from './set-input';
+
+const exo: Exercise = {
+  id: 'e1',
+  userId: 'u',
+  name: 'Squat',
+  muscleGroup: 'QUADS',
+  category: 'COMPOUND',
+  defaultRestSec: 120,
+  notes: null,
+  usesBodyweight: false,
+  createdAt: new Date(),
+};
+
+const pe: ProgramExercise & { exercise: Exercise } = {
+  id: 'pe',
+  workoutId: 'w',
+  exerciseId: 'e1',
+  order: 1,
+  targetSets: 3,
+  targetRepsMin: 6,
+  targetRepsMax: 10,
+  targetRIR: 2,
+  restSec: 120,
+  tempo: null,
+  notes: null,
+  exercise: exo,
+};
+
+function renderSetInput(unit: 'KG' | 'LB' = 'KG') {
+  const onSubmit = vi.fn().mockResolvedValue(undefined);
+  render(
+    <SetInput
+      programExercise={pe}
+      existingSets={[]}
+      lastPerformance={undefined}
+      readiness={null}
+      unit={unit}
+      onSubmit={onSubmit}
+    />,
+  );
+  return { onSubmit };
+}
+
+describe('SetInput quick entry', () => {
+  it('fills weight, reps, and RIR from a valid shorthand', async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderSetInput('KG');
+
+    await user.type(screen.getByLabelText('Quick entry'), '100x8@9');
+    await user.click(screen.getByRole('button', { name: /log the set/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ weight: 100, reps: 8, rir: 1 }),
+    );
+  });
+
+  it('keeps the RIR untouched when the shorthand has no RPE', async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderSetInput('KG');
+
+    await user.type(screen.getByLabelText('Quick entry'), '62.5x8');
+    await user.click(screen.getByRole('button', { name: /log the set/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      // targetRIR (2) comes from the default pre-fill and must survive.
+      expect.objectContaining({ weight: 62.5, reps: 8, rir: 2 }),
+    );
+  });
+
+  it('converts the shorthand weight from the display unit (lb) to kg', async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderSetInput('LB');
+
+    await user.type(screen.getByLabelText('Quick entry'), '225x5');
+    await user.click(screen.getByRole('button', { name: /log the set/i }));
+
+    const submitted = onSubmit.mock.calls[0]?.[0] as { weight: number };
+    // 225 lb = 102.06 kg.
+    expect(submitted.weight).toBeCloseTo(102.06, 1);
+  });
+
+  it('shows an inline format hint on invalid non-empty input', async () => {
+    const user = userEvent.setup();
+    renderSetInput('KG');
+
+    expect(screen.queryByText(/expected format/i)).not.toBeInTheDocument();
+    await user.type(screen.getByLabelText('Quick entry'), 'squat');
+    expect(screen.getByText(/expected format/i)).toBeInTheDocument();
+  });
+
+  it('does not touch the form values on an invalid entry', async () => {
+    const user = userEvent.setup();
+    const { onSubmit } = renderSetInput('KG');
+
+    await user.type(screen.getByLabelText('Quick entry'), 'nonsense');
+    await user.click(screen.getByRole('button', { name: /log the set/i }));
+
+    // Defaults still submit: mid rep range (8), target RIR (2), weight 0.
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ weight: 0, reps: 8, rir: 2 }),
+    );
+  });
+});

--- a/components/session/set-input.tsx
+++ b/components/session/set-input.tsx
@@ -17,6 +17,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { suggestNextWeight, weightIncrement, type ReadinessSignal } from '@/lib/progression';
+import { parseSetShorthand, rpeToRir } from '@/lib/set-shorthand';
 import { PlateCalculator } from '@/components/session/plate-calculator';
 import { WarmupCalculator } from '@/components/session/warmup-calculator';
 import type { PendingSet } from '@/lib/indexeddb';
@@ -62,10 +63,12 @@ export function SetInput({
   const initial = computeInitial(programExercise, existingSets, lastPerformance, readiness);
   const [form, setForm] = useState<FormState>(initial);
   const [submitting, setSubmitting] = useState(false);
+  const [quickEntry, setQuickEntry] = useState('');
 
   // Re-init when the exercise changes or a set changes.
   useEffect(() => {
     setForm(computeInitial(programExercise, existingSets, lastPerformance, readiness));
+    setQuickEntry('');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [programExercise.id, existingSets.length]);
 
@@ -85,6 +88,25 @@ export function SetInput({
   function adjustReps(delta: number) {
     setForm((f) => ({ ...f, reps: Math.max(0, f.reps + delta) }));
   }
+
+  // Quick entry: parse shorthand like "100x8@9" and fill the classic fields.
+  // The user still confirms with the log button; the classic fields keep
+  // working unchanged.
+  function handleQuickEntry(value: string) {
+    setQuickEntry(value);
+    const parsed = parseSetShorthand(value);
+    if (!parsed) return;
+    setForm((f) => ({
+      ...f,
+      // The shorthand weight is typed in the user's display unit, exactly
+      // like the classic weight field.
+      weight: fromDisplayWeight(parsed.weight, unit),
+      reps: parsed.reps,
+      rir: parsed.rpe !== undefined ? rpeToRir(parsed.rpe) : f.rir,
+    }));
+  }
+
+  const quickEntryInvalid = quickEntry.trim() !== '' && parseSetShorthand(quickEntry) === null;
 
   async function handleValidate() {
     setSubmitting(true);
@@ -106,6 +128,31 @@ export function SetInput({
   return (
     <Card>
       <CardContent className="flex flex-col gap-4 pt-6">
+        {/* Quick entry shorthand */}
+        <div className="space-y-1">
+          <Label
+            htmlFor="quick-entry"
+            className="text-xs uppercase tracking-wide text-muted-foreground"
+          >
+            Quick entry
+          </Label>
+          <Input
+            id="quick-entry"
+            type="text"
+            inputMode="text"
+            autoComplete="off"
+            value={quickEntry}
+            onChange={(e) => handleQuickEntry(e.target.value)}
+            placeholder={`e.g. 100x8@9 (${unitLabel(unit)} x reps @ RPE)`}
+            aria-invalid={quickEntryInvalid}
+          />
+          {quickEntryInvalid && (
+            <p className="text-xs text-muted-foreground">
+              Expected format: weight x reps, optionally @ RPE - e.g. 100x8 or 62.5x8@8.5
+            </p>
+          )}
+        </div>
+
         {/* Load */}
         <div className="space-y-2">
           <div className="flex items-center justify-between">

--- a/lib/set-shorthand.test.ts
+++ b/lib/set-shorthand.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { parseSetShorthand, rpeToRir } from './set-shorthand';
+
+describe('parseSetShorthand', () => {
+  it('parses the compact "weight x reps" form', () => {
+    expect(parseSetShorthand('100x8')).toEqual({ weight: 100, reps: 8 });
+  });
+
+  it('parses the spaced "weight x reps" form', () => {
+    expect(parseSetShorthand('100 x 8')).toEqual({ weight: 100, reps: 8 });
+  });
+
+  it('is case-insensitive on the x separator', () => {
+    expect(parseSetShorthand('100X8')).toEqual({ weight: 100, reps: 8 });
+  });
+
+  it('parses the space-separated "weight reps" form', () => {
+    expect(parseSetShorthand('100 8')).toEqual({ weight: 100, reps: 8 });
+  });
+
+  it('parses an RPE after @', () => {
+    expect(parseSetShorthand('100x8@9')).toEqual({ weight: 100, reps: 8, rpe: 9 });
+  });
+
+  it('parses a spaced RPE after @', () => {
+    expect(parseSetShorthand('100 x 8 @ 9')).toEqual({ weight: 100, reps: 8, rpe: 9 });
+  });
+
+  it('parses the fully space-separated "weight reps rpe" form', () => {
+    expect(parseSetShorthand('100 8 9')).toEqual({ weight: 100, reps: 8, rpe: 9 });
+  });
+
+  it('parses a decimal weight', () => {
+    expect(parseSetShorthand('62.5x8')).toEqual({ weight: 62.5, reps: 8 });
+  });
+
+  it('parses a decimal RPE', () => {
+    expect(parseSetShorthand('100x8@8.5')).toEqual({ weight: 100, reps: 8, rpe: 8.5 });
+  });
+
+  it('tolerates surrounding whitespace', () => {
+    expect(parseSetShorthand('  100x8  ')).toEqual({ weight: 100, reps: 8 });
+  });
+
+  it('rejects an RPE above 10', () => {
+    expect(parseSetShorthand('100x8@11')).toBeNull();
+    expect(parseSetShorthand('100x8@10.5')).toBeNull();
+  });
+
+  it('rejects an RPE below 1', () => {
+    expect(parseSetShorthand('100x8@0')).toBeNull();
+    expect(parseSetShorthand('100x8@0.5')).toBeNull();
+  });
+
+  it('accepts the RPE bounds 1 and 10', () => {
+    expect(parseSetShorthand('100x8@1')).toEqual({ weight: 100, reps: 8, rpe: 1 });
+    expect(parseSetShorthand('100x8@10')).toEqual({ weight: 100, reps: 8, rpe: 10 });
+  });
+
+  it('rejects zero reps', () => {
+    expect(parseSetShorthand('100x0')).toBeNull();
+  });
+
+  it('rejects decimal reps', () => {
+    expect(parseSetShorthand('100x8.5')).toBeNull();
+  });
+
+  it('does not misread a decimal as an RPE when the separator is missing', () => {
+    // Without a required separator this would backtrack into reps=8, rpe=9.5.
+    expect(parseSetShorthand('100 89.5')).toBeNull();
+  });
+
+  it('rejects empty and whitespace-only input', () => {
+    expect(parseSetShorthand('')).toBeNull();
+    expect(parseSetShorthand('   ')).toBeNull();
+  });
+
+  it('rejects plain words and partial entries', () => {
+    expect(parseSetShorthand('squat')).toBeNull();
+    expect(parseSetShorthand('100')).toBeNull();
+    expect(parseSetShorthand('100x')).toBeNull();
+    expect(parseSetShorthand('x8')).toBeNull();
+    expect(parseSetShorthand('100x8@')).toBeNull();
+  });
+
+  it('rejects negative numbers and trailing junk', () => {
+    expect(parseSetShorthand('-100x8')).toBeNull();
+    expect(parseSetShorthand('100x8 extra')).toBeNull();
+  });
+
+  it('rejects out-of-scope shorthands (bodyweight, multi-set)', () => {
+    expect(parseSetShorthand('bw x 10')).toBeNull();
+    expect(parseSetShorthand('3x8x100')).toBeNull();
+  });
+});
+
+describe('rpeToRir', () => {
+  it('maps RPE to RIR as 10 - RPE', () => {
+    expect(rpeToRir(10)).toBe(0);
+    expect(rpeToRir(9)).toBe(1);
+    expect(rpeToRir(7)).toBe(3);
+  });
+
+  it('rounds half-point RPEs to the nearest integer RIR', () => {
+    expect(rpeToRir(8.5)).toBe(2);
+    expect(rpeToRir(9.5)).toBe(1);
+  });
+
+  it('clamps to the API range 0-5', () => {
+    expect(rpeToRir(1)).toBe(5);
+    expect(rpeToRir(4)).toBe(5);
+  });
+});

--- a/lib/set-shorthand.ts
+++ b/lib/set-shorthand.ts
@@ -1,0 +1,68 @@
+// Shorthand set parser: lets a lifter type "100x8@9" instead of tabbing
+// through separate weight/reps fields (issue #89). Fully deterministic, no
+// LLM involved.
+//
+// Accepted forms (case-insensitive, flexible whitespace):
+//   "100x8"      weight x reps
+//   "100 x 8"    same, spaced
+//   "100 8"      space-separated weight reps
+//   "100x8@9"    with an RPE
+//   "100 8 9"    space-separated weight reps rpe
+//   "62.5x8"     decimal weight
+//   "100x8@8.5"  decimal RPE
+//
+// The weight is a number in the user's DISPLAY unit (kg or lb); callers
+// convert with fromDisplayWeight before storing, exactly like the classic
+// weight field does.
+//
+// Out of scope for this slice (deliberately not implemented):
+// - bodyweight shorthand ("bw x 10")
+// - multi-set shorthand ("3x8x100")
+// - any LLM-backed natural-language parsing
+
+export interface ParsedSetShorthand {
+  // Weight in the user's display unit (not yet converted to kg).
+  weight: number;
+  reps: number;
+  rpe?: number;
+}
+
+// A decimal number like "100", "62.5".
+const NUM = String.raw`\d+(?:\.\d+)?`;
+
+// weight ("x" | space) reps [("@" | space) rpe]
+// The separator before the RPE is required so e.g. "100 89.5" does not
+// backtrack into reps=8, rpe=9.5.
+const SHORTHAND_RE = new RegExp(
+  String.raw`^(${NUM})\s*(?:x\s*|\s+)(\d+)(?:(?:\s*@\s*|\s+)(${NUM}))?$`,
+  'i',
+);
+
+// Parse a shorthand set entry. Returns null when the input does not match an
+// accepted form, when reps is not a positive integer, or when the RPE is out
+// of the 1-10 range.
+export function parseSetShorthand(input: string): ParsedSetShorthand | null {
+  const match = SHORTHAND_RE.exec(input.trim());
+  if (!match) return null;
+
+  const [, weightStr, repsStr, rpeStr] = match;
+  if (weightStr === undefined || repsStr === undefined) return null;
+
+  const weight = parseFloat(weightStr);
+  const reps = parseInt(repsStr, 10);
+  if (!Number.isFinite(weight) || reps < 1) return null;
+
+  if (rpeStr === undefined) {
+    return { weight, reps };
+  }
+  const rpe = parseFloat(rpeStr);
+  if (rpe < 1 || rpe > 10) return null;
+  return { weight, reps, rpe };
+}
+
+// The app tracks effort as RIR (reps in reserve), not RPE. Map a shorthand
+// RPE to the RIR stored on the set: RIR = 10 - RPE, rounded to the nearest
+// integer and clamped to the API's accepted 0-5 range.
+export function rpeToRir(rpe: number): number {
+  return Math.min(5, Math.max(0, Math.round(10 - rpe)));
+}


### PR DESCRIPTION
Implements the smallest valuable slice of natural-language set logging: a fully deterministic shorthand parser, no LLM involved.

- New pure parser `lib/set-shorthand.ts`: `parseSetShorthand` accepts `100x8`, `100 x 8`, `100 8`, `100x8@9`, `100 8 9`, decimal weights (`62.5x8`) and decimal RPE (`@8.5`); rejects RPE outside 1-10, zero/decimal reps, and out-of-scope forms (bodyweight, multi-set).
- Quick-entry field at the top of the set form in `components/session/set-input.tsx`. A valid parse fills the existing weight/reps/RIR fields (the app tracks RIR, so RPE maps as RIR = 10 - RPE, rounded and clamped to the API's 0-5 range); the user still confirms with the existing log button. Invalid non-empty input shows a subtle inline hint; the classic fields keep working unchanged.
- Weight is read in the user's display unit (kg/lb) and converted with the existing `fromDisplayWeight`, exactly like the classic weight field.
- No API, schema, or prompt changes; the logged set goes through the same submit path.

Closes #89

## How I tested

- `bash scripts/verify.sh` passed (prisma generate + lint + typecheck + unit + build).
- New colocated unit tests `lib/set-shorthand.test.ts` (all accepted forms, decimals, RPE bounds, ambiguous-backtracking edge case, invalid inputs) and component tests `components/session/set-input.test.tsx` (form fill on valid parse, RIR preserved without RPE, lb-to-kg conversion, inline hint, invalid input leaving the form untouched) - 28 tests, all green.
- Independent skeptic review of the staged diff: two cosmetic findings (a misleading test name, fixed; a keep-RIR-on-RPE-deletion behavior judged the correct default), no correctness issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)