### PR TITLE
feat: per-exercise target goals (weight x reps) with progress toward goal

### DIFF
--- a/app/(app)/progress/page.tsx
+++ b/app/(app)/progress/page.tsx
@@ -5,6 +5,7 @@ import { EmptyState } from '@/components/ui/empty-state';
 import { MUSCLE_GROUP_LABELS } from '@/lib/schemas/exercise';
 import {
   applyBodyweight,
+  best1RM,
   classifyWeeklySets,
   exerciseProgress,
   isStalled,
@@ -86,42 +87,55 @@ export default async function ProgressPage({
   const selectedExerciseId =
     searchParams.exerciseId ?? exercisesWithSets[0]?.id;
 
-  // Max load + 1RM for the selected exercise, over all available history.
-  const exerciseSets = selectedExerciseId
-    ? await db.set.findMany({
-        where: {
-          exerciseId: selectedExerciseId,
-          isWarmup: false,
-          session: { userId: auth.userId },
-        },
-        orderBy: { completedAt: 'asc' },
-        select: {
-          weight: true,
-          reps: true,
-          isWarmup: true,
-          sessionId: true,
-          session: { select: { startedAt: true } },
-        },
-      })
-    : [];
+  // Max load + 1RM for the selected exercise, over all available history,
+  // plus its target goal (issue #90) fetched in parallel.
+  const [exerciseSets, selectedGoal] = await Promise.all([
+    selectedExerciseId
+      ? db.set.findMany({
+          where: {
+            exerciseId: selectedExerciseId,
+            isWarmup: false,
+            session: { userId: auth.userId },
+          },
+          orderBy: { completedAt: 'asc' },
+          select: {
+            weight: true,
+            reps: true,
+            isWarmup: true,
+            sessionId: true,
+            session: { select: { startedAt: true } },
+          },
+        })
+      : Promise.resolve([]),
+    selectedExerciseId
+      ? db.exerciseGoal.findUnique({
+          where: {
+            userId_exerciseId: { userId: auth.userId, exerciseId: selectedExerciseId },
+          },
+        })
+      : Promise.resolve(null),
+  ]);
 
   const selectedUsesBodyweight =
     selectedExerciseId != null
       ? (usesBodyweightById.get(selectedExerciseId) ?? false)
       : false;
-  const exercisePoints = exerciseProgress(
-    applyBodyweight(
-      exerciseSets.map((s) => ({
-        weight: s.weight,
-        reps: s.reps,
-        isWarmup: s.isWarmup,
-        sessionId: s.sessionId,
-        sessionStartedAt: s.session.startedAt,
-        usesBodyweight: selectedUsesBodyweight,
-      })),
-      bodyweight,
-    ),
+  const adjustedExerciseSets = applyBodyweight(
+    exerciseSets.map((s) => ({
+      weight: s.weight,
+      reps: s.reps,
+      isWarmup: s.isWarmup,
+      sessionId: s.sessionId,
+      sessionStartedAt: s.session.startedAt,
+      usesBodyweight: selectedUsesBodyweight,
+    })),
+    bodyweight,
   );
+  const exercisePoints = exerciseProgress(adjustedExerciseSets);
+
+  // The goal is measured against the best bodyweight-adjusted e1RM over the
+  // full history loaded above.
+  const selectedBestE1RM = best1RM(adjustedExerciseSets);
 
   // Weekly volume by muscle group over the period (12 weeks).
   const weeklySetsRaw = await db.set.findMany({
@@ -307,6 +321,18 @@ export default async function ProgressPage({
               volumeLandmarks={volumeLandmarks}
               recap={recap}
               unit={unit}
+              selectedGoal={
+                selectedGoal
+                  ? {
+                      id: selectedGoal.id,
+                      targetWeight: selectedGoal.targetWeight,
+                      targetReps: selectedGoal.targetReps,
+                      achievedAt: selectedGoal.achievedAt?.toISOString() ?? null,
+                    }
+                  : null
+              }
+              selectedBestE1RM={selectedBestE1RM}
+              selectedUsesBodyweight={selectedUsesBodyweight}
             />
           </>
         )}

--- a/app/api/goals/[id]/route.ts
+++ b/app/api/goals/[id]/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { ApiError, handleApiError, requireApiUserId } from '@/lib/api';
+
+interface Params {
+  params: { id: string };
+}
+
+// DELETE /api/goals/[id]: removes one of the user's exercise goals.
+export async function DELETE(_req: Request, { params }: Params) {
+  try {
+    const userId = await requireApiUserId();
+    const goal = await db.exerciseGoal.findUnique({ where: { id: params.id } });
+    if (!goal || goal.userId !== userId) {
+      throw new ApiError(404, 'Goal not found.');
+    }
+    await db.exerciseGoal.delete({ where: { id: params.id } });
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/app/api/goals/route.ts
+++ b/app/api/goals/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { goalInputSchema } from '@/lib/schemas/goal';
+import { ApiError, handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
+import { findAchievingSet } from '@/lib/goals';
+import { applyBodyweight } from '@/lib/stats';
+
+// GET /api/goals: the user's exercise goals, with the exercise identity.
+export async function GET() {
+  try {
+    const userId = await requireApiUserId();
+    const goals = await db.exerciseGoal.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+      include: {
+        exercise: { select: { id: true, name: true, usesBodyweight: true } },
+      },
+    });
+    return NextResponse.json(goals);
+  } catch (err) {
+    return handleApiError(err);
+  }
+}
+
+// POST /api/goals: create or replace the goal for one of the user's
+// exercises (one active goal per exercise - upsert on the unique constraint).
+// achievedAt is re-derived deterministically from the logged sets: if a past
+// working set already meets the target, the goal is achieved as of that set's
+// completedAt; otherwise it starts unachieved and gets stamped at set-save.
+export async function POST(req: Request) {
+  try {
+    const userId = await requireApiUserId();
+    const data = await parseJsonBody(req, goalInputSchema);
+
+    const exercise = await db.exercise.findUnique({ where: { id: data.exerciseId } });
+    if (!exercise || exercise.userId !== userId) {
+      throw new ApiError(404, 'Exercise not found.');
+    }
+
+    // All working sets of this exercise, bodyweight-adjusted so the
+    // comparison runs on effective load (same semantics as lib/stats).
+    const [user, sets] = await Promise.all([
+      db.user.findUnique({ where: { id: userId }, select: { bodyweight: true } }),
+      db.set.findMany({
+        where: { exerciseId: data.exerciseId, isWarmup: false, session: { userId } },
+        select: { weight: true, reps: true, isWarmup: true, completedAt: true },
+      }),
+    ]);
+    const adjusted = applyBodyweight(
+      sets.map((s) => ({ ...s, usesBodyweight: exercise.usesBodyweight })),
+      user?.bodyweight,
+    );
+    const achieving = findAchievingSet(adjusted, data);
+
+    const goal = await db.exerciseGoal.upsert({
+      where: { userId_exerciseId: { userId, exerciseId: data.exerciseId } },
+      create: {
+        userId,
+        exerciseId: data.exerciseId,
+        targetWeight: data.targetWeight,
+        targetReps: data.targetReps,
+        achievedAt: achieving?.completedAt ?? null,
+      },
+      update: {
+        targetWeight: data.targetWeight,
+        targetReps: data.targetReps,
+        achievedAt: achieving?.completedAt ?? null,
+        // Replacing the goal restarts its lifetime.
+        createdAt: new Date(),
+      },
+    });
+    return NextResponse.json(goal, { status: 201 });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/app/api/sessions/[id]/sets/route.ts
+++ b/app/api/sessions/[id]/sets/route.ts
@@ -1,7 +1,10 @@
 import { NextResponse } from 'next/server';
+import type { Exercise, Set } from '@prisma/client';
 import { db } from '@/lib/db';
 import { setInputSchema } from '@/lib/schemas/set';
 import { ApiError, handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
+import { setAchievesGoal } from '@/lib/goals';
+import { effectiveWeight } from '@/lib/stats';
 
 interface Params {
   params: { id: string };
@@ -41,8 +44,50 @@ export async function POST(req: Request, { params }: Params) {
         isDropSet: data.isDropSet ?? false,
       },
     });
+    // Best-effort: the set is already committed, so a failure here must never
+    // fail the request (a 500 would make the offline sync retry the POST and
+    // duplicate the set). An unstamped goal self-heals on the next achieving
+    // set or on goal re-creation, which re-derives achievedAt from history.
+    try {
+      await stampGoalIfAchieved(userId, exercise, created);
+    } catch (stampErr) {
+      console.error('[api] goal achievement stamping failed:', stampErr);
+    }
+
     return NextResponse.json(created, { status: 201 });
   } catch (err) {
     return handleApiError(err);
+  }
+}
+
+// Per-exercise goal (issue #90): when a freshly logged working set meets an
+// unachieved goal's target, stamp achievedAt with the set's completedAt
+// (deterministic - the same instant the goal-creation path would derive).
+// Comparison runs on the effective load (bodyweight + added load for
+// bodyweight exercises), consistent with lib/stats.
+async function stampGoalIfAchieved(
+  userId: string,
+  exercise: Exercise,
+  set: Set,
+): Promise<void> {
+  if (set.isWarmup) return;
+  const goal = await db.exerciseGoal.findUnique({
+    where: { userId_exerciseId: { userId, exerciseId: exercise.id } },
+  });
+  if (!goal || goal.achievedAt) return;
+
+  let weight = set.weight;
+  if (exercise.usesBodyweight) {
+    const user = await db.user.findUnique({
+      where: { id: userId },
+      select: { bodyweight: true },
+    });
+    weight = effectiveWeight(set.weight, true, user?.bodyweight);
+  }
+  if (setAchievesGoal({ weight, reps: set.reps, isWarmup: set.isWarmup }, goal)) {
+    await db.exerciseGoal.update({
+      where: { id: goal.id },
+      data: { achievedAt: set.completedAt },
+    });
   }
 }

--- a/components/progress/exercise-goal-card.test.tsx
+++ b/components/progress/exercise-goal-card.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ExerciseGoalCard } from './exercise-goal-card';
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const refresh = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh }),
+}));
+
+function lastFetchCall(fetchMock: ReturnType<typeof vi.fn>) {
+  return fetchMock.mock.calls.at(-1) as [string, RequestInit | undefined];
+}
+
+// 100x5 goal -> target e1RM 116.7; best e1RM 105 -> 90%.
+const goal = {
+  id: 'g1',
+  targetWeight: 100,
+  targetReps: 5,
+  achievedAt: null,
+};
+
+function renderCard(over: Partial<Parameters<typeof ExerciseGoalCard>[0]> = {}) {
+  return render(
+    <ExerciseGoalCard
+      exerciseId="e1"
+      exerciseName="Squat"
+      usesBodyweight={false}
+      goal={goal}
+      bestE1RM={105}
+      unit="KG"
+      {...over}
+    />,
+  );
+}
+
+describe('ExerciseGoalCard', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('shows the target and the e1RM progress percentage', () => {
+    renderCard();
+    expect(screen.getByText(/target: 100 kg x 5 reps/i)).toBeInTheDocument();
+    // 105 / 116.67 = 90%.
+    expect(screen.getByText(/90% of the target/i)).toBeInTheDocument();
+    expect(screen.queryByText('Achieved')).not.toBeInTheDocument();
+  });
+
+  it('shows the achieved badge once achievedAt is set', () => {
+    renderCard({ goal: { ...goal, achievedAt: '2026-06-01T10:00:00Z' } });
+    expect(screen.getByText('Achieved')).toBeInTheDocument();
+  });
+
+  it('offers to set a goal when none exists', () => {
+    renderCard({ goal: null });
+    expect(screen.getByText(/no goal set for this exercise/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Set a goal' })).toBeInTheDocument();
+  });
+
+  it('posts the goal in kg, converting from the display unit (lb)', async () => {
+    const user = userEvent.setup();
+    renderCard({ goal: null, unit: 'LB' });
+
+    await user.click(screen.getByRole('button', { name: 'Set a goal' }));
+    await user.type(screen.getByLabelText(/target load/i), '225');
+    await user.type(screen.getByLabelText(/target reps/i), '5');
+    await user.click(screen.getByRole('button', { name: 'Save goal' }));
+
+    const [url, init] = lastFetchCall(fetchMock);
+    expect(url).toBe('/api/goals');
+    const body = JSON.parse(init?.body as string) as {
+      exerciseId: string;
+      targetWeight: number;
+      targetReps: number;
+    };
+    expect(body.exerciseId).toBe('e1');
+    // 225 lb = 102.06 kg.
+    expect(body.targetWeight).toBeCloseTo(102.06, 1);
+    expect(body.targetReps).toBe(5);
+    expect(refresh).toHaveBeenCalled();
+  });
+
+  it('deletes the goal through the API', async () => {
+    const user = userEvent.setup();
+    renderCard();
+
+    await user.click(screen.getByRole('button', { name: 'Remove' }));
+
+    const [url, init] = lastFetchCall(fetchMock);
+    expect(url).toBe('/api/goals/g1');
+    expect(init?.method).toBe('DELETE');
+    expect(refresh).toHaveBeenCalled();
+  });
+
+  it('rejects an empty or non-positive target without calling the API', async () => {
+    const user = userEvent.setup();
+    renderCard({ goal: null });
+
+    await user.click(screen.getByRole('button', { name: 'Set a goal' }));
+    await user.click(screen.getByRole('button', { name: 'Save goal' }));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('mentions the effective-load semantics for bodyweight exercises', async () => {
+    const user = userEvent.setup();
+    renderCard({ goal: null, usesBodyweight: true });
+
+    await user.click(screen.getByRole('button', { name: 'Set a goal' }));
+    expect(screen.getByText(/total effective load/i)).toBeInTheDocument();
+  });
+});

--- a/components/progress/exercise-goal-card.tsx
+++ b/components/progress/exercise-goal-card.tsx
@@ -1,0 +1,228 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { Target } from 'lucide-react';
+import type { WeightUnit } from '@prisma/client';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Progress } from '@/components/ui/progress';
+import { goalProgress, goalTargetE1RM } from '@/lib/goals';
+import { formatWeight, fromDisplayWeight, roundWeight, toDisplayWeight, unitLabel } from '@/lib/units';
+
+// One active goal per exercise, as served by the goals API. achievedAt is
+// serialized to an ISO string by the Server Component boundary.
+export interface GoalView {
+  id: string;
+  targetWeight: number; // kg (effective load for bodyweight exercises)
+  targetReps: number;
+  achievedAt: string | null;
+}
+
+interface Props {
+  exerciseId: string;
+  exerciseName: string;
+  usesBodyweight: boolean;
+  goal: GoalView | null;
+  // Best e1RM ever logged for this exercise (kg, bodyweight-adjusted).
+  bestE1RM: number;
+  unit: WeightUnit;
+}
+
+export function ExerciseGoalCard({
+  exerciseId,
+  exerciseName,
+  usesBodyweight,
+  goal,
+  bestE1RM,
+  unit,
+}: Props) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  // Dialog fields, kept in the display unit like every weight input.
+  const [weightField, setWeightField] = useState('');
+  const [repsField, setRepsField] = useState('');
+
+  const target = goal
+    ? { targetWeight: goal.targetWeight, targetReps: goal.targetReps }
+    : null;
+  const progress = target ? goalProgress(bestE1RM, target) : 0;
+  const achieved = goal?.achievedAt != null;
+
+  function openDialog() {
+    setWeightField(
+      goal ? String(roundWeight(toDisplayWeight(goal.targetWeight, unit), 1)) : '',
+    );
+    setRepsField(goal ? String(goal.targetReps) : '');
+    setOpen(true);
+  }
+
+  async function saveGoal() {
+    const weight = parseFloat(weightField);
+    const reps = parseInt(repsField, 10);
+    if (!Number.isFinite(weight) || weight <= 0 || !Number.isInteger(reps) || reps < 1) {
+      toast.error('Enter a positive target weight and at least 1 rep.');
+      return;
+    }
+    setBusy(true);
+    try {
+      const res = await fetch('/api/goals', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          exerciseId,
+          targetWeight: fromDisplayWeight(weight, unit),
+          targetReps: reps,
+        }),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as { error?: string } | null;
+        toast.error(data?.error ?? 'Could not save the goal.');
+        return;
+      }
+      toast.success('Goal saved.');
+      setOpen(false);
+      router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function removeGoal() {
+    if (!goal) return;
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/goals/${goal.id}`, { method: 'DELETE' });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as { error?: string } | null;
+        toast.error(data?.error ?? 'Could not remove the goal.');
+        return;
+      }
+      toast.success('Goal removed.');
+      router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h2 className="flex items-center gap-2 text-base font-semibold">
+            <Target className="size-4" />
+            Goal - {exerciseName}
+          </h2>
+          <div className="flex items-center gap-2">
+            <Button type="button" variant="outline" size="sm" onClick={openDialog}>
+              {goal ? 'Edit goal' : 'Set a goal'}
+            </Button>
+            {goal && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={removeGoal}
+                disabled={busy}
+              >
+                Remove
+              </Button>
+            )}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {!goal || !target ? (
+          <p className="text-sm text-muted-foreground">
+            No goal set for this exercise. Set a target load and reps to track
+            your progress toward it.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            <div className="flex flex-wrap items-center justify-between gap-2 text-sm">
+              <span className="font-medium">
+                Target: {formatWeight(goal.targetWeight, unit)} x {goal.targetReps}{' '}
+                {goal.targetReps === 1 ? 'rep' : 'reps'}
+              </span>
+              {achieved && (
+                <Badge className="bg-emerald-600 text-white hover:bg-emerald-600">
+                  Achieved
+                </Badge>
+              )}
+            </div>
+            <Progress
+              value={Math.round(progress * 100)}
+              aria-label="Progress toward goal"
+            />
+            <p className="text-xs text-muted-foreground">
+              {Math.round(progress * 100)}% of the target on the estimated-1RM
+              scale ({formatWeight(bestE1RM, unit)} best vs{' '}
+              {formatWeight(goalTargetE1RM(target), unit)} target).
+            </p>
+          </div>
+        )}
+      </CardContent>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {goal ? 'Edit the goal' : 'Set a goal'} - {exerciseName}
+            </DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="goal-weight">Target load ({unitLabel(unit)})</Label>
+              <Input
+                id="goal-weight"
+                type="number"
+                inputMode="decimal"
+                step="0.5"
+                min="0"
+                value={weightField}
+                onChange={(e) => setWeightField(e.target.value)}
+              />
+              {usesBodyweight && (
+                <p className="text-xs text-muted-foreground">
+                  Bodyweight exercise: enter the total effective load
+                  (bodyweight + added load), like the progress charts.
+                </p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="goal-reps">Target reps</Label>
+              <Input
+                id="goal-reps"
+                type="number"
+                inputMode="numeric"
+                min="1"
+                value={repsField}
+                onChange={(e) => setRepsField(e.target.value)}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="button" onClick={saveGoal} disabled={busy}>
+              {busy ? 'Saving...' : 'Save goal'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}

--- a/components/progress/progress-dashboard.tsx
+++ b/components/progress/progress-dashboard.tsx
@@ -31,6 +31,7 @@ import {
   type VolumeLandmarkZone,
 } from '@/lib/stats';
 import { roundWeight, toDisplayWeight, unitLabel } from '@/lib/units';
+import { ExerciseGoalCard, type GoalView } from '@/components/progress/exercise-goal-card';
 
 interface RecapRow {
   exerciseId: string;
@@ -72,6 +73,11 @@ interface Props {
   volumeLandmarks: VolumeLandmarks | null;
   recap: RecapRow[];
   unit: WeightUnit;
+  // Target goal for the selected exercise (issue #90), with the
+  // bodyweight-adjusted best e1RM it is measured against.
+  selectedGoal: GoalView | null;
+  selectedBestE1RM: number;
+  selectedUsesBodyweight: boolean;
 }
 
 // Badge variant + short label per zone. Below MEV and above MRV are both
@@ -124,6 +130,9 @@ export function ProgressDashboard({
   volumeLandmarks,
   recap,
   unit,
+  selectedGoal,
+  selectedBestE1RM,
+  selectedUsesBodyweight,
 }: Props) {
   const router = useRouter();
   const search = useSearchParams();
@@ -264,6 +273,18 @@ export function ProgressDashboard({
           )}
         </CardContent>
       </Card>
+
+      {/* Target goal for the selected exercise */}
+      {selectedExerciseId && selectedExo && (
+        <ExerciseGoalCard
+          exerciseId={selectedExerciseId}
+          exerciseName={selectedExo.name}
+          usesBodyweight={selectedUsesBodyweight}
+          goal={selectedGoal}
+          bestE1RM={selectedBestE1RM}
+          unit={unit}
+        />
+      )}
 
       {/* Stacked weekly volume per muscle group */}
       <Card>

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -6,6 +6,40 @@ by the charter in [`07-autonomy.md`](07-autonomy.md).
 
 ---
 
+## 2026-06-10 - Maintainer run: shipped #89 (set shorthand) and #90 (exercise goals)
+
+**Context.** Maintainer tick over the third ideate batch. Both issues trust-gated (author
+`JulienAu`), implemented in order, each behind its own PR and CI run. Merge budget 3; used 2.
+
+**Shipped.**
+- **#89 -> PR #94 (merged): quick set logging via shorthand.** Pure parser
+  `lib/set-shorthand.ts` (`100x8`, `100 8`, `100x8@9`, decimals, RPE 1-10) + a quick-entry
+  field in `set-input.tsx` that fills the classic weight/reps/RIR fields. The app tracks RIR,
+  not RPE, so `rpeToRir` maps RIR = 10 - RPE rounded, clamped to the API's 0-5. Weight read in
+  the display unit via `fromDisplayWeight`. No API/schema change. 28 new unit/component tests.
+- **#90 -> PR #95 (this PR): per-exercise target goals.** First feature shipped under the
+  charter's "complex features" directive, so it carries the reinforced controls: additive
+  `ExerciseGoal` migration (validated with `prisma migrate deploy` + `migrate diff` drift
+  check against the seeded test DB), Zod-validated upsert/list/delete routes with ownership
+  tests, pure `lib/goals.ts` (progress = best e1RM / target e1RM; achievement = working set
+  meeting both axes, stamped deterministically with the achieving set's `completedAt`),
+  effectiveWeight semantics for bodyweight exercises at every layer, goal card + dialog on the
+  progress page, and tests at all touched layers including a full E2E flow
+  (`tests/e2e/goals.spec.ts`: set -> track -> achieve -> remove). `verify.sh --full` run
+  locally before the PR; rollback baseline `autonomy-baseline-2026-06-10` tagged before merge.
+
+**Challenged.**
+- #89: independent skeptic on the staged diff. Caught early in self-review: a regex
+  backtracking trap (`100 89.5` would have parsed as reps 8 @ RPE 9.5) - fixed by requiring a
+  separator before the RPE; the skeptic pass then surfaced two cosmetic findings (a misleading
+  test name, fixed; keep-RIR-when-RPE-deleted judged the correct default).
+- #90: multi-lens review (correctness + does-it-actually-work), findings recorded in the PR.
+
+**Deferred to human.** Nothing blocking. Note for ops: the local Docker daemon was down at
+run start; the loop started Docker Desktop itself to run the full gate.
+
+---
+
 ## 2026-06-10 - Operator directive: complex features with reinforced controls; third ideate batch
 
 **Context.** The operator widened the feature mandate in-session: complex features (data-safe

--- a/lib/goals.test.ts
+++ b/lib/goals.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import {
+  findAchievingSet,
+  goalProgress,
+  goalTargetE1RM,
+  setAchievesGoal,
+} from './goals';
+import { applyBodyweight, best1RM, effectiveWeight } from './stats';
+
+const target = { targetWeight: 100, targetReps: 5 };
+
+function set(over: Partial<{ weight: number; reps: number; isWarmup: boolean; completedAt: Date }>) {
+  return {
+    weight: 80,
+    reps: 8,
+    isWarmup: false,
+    completedAt: new Date('2026-06-01T10:00:00Z'),
+    ...over,
+  };
+}
+
+describe('goalTargetE1RM', () => {
+  it('uses the Epley formula like the rest of the app', () => {
+    // 100 x 5 -> 100 * (1 + 5/30)
+    expect(goalTargetE1RM(target)).toBeCloseTo(116.67, 1);
+  });
+});
+
+describe('goalProgress', () => {
+  it('returns 0 with no sets yet (bestE1RM = 0)', () => {
+    expect(goalProgress(0, target)).toBe(0);
+    expect(goalProgress(best1RM([]), target)).toBe(0);
+  });
+
+  it('returns the e1RM fraction toward the goal', () => {
+    // Best so far: 90x5 -> 105 e1RM; target 100x5 -> 116.67.
+    const best = best1RM([set({ weight: 90, reps: 5 })]);
+    expect(goalProgress(best, target)).toBeCloseTo(105 / (100 * (1 + 5 / 30)), 5);
+  });
+
+  it('clamps at 1 when the target is already beaten', () => {
+    const best = best1RM([set({ weight: 120, reps: 8 })]);
+    expect(goalProgress(best, target)).toBe(1);
+  });
+
+  it('returns 0 on a degenerate target', () => {
+    expect(goalProgress(100, { targetWeight: 0, targetReps: 5 })).toBe(0);
+  });
+});
+
+describe('setAchievesGoal', () => {
+  it('requires both axes to meet the target', () => {
+    expect(setAchievesGoal(set({ weight: 100, reps: 5 }), target)).toBe(true);
+    expect(setAchievesGoal(set({ weight: 102.5, reps: 6 }), target)).toBe(true);
+    expect(setAchievesGoal(set({ weight: 100, reps: 4 }), target)).toBe(false);
+    expect(setAchievesGoal(set({ weight: 97.5, reps: 12 }), target)).toBe(false);
+  });
+
+  it('ignores warmup sets', () => {
+    expect(setAchievesGoal(set({ weight: 100, reps: 5, isWarmup: true }), target)).toBe(false);
+  });
+});
+
+describe('findAchievingSet', () => {
+  it('returns null when nothing meets the target', () => {
+    expect(findAchievingSet([set({ weight: 95, reps: 5 })], target)).toBeNull();
+  });
+
+  it('finds a past set that already beat the target at goal-creation time', () => {
+    const old = set({ weight: 105, reps: 5, completedAt: new Date('2026-05-01T10:00:00Z') });
+    const recent = set({ weight: 110, reps: 5, completedAt: new Date('2026-06-01T10:00:00Z') });
+    expect(findAchievingSet([recent, old], target)).toBe(old);
+  });
+
+  it('is deterministic: picks the earliest achieving set regardless of order', () => {
+    const a = set({ weight: 100, reps: 5, completedAt: new Date('2026-05-02T10:00:00Z') });
+    const b = set({ weight: 100, reps: 6, completedAt: new Date('2026-05-01T10:00:00Z') });
+    expect(findAchievingSet([a, b], target)).toBe(b);
+    expect(findAchievingSet([b, a], target)).toBe(b);
+  });
+});
+
+describe('bodyweight exercises (effectiveWeight semantics, like lib/stats)', () => {
+  // Weighted pull-ups: bodyweight 80 kg, target = 100 kg effective x 5
+  // (i.e. +20 kg added). Set.weight stores only the added load.
+  const bodyweight = 80;
+
+  it('achieves through the effective load, not the raw added load', () => {
+    const raw = { weight: 20, reps: 5, isWarmup: false };
+    // Raw added load (20) never reaches 100 ...
+    expect(setAchievesGoal(raw, target)).toBe(false);
+    // ... but the effective load (80 + 20) does.
+    const adjusted = {
+      ...raw,
+      weight: effectiveWeight(raw.weight, true, bodyweight),
+    };
+    expect(setAchievesGoal(adjusted, target)).toBe(true);
+  });
+
+  it('progress uses the bodyweight-adjusted best e1RM, like the progress page', () => {
+    const sets = applyBodyweight(
+      [{ weight: 10, reps: 5, isWarmup: false, usesBodyweight: true }],
+      bodyweight,
+    );
+    // Effective 90x5 -> 105 e1RM vs target 116.67.
+    expect(goalProgress(best1RM(sets), target)).toBeCloseTo(105 / (100 * (1 + 5 / 30)), 5);
+  });
+});

--- a/lib/goals.ts
+++ b/lib/goals.ts
@@ -1,0 +1,59 @@
+import { estimate1RM } from '@/lib/stats';
+
+// ============================================================
+// Per-exercise target goals (issue #90) - pure derivations
+// ============================================================
+//
+// A goal is a concrete "weight x reps" target. Progress is measured on the
+// e1RM scale so a 5-rep target and an 8-rep PR remain comparable:
+//
+//   progress = min(1, best e1RM so far / estimate1RM(targetWeight, targetReps))
+//
+// Bodyweight semantics: every weight entering these helpers (set weights AND
+// the goal target) must be on the same scale as lib/stats.ts - i.e. the
+// EFFECTIVE load. Callers adjust set weights with applyBodyweight /
+// effectiveWeight before calling, exactly like the progress page does.
+
+export interface GoalTarget {
+  // Target load in kg (effective load for bodyweight exercises).
+  targetWeight: number;
+  targetReps: number;
+}
+
+// The e1RM the target corresponds to (Epley, like the rest of the app).
+export function goalTargetE1RM(target: GoalTarget): number {
+  return estimate1RM(target.targetWeight, target.targetReps);
+}
+
+// Fraction of the way to the goal on the e1RM scale, clamped to [0, 1].
+// Returns 0 with no training data yet (bestE1RM <= 0) or a degenerate target.
+export function goalProgress(bestE1RM: number, target: GoalTarget): number {
+  const targetE1RM = goalTargetE1RM(target);
+  if (targetE1RM <= 0 || bestE1RM <= 0) return 0;
+  return Math.min(1, bestE1RM / targetE1RM);
+}
+
+// A set is achieving when it is a working set (not a warmup) matching or
+// beating the target on BOTH axes: weight >= targetWeight and
+// reps >= targetReps.
+export function setAchievesGoal(
+  set: { weight: number; reps: number; isWarmup: boolean },
+  target: GoalTarget,
+): boolean {
+  return !set.isWarmup && set.weight >= target.targetWeight && set.reps >= target.targetReps;
+}
+
+// Earliest set that achieves the goal, or null. Used to stamp achievedAt
+// deterministically (the achieving set's completedAt, not "now"), so the
+// result is the same whether the goal is checked at set-save time or when a
+// goal is created over an already-beaten target.
+export function findAchievingSet<
+  T extends { weight: number; reps: number; isWarmup: boolean; completedAt: Date },
+>(sets: T[], target: GoalTarget): T | null {
+  let earliest: T | null = null;
+  for (const s of sets) {
+    if (!setAchievesGoal(s, target)) continue;
+    if (earliest === null || s.completedAt < earliest.completedAt) earliest = s;
+  }
+  return earliest;
+}

--- a/lib/schemas/goal.test.ts
+++ b/lib/schemas/goal.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { goalInputSchema } from './goal';
+
+const valid = { exerciseId: 'e1', targetWeight: 100, targetReps: 5 };
+
+describe('goalInputSchema', () => {
+  it('accepts a valid goal', () => {
+    expect(goalInputSchema.parse(valid)).toEqual(valid);
+  });
+
+  it('coerces numeric strings (form payloads)', () => {
+    const parsed = goalInputSchema.parse({
+      exerciseId: 'e1',
+      targetWeight: '62.5',
+      targetReps: '8',
+    });
+    expect(parsed.targetWeight).toBe(62.5);
+    expect(parsed.targetReps).toBe(8);
+  });
+
+  it('rejects a missing or empty exerciseId', () => {
+    expect(goalInputSchema.safeParse({ ...valid, exerciseId: '' }).success).toBe(false);
+    const { exerciseId: _omitted, ...rest } = valid;
+    expect(goalInputSchema.safeParse(rest).success).toBe(false);
+  });
+
+  it('rejects non-positive or out-of-range weight', () => {
+    expect(goalInputSchema.safeParse({ ...valid, targetWeight: 0 }).success).toBe(false);
+    expect(goalInputSchema.safeParse({ ...valid, targetWeight: -10 }).success).toBe(false);
+    expect(goalInputSchema.safeParse({ ...valid, targetWeight: 1001 }).success).toBe(false);
+  });
+
+  it('rejects zero, negative, decimal, or out-of-range reps', () => {
+    expect(goalInputSchema.safeParse({ ...valid, targetReps: 0 }).success).toBe(false);
+    expect(goalInputSchema.safeParse({ ...valid, targetReps: -1 }).success).toBe(false);
+    expect(goalInputSchema.safeParse({ ...valid, targetReps: 5.5 }).success).toBe(false);
+    expect(goalInputSchema.safeParse({ ...valid, targetReps: 101 }).success).toBe(false);
+  });
+});

--- a/lib/schemas/goal.ts
+++ b/lib/schemas/goal.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+// Per-exercise target goal input (issue #90). The weight arrives in kg (the
+// client converts from the display unit before posting, like the set form).
+// For bodyweight exercises the target is the EFFECTIVE load (bodyweight +
+// added load), consistent with lib/stats.ts effectiveWeight semantics.
+//
+// Bounds: weight mirrors the set schema's 500 kg ceiling but doubled to leave
+// room for effective bodyweight loads; reps mirrors the set schema's 100 cap.
+export const goalInputSchema = z.object({
+  exerciseId: z.string().min(1),
+  targetWeight: z.coerce.number().positive().max(1000),
+  targetReps: z.coerce.number().int().min(1).max(100),
+});
+
+export type GoalInput = z.infer<typeof goalInputSchema>;

--- a/prisma/migrations/20260610080000_add_exercise_goal/migration.sql
+++ b/prisma/migrations/20260610080000_add_exercise_goal/migration.sql
@@ -1,0 +1,23 @@
+-- Additive migration (issue #90): per-exercise target goals. New table only,
+-- no change to existing tables.
+
+-- CreateTable
+CREATE TABLE "ExerciseGoal" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "exerciseId" TEXT NOT NULL,
+    "targetWeight" DOUBLE PRECISION NOT NULL,
+    "targetReps" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "achievedAt" TIMESTAMP(3),
+    CONSTRAINT "ExerciseGoal_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ExerciseGoal_userId_exerciseId_key" ON "ExerciseGoal"("userId", "exerciseId");
+
+-- AddForeignKey
+ALTER TABLE "ExerciseGoal" ADD CONSTRAINT "ExerciseGoal_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ExerciseGoal" ADD CONSTRAINT "ExerciseGoal_exerciseId_fkey" FOREIGN KEY ("exerciseId") REFERENCES "Exercise"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,6 +34,7 @@ model User {
   exercises     Exercise[]
   conversations Conversation[]
   readinessCheckins ReadinessCheckin[]
+  exerciseGoals ExerciseGoal[]
 }
 
 enum Sex {
@@ -100,6 +101,7 @@ model Exercise {
   createdAt        DateTime          @default(now())
   programExercises ProgramExercise[]
   sets             Set[]
+  goals            ExerciseGoal[]
 
   @@unique([userId, name])
 }
@@ -202,6 +204,29 @@ model Set {
   completedAt DateTime @default(now())
 
   @@index([exerciseId, completedAt])
+}
+
+// Per-exercise target goal (issue #90): a concrete "weight x reps" the user
+// wants to reach, measured against the existing e1RM machinery (lib/goals.ts).
+// Additive: one active goal per (user, exercise); creating a new one replaces
+// it (upsert on the unique constraint). Weight is stored in kg like Set.weight;
+// for bodyweight exercises it is the EFFECTIVE load (bodyweight + added load),
+// consistent with lib/stats.ts effectiveWeight semantics.
+model ExerciseGoal {
+  id           String    @id @default(cuid())
+  userId       String
+  user         User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  exerciseId   String
+  exercise     Exercise  @relation(fields: [exerciseId], references: [id], onDelete: Cascade)
+  // Target load in kg (effective load for bodyweight exercises).
+  targetWeight Float
+  targetReps   Int
+  createdAt    DateTime  @default(now())
+  // Stamped server-side when a logged working set meets the target
+  // (weight >= targetWeight and reps >= targetReps). Null = not achieved yet.
+  achievedAt   DateTime?
+
+  @@unique([userId, exerciseId])
 }
 
 model CoachSession {

--- a/tests/e2e/goals.spec.ts
+++ b/tests/e2e/goals.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// Per-exercise target goals (issue #90): set a goal on the progress page,
+// watch the progress bar, reach it, see the achieved badge, remove it.
+// Data is seeded through the authenticated API (the browser context shares
+// cookies with page.request), which keeps the test fast and deterministic.
+
+async function seedLoggedSet(page: Page) {
+  // One exercise, one program/workout, one finished session with a 90x5 set.
+  const exerciseRes = await page.request.post('/api/exercises', {
+    data: { name: 'Goal Bench', muscleGroup: 'CHEST', category: 'COMPOUND' },
+  });
+  expect(exerciseRes.ok()).toBeTruthy();
+  const exercise = await exerciseRes.json();
+
+  const programRes = await page.request.post('/api/programs', {
+    data: { name: 'E2E Program', phase: 'Base' },
+  });
+  expect(programRes.ok()).toBeTruthy();
+  const program = await programRes.json();
+
+  const workoutRes = await page.request.post(`/api/programs/${program.id}/workouts`, {
+    data: { name: 'Day A' },
+  });
+  expect(workoutRes.ok()).toBeTruthy();
+  const workout = await workoutRes.json();
+
+  const sessionRes = await page.request.post('/api/sessions', {
+    data: { workoutId: workout.id },
+  });
+  expect(sessionRes.ok()).toBeTruthy();
+  const session = await sessionRes.json();
+
+  const setRes = await page.request.post(`/api/sessions/${session.id}/sets`, {
+    data: { exerciseId: exercise.id, setNumber: 1, weight: 90, reps: 5 },
+  });
+  expect(setRes.ok()).toBeTruthy();
+
+  const finishRes = await page.request.put(`/api/sessions/${session.id}`, {
+    data: { finish: true },
+  });
+  expect(finishRes.ok()).toBeTruthy();
+}
+
+test('a lifter can set, track, achieve, and remove an exercise goal', async ({ page }) => {
+  // Sign up (fresh user each run).
+  await page.goto('/signup');
+  await page.getByLabel('Name').fill('Goal E2E');
+  await page.getByLabel('Email').fill(`e2e-goals-${Date.now()}@test.dev`);
+  await page.getByLabel('Password').fill('supersecret');
+  await page.getByRole('button', { name: 'Create account' }).click();
+  await expect(page).toHaveURL('/');
+
+  await seedLoggedSet(page);
+
+  // Set a goal of 100x5: the 90x5 best (e1RM 105 vs 116.7) is 90% there.
+  await page.goto('/progress');
+  await expect(page.getByText('Goal - Goal Bench')).toBeVisible();
+  await page.getByRole('button', { name: 'Set a goal' }).click();
+  await page.getByLabel(/target load/i).fill('100');
+  await page.getByLabel(/target reps/i).fill('5');
+  await page.getByRole('button', { name: 'Save goal' }).click();
+
+  await expect(page.getByText(/90% of the target/i)).toBeVisible();
+  await expect(page.getByText('Achieved')).not.toBeVisible();
+
+  // Lower the target to 80x3: the existing 90x5 set already beats it.
+  await page.getByRole('button', { name: 'Edit goal' }).click();
+  await page.getByLabel(/target load/i).fill('80');
+  await page.getByLabel(/target reps/i).fill('3');
+  await page.getByRole('button', { name: 'Save goal' }).click();
+
+  await expect(page.getByText('Achieved')).toBeVisible();
+  await expect(page.getByText(/100% of the target/i)).toBeVisible();
+
+  // Remove the goal.
+  await page.getByRole('button', { name: 'Remove' }).click();
+  await expect(page.getByText(/no goal set for this exercise/i)).toBeVisible();
+});

--- a/tests/integration/goals-route.test.ts
+++ b/tests/integration/goals-route.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { db } from '@/lib/db';
+import { getCurrentUserId } from '@/lib/auth';
+
+// Auth is read through getCurrentUserId (via requireApiUserId in @/lib/api).
+// Mock it so we can act as either user without real cookies/JWTs.
+vi.mock('@/lib/auth', () => ({ getCurrentUserId: vi.fn() }));
+const mockUserId = vi.mocked(getCurrentUserId);
+
+import { GET as listGoals, POST as postGoal } from '@/app/api/goals/route';
+import { DELETE as deleteGoal } from '@/app/api/goals/[id]/route';
+import { POST as postSet } from '@/app/api/sessions/[id]/sets/route';
+
+function actAs(userId: string) {
+  mockUserId.mockResolvedValue(userId);
+}
+
+function jsonReq(method: string, body: unknown): Request {
+  return new Request('http://test.local/api', {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+// Seed two users; user A owns an exercise with one logged set (100x5).
+async function seed() {
+  const [a, b] = await Promise.all([
+    db.user.create({ data: { email: 'owner@test.dev', passwordHash: 'x' } }),
+    db.user.create({ data: { email: 'stranger@test.dev', passwordHash: 'x' } }),
+  ]);
+  const exercise = await db.exercise.create({
+    data: { userId: a.id, name: 'Bench', muscleGroup: 'CHEST', category: 'COMPOUND' },
+  });
+  const session = await db.session.create({ data: { userId: a.id } });
+  const set = await db.set.create({
+    data: { sessionId: session.id, exerciseId: exercise.id, setNumber: 1, weight: 100, reps: 5 },
+  });
+  return { a, b, exercise, session, set };
+}
+
+beforeEach(() => {
+  mockUserId.mockReset();
+});
+
+describe('POST /api/goals (create / upsert)', () => {
+  it('creates a goal for the owner, unachieved when no set meets it', async () => {
+    const { a, exercise } = await seed();
+    actAs(a.id);
+    const res = await postGoal(
+      jsonReq('POST', { exerciseId: exercise.id, targetWeight: 120, targetReps: 5 }),
+    );
+    expect(res.status).toBe(201);
+    const goal = await res.json();
+    expect(goal.targetWeight).toBe(120);
+    expect(goal.achievedAt).toBeNull();
+  });
+
+  it('stamps achievedAt at creation when a past set already beats the target', async () => {
+    const { a, exercise, set } = await seed();
+    actAs(a.id);
+    const res = await postGoal(
+      jsonReq('POST', { exerciseId: exercise.id, targetWeight: 95, targetReps: 5 }),
+    );
+    expect(res.status).toBe(201);
+    const goal = await res.json();
+    // Deterministic: stamped with the achieving set's completedAt.
+    expect(new Date(goal.achievedAt).getTime()).toBe(set.completedAt.getTime());
+  });
+
+  it('replaces the existing goal (one per exercise) instead of adding another', async () => {
+    const { a, exercise } = await seed();
+    actAs(a.id);
+    await postGoal(jsonReq('POST', { exerciseId: exercise.id, targetWeight: 95, targetReps: 5 }));
+    const res = await postGoal(
+      jsonReq('POST', { exerciseId: exercise.id, targetWeight: 140, targetReps: 3 }),
+    );
+    expect(res.status).toBe(201);
+    const goals = await db.exerciseGoal.findMany({ where: { userId: a.id } });
+    expect(goals).toHaveLength(1);
+    expect(goals[0]?.targetWeight).toBe(140);
+    // The heavier target is no longer met by the 100x5 set.
+    expect(goals[0]?.achievedAt).toBeNull();
+  });
+
+  it("rejects a goal on another user's exercise", async () => {
+    const { b, exercise } = await seed();
+    actAs(b.id);
+    const res = await postGoal(
+      jsonReq('POST', { exerciseId: exercise.id, targetWeight: 100, targetReps: 5 }),
+    );
+    expect(res.status).toBe(404);
+    expect(await db.exerciseGoal.count()).toBe(0);
+  });
+
+  it('rejects invalid input (Zod)', async () => {
+    const { a, exercise } = await seed();
+    actAs(a.id);
+    const res = await postGoal(
+      jsonReq('POST', { exerciseId: exercise.id, targetWeight: -10, targetReps: 5 }),
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('GET /api/goals', () => {
+  it("lists only the user's own goals", async () => {
+    const { a, b, exercise } = await seed();
+    actAs(a.id);
+    await postGoal(jsonReq('POST', { exerciseId: exercise.id, targetWeight: 120, targetReps: 5 }));
+
+    actAs(b.id);
+    const res = await listGoals();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([]);
+
+    actAs(a.id);
+    const own = await (await listGoals()).json();
+    expect(own).toHaveLength(1);
+    expect(own[0].exercise.name).toBe('Bench');
+  });
+});
+
+describe('DELETE /api/goals/[id]', () => {
+  it('lets the owner delete their goal', async () => {
+    const { a, exercise } = await seed();
+    actAs(a.id);
+    const goal = await (
+      await postGoal(jsonReq('POST', { exerciseId: exercise.id, targetWeight: 120, targetReps: 5 }))
+    ).json();
+    const res = await deleteGoal(new Request('http://t/api', { method: 'DELETE' }), {
+      params: { id: goal.id },
+    });
+    expect(res.status).toBe(200);
+    expect(await db.exerciseGoal.count()).toBe(0);
+  });
+
+  it('returns 404 and keeps the goal when a stranger tries to delete it', async () => {
+    const { a, b, exercise } = await seed();
+    actAs(a.id);
+    const goal = await (
+      await postGoal(jsonReq('POST', { exerciseId: exercise.id, targetWeight: 120, targetReps: 5 }))
+    ).json();
+    actAs(b.id);
+    const res = await deleteGoal(new Request('http://t/api', { method: 'DELETE' }), {
+      params: { id: goal.id },
+    });
+    expect(res.status).toBe(404);
+    expect(await db.exerciseGoal.count()).toBe(1);
+  });
+});
+
+describe('goal achievement at set-save time', () => {
+  it('stamps achievedAt when a newly logged working set meets the target', async () => {
+    const { a, exercise, session } = await seed();
+    actAs(a.id);
+    await postGoal(jsonReq('POST', { exerciseId: exercise.id, targetWeight: 110, targetReps: 4 }));
+
+    const res = await postSet(
+      jsonReq('POST', { exerciseId: exercise.id, setNumber: 2, weight: 110, reps: 4 }),
+      { params: { id: session.id } },
+    );
+    expect(res.status).toBe(201);
+    const created = await res.json();
+
+    const goal = await db.exerciseGoal.findFirst({ where: { userId: a.id } });
+    expect(goal?.achievedAt?.getTime()).toBe(new Date(created.completedAt).getTime());
+  });
+
+  it('does not stamp on a warmup set or a set below the target', async () => {
+    const { a, exercise, session } = await seed();
+    actAs(a.id);
+    await postGoal(jsonReq('POST', { exerciseId: exercise.id, targetWeight: 110, targetReps: 4 }));
+
+    await postSet(
+      jsonReq('POST', { exerciseId: exercise.id, setNumber: 2, weight: 110, reps: 4, isWarmup: true }),
+      { params: { id: session.id } },
+    );
+    await postSet(
+      jsonReq('POST', { exerciseId: exercise.id, setNumber: 3, weight: 105, reps: 4 }),
+      { params: { id: session.id } },
+    );
+
+    const goal = await db.exerciseGoal.findFirst({ where: { userId: a.id } });
+    expect(goal?.achievedAt).toBeNull();
+  });
+
+  it('uses the effective load for bodyweight exercises', async () => {
+    const { a, session } = await seed();
+    await db.user.update({ where: { id: a.id }, data: { bodyweight: 80 } });
+    const pullups = await db.exercise.create({
+      data: {
+        userId: a.id,
+        name: 'Pull-up',
+        muscleGroup: 'BACK_WIDTH',
+        category: 'COMPOUND',
+        usesBodyweight: true,
+      },
+    });
+    actAs(a.id);
+    // Target: 100 kg effective x 5 (bodyweight 80 + 20 added).
+    await postGoal(jsonReq('POST', { exerciseId: pullups.id, targetWeight: 100, targetReps: 5 }));
+
+    // +15 added (95 effective): not achieved.
+    await postSet(
+      jsonReq('POST', { exerciseId: pullups.id, setNumber: 1, weight: 15, reps: 5 }),
+      { params: { id: session.id } },
+    );
+    let goal = await db.exerciseGoal.findFirst({ where: { exerciseId: pullups.id } });
+    expect(goal?.achievedAt).toBeNull();
+
+    // +20 added (100 effective): achieved.
+    await postSet(
+      jsonReq('POST', { exerciseId: pullups.id, setNumber: 2, weight: 20, reps: 5 }),
+      { params: { id: session.id } },
+    );
+    goal = await db.exerciseGoal.findFirst({ where: { exerciseId: pullups.id } });
+    expect(goal?.achievedAt).not.toBeNull();
+  });
+});

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -11,7 +11,7 @@ if (!process.env.DATABASE_URL) {
 // Truncates every table between tests so each starts from a clean slate.
 export async function resetDb(): Promise<void> {
   await db.$executeRawUnsafe(
-    'TRUNCATE TABLE "Message","Conversation","ReadinessCheckin","Set","Session","ProgramExercise","Workout","Program","Exercise","CoachSession","User" RESTART IDENTITY CASCADE;',
+    'TRUNCATE TABLE "Message","Conversation","ReadinessCheckin","ExerciseGoal","Set","Session","ProgramExercise","Workout","Program","Exercise","CoachSession","User" RESTART IDENTITY CASCADE;',
   );
 }
 


### PR DESCRIPTION
Implements issue #90 under the charter's complex-features directive (schema + API + multi-surface), with the reinforced non-regression controls.

## What

- **Additive migration** `20260610080000_add_exercise_goal`: new `ExerciseGoal` table only (unique `(userId, exerciseId)`, cascade on user/exercise delete). Validated locally with `prisma migrate deploy` against the seeded test DB and a `prisma migrate diff` drift check (empty).
- **Zod-validated API**: `POST /api/goals` (create/replace via upsert, exercise ownership enforced), `GET /api/goals`, `DELETE /api/goals/[id]` - all following the existing route patterns (`requireApiUserId`, `parseJsonBody`, `handleApiError`).
- **Pure derivation** in `lib/goals.ts`: progress = min(1, best e1RM / estimate1RM(targetWeight, targetReps)) on the app's Epley scale; a goal is achieved when a working set meets BOTH axes. `achievedAt` is stamped deterministically with the achieving set's `completedAt`, at goal creation (target already beaten) and at set-save (best-effort: a stamping failure never fails the committed set write, so offline sync cannot duplicate sets on retry).
- **Bodyweight exercises** use effectiveWeight semantics at every layer (goal POST re-derivation, set-save stamping, progress page best e1RM), consistent with `lib/stats.ts`; the goal dialog says so explicitly.
- **UI**: goal card on the progress page per-exercise view - progress bar (`components/ui/progress`), achieved badge, set/edit/remove dialog reusing `components/ui` primitives, weights entered/displayed in the user's unit via the existing helpers.
- No LLM/coach output-contract change.

Closes #90

## How I tested

- `bash scripts/verify.sh --full` passed locally (lint + typecheck + unit + build + integration + Playwright E2E), twice: before and after the review fixes.
- Tests at every touched layer: `lib/schemas/goal.test.ts`, `lib/goals.test.ts` (no sets yet, already-beaten target, determinism, bodyweight effective-load semantics), `components/progress/exercise-goal-card.test.tsx` (progress %, achieved badge, lb-to-kg conversion, client-side rejection, bodyweight hint), `tests/integration/goals-route.test.ts` (ownership for POST/GET/DELETE, upsert-replaces, achievement at creation and at set-save incl. warmup/below-target/bodyweight cases), and `tests/e2e/goals.spec.ts` (real app: set goal at 90% -> edit to beaten target -> achieved badge -> remove).
- Multi-lens skeptic review (correctness + does-it-actually-work): one real finding fixed (set-save 500-after-write risk from goal stamping -> made best-effort), one efficiency nit fixed (goal query parallelized), one cosmetic note (no delete confirmation; goal re-creation is lossless) left as-is.
- Rollback baseline `autonomy-baseline-2026-06-10` tagged on main before merge, per the charter's migration rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)