### PR TITLE
fix: re-derive goal achievedAt when the achieving set is deleted

### DIFF
--- a/app/api/sets/[id]/route.ts
+++ b/app/api/sets/[id]/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { ApiError, handleApiError, requireApiUserId } from '@/lib/api';
+import { findAchievingSet } from '@/lib/goals';
+import { effectiveWeight } from '@/lib/stats';
 
 interface Params {
   params: { id: string };
@@ -19,8 +21,67 @@ export async function DELETE(_req: Request, { params }: Params) {
       throw new ApiError(404, 'Set not found.');
     }
     await db.set.delete({ where: { id: params.id } });
+    // Best-effort, mirroring the stamping at set-save: the set is already
+    // gone, so a failure here must never fail the deletion. A stale
+    // achievedAt also self-heals on goal re-creation.
+    try {
+      await rederiveGoalAchievement(userId, set.exerciseId);
+    } catch (rederiveErr) {
+      console.error('[api] goal achievement re-derivation failed:', rederiveErr);
+    }
     return NextResponse.json({ ok: true });
   } catch (err) {
     return handleApiError(err);
+  }
+}
+
+// A deleted set may have been the one that stamped the exercise's goal as
+// achieved (issue #96). Re-derive achievedAt from the remaining sets: clear it
+// when nothing meets the target anymore, or re-stamp it with the earliest
+// remaining achieving set. Comparison runs on the effective load, consistent
+// with the stamping path and lib/stats.
+async function rederiveGoalAchievement(
+  userId: string,
+  exerciseId: string,
+): Promise<void> {
+  const goal = await db.exerciseGoal.findUnique({
+    where: { userId_exerciseId: { userId, exerciseId } },
+  });
+  if (!goal || !goal.achievedAt) return;
+
+  const [exercise, sets] = await Promise.all([
+    db.exercise.findUnique({
+      where: { id: exerciseId },
+      select: { usesBodyweight: true },
+    }),
+    db.set.findMany({
+      where: { exerciseId, isWarmup: false, session: { userId } },
+      select: { weight: true, reps: true, isWarmup: true, completedAt: true },
+    }),
+  ]);
+  if (!exercise) return;
+
+  let bodyweight: number | null = null;
+  if (exercise.usesBodyweight) {
+    const user = await db.user.findUnique({
+      where: { id: userId },
+      select: { bodyweight: true },
+    });
+    bodyweight = user?.bodyweight ?? null;
+  }
+
+  const achieving = findAchievingSet(
+    sets.map((s) => ({
+      ...s,
+      weight: effectiveWeight(s.weight, exercise.usesBodyweight, bodyweight),
+    })),
+    goal,
+  );
+  const achievedAt = achieving?.completedAt ?? null;
+  if (achievedAt?.getTime() !== goal.achievedAt.getTime()) {
+    await db.exerciseGoal.update({
+      where: { id: goal.id },
+      data: { achievedAt },
+    });
   }
 }

--- a/tests/integration/goals-route.test.ts
+++ b/tests/integration/goals-route.test.ts
@@ -10,6 +10,7 @@ const mockUserId = vi.mocked(getCurrentUserId);
 import { GET as listGoals, POST as postGoal } from '@/app/api/goals/route';
 import { DELETE as deleteGoal } from '@/app/api/goals/[id]/route';
 import { POST as postSet } from '@/app/api/sessions/[id]/sets/route';
+import { DELETE as deleteSet } from '@/app/api/sets/[id]/route';
 
 function actAs(userId: string) {
   mockUserId.mockResolvedValue(userId);
@@ -216,5 +217,58 @@ describe('goal achievement at set-save time', () => {
     );
     goal = await db.exerciseGoal.findFirst({ where: { exerciseId: pullups.id } });
     expect(goal?.achievedAt).not.toBeNull();
+  });
+});
+
+describe('goal re-derivation when the achieving set is deleted (issue #96)', () => {
+  it('clears achievedAt when no remaining set meets the target', async () => {
+    const { a, exercise, set } = await seed();
+    actAs(a.id);
+    // The seeded 100x5 set already beats this target -> stamped at creation.
+    await postGoal(jsonReq('POST', { exerciseId: exercise.id, targetWeight: 95, targetReps: 5 }));
+    let goal = await db.exerciseGoal.findFirst({ where: { userId: a.id } });
+    expect(goal?.achievedAt).not.toBeNull();
+
+    const res = await deleteSet(new Request('http://t/api', { method: 'DELETE' }), {
+      params: { id: set.id },
+    });
+    expect(res.status).toBe(200);
+    goal = await db.exerciseGoal.findFirst({ where: { userId: a.id } });
+    expect(goal?.achievedAt).toBeNull();
+  });
+
+  it('re-stamps with the earliest remaining achieving set', async () => {
+    const { a, exercise, session, set } = await seed();
+    actAs(a.id);
+    await postGoal(jsonReq('POST', { exerciseId: exercise.id, targetWeight: 95, targetReps: 5 }));
+
+    // A second, later set that also meets the target.
+    const later = await (
+      await postSet(
+        jsonReq('POST', { exerciseId: exercise.id, setNumber: 2, weight: 97.5, reps: 5 }),
+        { params: { id: session.id } },
+      )
+    ).json();
+
+    // Deleting the original achieving set must move achievedAt to the
+    // remaining one, not clear it and not keep the dead timestamp.
+    await deleteSet(new Request('http://t/api', { method: 'DELETE' }), {
+      params: { id: set.id },
+    });
+    const goal = await db.exerciseGoal.findFirst({ where: { userId: a.id } });
+    expect(goal?.achievedAt?.getTime()).toBe(new Date(later.completedAt).getTime());
+  });
+
+  it('leaves an unachieved goal untouched when an unrelated set is deleted', async () => {
+    const { a, exercise, set } = await seed();
+    actAs(a.id);
+    await postGoal(jsonReq('POST', { exerciseId: exercise.id, targetWeight: 120, targetReps: 5 }));
+
+    const res = await deleteSet(new Request('http://t/api', { method: 'DELETE' }), {
+      params: { id: set.id },
+    });
+    expect(res.status).toBe(200);
+    const goal = await db.exerciseGoal.findFirst({ where: { userId: a.id } });
+    expect(goal?.achievedAt).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #96 (found by the independent post-merge review of PR #95).

Deleting the set that stamped an ExerciseGoal as achieved left achievedAt pointing at a dead set, permanently showing the Achieved badge. The set DELETE handler now re-derives achievedAt from the remaining sets via the existing findAchievingSet derivation - cleared when nothing meets the target anymore, re-stamped with the earliest remaining achieving set otherwise. Same best-effort pattern as stampGoalIfAchieved at set-save (logged catch; a re-derivation failure never fails the deletion), same effective-load semantics for bodyweight exercises.

## How I tested

- bash scripts/verify.sh --full - GREEN-GATE PASSED (lint, typecheck, unit, integration incl. 3 new tests, build, E2E)
- New integration tests cover: achievedAt cleared when no remaining set meets the target, re-stamped with the earliest remaining achieving set, and untouched for an unachieved goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)