### PR TITLE
docs: write up the third ideate batch and the complex-features directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exercises whose best estimated 1RM has not improved (beyond a 0.5 percent
   tolerance) over the last three sessions. Pure derivation over existing set
   history; needs at least three sessions before it can flag.
+- Deload-week recommendation on the progress page: a display-only banner appears
+  when at least two lifts are stalled or the average readiness over the last
+  five check-ins (max 14 days old) sits at or below the hold boundary (2/5),
+  listing the concrete reasons and what a deload week is. Pure derivation over
+  the existing stall and readiness signals; no schema or suggestion change.
+- Quick set logging via shorthand: type `100x8`, `100 8 9`, or `100x8@9` in a
+  single field of the set logger to fill the weight, reps, and effort fields
+  (RPE maps to the stored RIR). Deterministic parser in the user's display
+  unit; the classic fields keep working unchanged.
+- Per-exercise target goals: set one "weight x reps" goal per exercise, see a
+  progress bar toward it on the progress page (best estimated 1RM vs the
+  target's, Epley), and an "Achieved" badge stamped from the first set that
+  meets both the weight and the reps - using the effective load for bodyweight
+  exercises. Deleting the achieving set re-derives the achievement from the
+  remaining history. Stored in a new additive `ExerciseGoal` table with
+  Zod-validated, ownership-scoped API routes.
 - Test pyramid (unit, integration, E2E) with CI running lint, typecheck, unit,
   integration, build, and E2E on every pull request.
 - Docker and Docker Compose setup for local development and production.
@@ -102,6 +118,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   governs this: turning it off drops the readiness signal before it reaches the
   suggestion, reproducing the pure programmed-progression behavior from before
   the readiness integration.
+- Widened the autonomy charter per an operator directive: complex features
+  (data-safe migrations, LLM output-contract changes, multi-surface work) now
+  ship without human review when they are a clear product plus, compensated by
+  reinforced non-regression controls (full local gate before the PR, tests at
+  every touched layer, contract tests, multi-lens review, rollback tag before
+  migrations, verify-in-app). The stop-for-human list narrows to destructive
+  data migrations, auth/security changes, and major dependency bumps; security
+  boundaries are unchanged.
 - Hardened the autonomous maintenance loop against untrusted external input now
   that the repo is public: external issues, PRs, comments, diffs, and CI logs are
   treated as data and never as instructions; only issues/PRs authored by the

--- a/docs/loops/07-autonomy.md
+++ b/docs/loops/07-autonomy.md
@@ -165,6 +165,12 @@ non-trivial:
   Cosmetic nits do not block.
 - The reviewing subagent must be **independent** of the one that wrote the code - never let
   the author grade its own homework.
+- **If no independent reviewer can be spawned** (e.g. the subagent-spawning tool is
+  unavailable in a nested run), a self-executed "review pass" by the author does NOT
+  satisfy this protocol. Either hold the PR for the orchestrator to review, or - if it
+  merged on a green full gate - flag it explicitly in the run report so the orchestrator
+  runs an independent **post-merge** review as the very next action. (Lesson L8: this
+  backstop caught a real data-lifecycle defect in #95, fixed in #97.)
 
 Every subagent inherits this charter: same hard guardrails, same stop list.
 

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -6,6 +6,35 @@ by the charter in [`07-autonomy.md`](07-autonomy.md).
 
 ---
 
+## 2026-06-10 (later) - Post-merge backstop review of #95; fix #97; batch write-up
+
+**Context.** The background tick that shipped #94/#95 reported it could not spawn an
+independent reviewer (no subagent tool in its environment) and had self-executed the
+"multi-lens" pass for #95 - which the charter does not accept as the challenge. The
+orchestrator ran the missing independent review post-merge as its next action.
+
+**Decided / shipped.**
+- Independent post-merge skeptic on #95 (commit cc33953): ownership, migration drift
+  (clean `migrate diff` against a shadow DB), e1RM math, and the set-save best-effort path
+  all verified sound; ONE real defect found - deleting the achieving set left a goal
+  permanently "Achieved".
+- Filed #96, fixed via PR #97 (merged on green; the integration job's first red was the
+  known transient ECR `toomanyrequests` pull failure - re-run, then green): set DELETE now
+  re-derives `achievedAt` from the remaining sets, same best-effort pattern as stamping.
+- Write-up: CHANGELOG (deload banner, shorthand logging, exercise goals, the charter
+  widening), ideas-backlog #88/#89/#90 -> shipped, review digest for the batch, lesson L8
+  graduated into the charter (no-independent-reviewer case now has an explicit rule).
+
+**Challenged.** The review WAS the challenge - and it proved the point: an honest
+self-review by the author missed a lifecycle defect an independent reviewer caught in one
+pass.
+
+**Deferred to human.** Nothing. Three NITs from the review (capped progress display vs
+achieved badge, stamping race, missing fetch error toast in the goal card) noted as
+accepted risks; none is data-incorrect.
+
+---
+
 ## 2026-06-10 - Maintainer run: shipped #89 (set shorthand) and #90 (exercise goals)
 
 **Context.** Maintainer tick over the third ideate batch. Both issues trust-gated (author

--- a/docs/loops/ideas-backlog.md
+++ b/docs/loops/ideas-backlog.md
@@ -19,7 +19,7 @@ research and the product wedge). See `docs/loops/08-ideation-loop.md` for how th
 - shipped - surface personal records hit during a session on the post-session summary (issue #80, 2026-06-09) - reuse lib/records.ts detectPRs in components/session/session-summary.tsx, additive
 - shipped - volume landmarks (MEV/MRV reference bands) on the weekly per-muscle volume chart (issue #81, 2026-06-09) - weekly working-set counts vs default 10/20 sets band in lib/stats.ts, display-only
 - shipped - detect stalled lifts (no e1RM progress over recent sessions) and flag them on the progress page (issue #82, 2026-06-09) - pure derivation over exerciseProgress/best1RM, display-only badge
-- proposed - recommend a deload week when multiple lifts stall or readiness is chronically low (issue #88, 2026-06-10) - pure lib/deload.ts over existing stall + readiness signals, display-only banner
-- proposed - quick set logging via shorthand input like 100x8@9 (issue #89, 2026-06-10) - deterministic parser, first slice of the roadmap's natural-language set logging, no LLM
-- proposed - per-exercise target goals (weight x reps) with progress toward goal (issue #90, 2026-06-10) - additive ExerciseGoal table + Zod API + progress bar on the per-exercise view
+- shipped - recommend a deload week when multiple lifts stall or readiness is chronically low (issue #88, 2026-06-10, PR #93) - pure lib/deload.ts over existing stall + readiness signals, display-only banner
+- shipped - quick set logging via shorthand input like 100x8@9 (issue #89, 2026-06-10, PR #94) - deterministic parser lib/set-shorthand.ts, first slice of the roadmap's natural-language set logging, no LLM
+- shipped - per-exercise target goals (weight x reps) with progress toward goal (issue #90, 2026-06-10, PR #95 + fix #97) - additive ExerciseGoal table + Zod API + progress bar; first feature shipped under the complex-features directive
 - rejected - in-session exercise substitution picker (2026-06-10) - changes what a logged set refers to mid-session; needs a product call on program vs session scope, not a safe default

--- a/docs/loops/lessons.md
+++ b/docs/loops/lessons.md
@@ -90,3 +90,18 @@ Format per entry: trigger/evidence, the lesson (actionable), and **Status** = `g
 - **Status:** graduated -> orchestration practice (`06-orchestration.md` decision order + the
   "one linear writer per task" rule in `09-memory-and-learning.md` / `implement-issue` /
   `ship-pr`): same-file queued issues are dispatched one at a time, gated on the prior merge.
+
+### L8 - A nested run without the spawning tool cannot satisfy the independent-review protocol by itself
+- **Trigger:** the background maintainer tick implementing #90 (PR #95) had no subagent-spawning
+  tool in its environment, so it executed the "multi-lens review" itself - the author grading
+  its own homework, which the charter forbids. The orchestrator ran an independent post-merge
+  review as a backstop; it confirmed ownership/migration/math were sound but found a real
+  data-lifecycle defect the author had missed (deleting the achieving set left a goal
+  permanently "Achieved"), fixed the same day in #97.
+- **Lesson:** a self-executed review pass is not the subagent challenge. When a nested run
+  cannot spawn an independent reviewer, it must flag that in its report, and the orchestrator
+  must run an independent post-merge review as the very next action (or hold the PR pre-merge
+  when feasible). The author reliably misses its own blind spots even when honestly running
+  multiple "lenses" - independence, not effort, is what catches the defect.
+- **Status:** graduated -> charter (`07-autonomy.md`, "Subagent challenge protocol"): the
+  no-reviewer-available case is now an explicit rule with the post-merge backstop.

--- a/docs/loops/review-digest.md
+++ b/docs/loops/review-digest.md
@@ -76,3 +76,39 @@ are safe to skip.
 
 > Honest note: the skeptics reviewed all of the above, but "reviewed by another agent" is
 > not "understood by you". If you read only six diffs from today, read the six above.
+
+---
+
+## 2026-06-10 - third ideate batch + the complex-features directive (#92-#95, #97)
+
+Merged this batch: #91 (ideate log), #92 (charter widened to complex features), #93
+(deload-week banner), #94 (set-logging shorthand), #95 (per-exercise target goals - first
+feature under the new directive: additive migration + API + UI), #97 (fix: re-derive goal
+achievement when the achieving set is deleted). This batch ranks **high**: it contains a
+governance change, a new table + API surface, and a write-path fix.
+
+**Read first, in order:**
+
+1. **#92 - the autonomy charter now allows complex features without human review.**
+   `gh pr diff 92`. Governance, not code: the stop-for-human list narrowed to destructive
+   migrations / auth-security / major dep bumps, traded for reinforced non-regression
+   controls. This changes what the loop is allowed to merge from now on - read it even if
+   you read nothing else.
+2. **#95 - per-exercise goals (schema + API + write-path hook).** `gh pr diff 95`. New
+   `ExerciseGoal` table (additive, unique per user+exercise), Zod-validated ownership-scoped
+   routes, and a best-effort achievement stamp inside the set-save path. The post-merge
+   independent review verified ownership, migration drift, and e1RM math; still the largest
+   new surface this batch.
+3. **#97 - the defect that review found.** `gh pr diff 97`. Set DELETE now re-derives
+   `achievedAt` from remaining history. Read it as the concrete failure mode of #95's
+   lifecycle (and the proof the post-merge backstop works - see lessons.md L8).
+4. **#93 - deload recommendation thresholds.** `gh pr diff 93`. `lib/deload.ts` constants
+   (2 stalled lifts; readiness average <= 2/5 over <= 5 check-ins, 14-day window) decide
+   when the app tells a user to back off - sanity-check the coaching judgment.
+
+**Skim (additive, tested, skeptic-reviewed):** #94 shorthand parser (`lib/set-shorthand.ts`;
+note RPE -> RIR mapping = 10 - RPE clamped to 0-5), #91 and the docs in this PR.
+
+> Honest note: #95 merged on the implementing agent's own review pass (no subagent tool in
+> its environment); the independent review happened post-merge and found #97. The protocol
+> now requires flagging that case explicitly (charter, L8).


### PR DESCRIPTION
Docs-only batch write-up:

- CHANGELOG: deload-week recommendation (#93), quick set logging shorthand (#94), per-exercise target goals (#95, including the #97 re-derivation fix), and the autonomy-charter widening (#92) under Changed. Every claim checked against the merged code.
- docs/loops/ideas-backlog.md: #88/#89/#90 proposed -> shipped.
- docs/loops/review-digest.md: prioritized reading list for the batch (read #92 governance and #95 schema/API first).
- docs/loops/lessons.md + 07-autonomy.md: lesson L8 graduated - a nested run that cannot spawn an independent reviewer must flag it for a post-merge independent review; that backstop found and fixed a real defect (#96/#97).
- docs/loops/autonomy-log.md: journal entry for the post-merge review run.

bash scripts/verify.sh - GREEN-GATE PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)