### PR TITLE
feat: bodyweight tracking (log entries, trend on the progress page)

### DIFF
--- a/app/(app)/progress/page.tsx
+++ b/app/(app)/progress/page.tsx
@@ -24,6 +24,7 @@ import {
 import { ProgressDashboard } from '@/components/progress/progress-dashboard';
 import { ConsistencyCard } from '@/components/progress/consistency-card';
 import { DeloadBanner } from '@/components/progress/deload-banner';
+import { BodyweightCard } from '@/components/progress/bodyweight-card';
 
 interface SearchParams {
   exerciseId?: string;
@@ -274,6 +275,14 @@ export default async function ProgressPage({
     take: DELOAD_READINESS_LOOKBACK,
     select: { readiness: true },
   });
+  // Bodyweight trend (issue #99): entries of the last 12 weeks, newest first.
+  // Independent of training data, so the card renders even on the empty state.
+  const bodyweightEntries = await db.bodyweightEntry.findMany({
+    where: { userId: auth.userId, measuredAt: { gte: since } },
+    orderBy: { measuredAt: 'desc' },
+    select: { id: true, weightKg: true, measuredAt: true },
+  });
+
   const deload = recommendDeload({
     stalledExerciseNames: recap
       .filter((r) => r.stalled)
@@ -288,6 +297,15 @@ export default async function ProgressPage({
           <TrendingUp className="size-6" />
           <h1 className="text-2xl font-bold tracking-tight">Progress</h1>
         </div>
+
+        <BodyweightCard
+          entries={bodyweightEntries.map((e) => ({
+            id: e.id,
+            weightKg: e.weightKg,
+            measuredAt: e.measuredAt.toISOString(),
+          }))}
+          unit={unit}
+        />
 
         {exercisesWithSets.length === 0 ? (
           <EmptyState

--- a/app/api/bodyweight/[id]/route.ts
+++ b/app/api/bodyweight/[id]/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { ApiError, handleApiError, requireApiUserId } from '@/lib/api';
+import { currentBodyweightFromEntries } from '@/lib/bodyweight';
+
+interface Params {
+  params: { id: string };
+}
+
+// DELETE /api/bodyweight/[id]: remove one measurement. User.bodyweight is the
+// "current value" mirror of the newest entry, so after the delete it re-syncs
+// to the newest remaining entry. When no entries remain the profile value is
+// left as is (it may predate the history, and clearing it would silently
+// change effective-load math).
+export async function DELETE(_req: Request, { params }: Params) {
+  try {
+    const userId = await requireApiUserId();
+    const entry = await db.bodyweightEntry.findUnique({ where: { id: params.id } });
+    if (!entry || entry.userId !== userId) {
+      throw new ApiError(404, 'Entry not found.');
+    }
+
+    await db.$transaction(async (tx) => {
+      await tx.bodyweightEntry.delete({ where: { id: params.id } });
+      const remaining = await tx.bodyweightEntry.findMany({
+        where: { userId },
+        orderBy: { measuredAt: 'asc' },
+        select: { weightKg: true, measuredAt: true },
+      });
+      const current = currentBodyweightFromEntries(remaining);
+      if (current !== null) {
+        await tx.user.update({
+          where: { id: userId },
+          data: { bodyweight: current },
+        });
+      }
+    });
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/app/api/bodyweight/route.ts
+++ b/app/api/bodyweight/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { bodyweightEntryInputSchema } from '@/lib/schemas/bodyweight';
+import { handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
+
+// GET /api/bodyweight: the user's bodyweight history, newest first.
+export async function GET() {
+  try {
+    const userId = await requireApiUserId();
+    const entries = await db.bodyweightEntry.findMany({
+      where: { userId },
+      orderBy: { measuredAt: 'desc' },
+    });
+    return NextResponse.json(entries);
+  } catch (err) {
+    return handleApiError(err);
+  }
+}
+
+// POST /api/bodyweight: log a measurement. The new entry is stamped "now", so
+// it is the newest by construction and User.bodyweight (the current value the
+// rest of the app reads) syncs to it in the same transaction.
+export async function POST(req: Request) {
+  try {
+    const userId = await requireApiUserId();
+    const data = await parseJsonBody(req, bodyweightEntryInputSchema);
+
+    const entry = await db.$transaction(async (tx) => {
+      const created = await tx.bodyweightEntry.create({
+        data: { userId, weightKg: data.weightKg, note: data.note ?? null },
+      });
+      await tx.user.update({
+        where: { id: userId },
+        data: { bodyweight: data.weightKg },
+      });
+      return created;
+    });
+    return NextResponse.json(entry, { status: 201 });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/components/progress/bodyweight-card.test.tsx
+++ b/components/progress/bodyweight-card.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BodyweightCard } from './bodyweight-card';
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const refresh = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh }),
+}));
+
+function lastFetchCall(fetchMock: ReturnType<typeof vi.fn>) {
+  return fetchMock.mock.calls.at(-1) as [string, RequestInit | undefined];
+}
+
+const entries = [
+  { id: 'b2', weightKg: 81.2, measuredAt: '2026-06-08T08:00:00Z' },
+  { id: 'b1', weightKg: 80, measuredAt: '2026-06-01T08:00:00Z' },
+];
+
+describe('BodyweightCard', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('shows the current bodyweight from the newest entry', () => {
+    render(<BodyweightCard entries={entries} unit="KG" />);
+    expect(screen.getByText(/current: 81.2 kg/i)).toBeInTheDocument();
+  });
+
+  it('shows an empty state when nothing is logged yet', () => {
+    render(<BodyweightCard entries={[]} unit="KG" />);
+    expect(screen.getByText(/no bodyweight logged yet/i)).toBeInTheDocument();
+  });
+
+  it('posts the quick-add weight in kg, converting from the display unit (lb)', async () => {
+    const user = userEvent.setup();
+    render(<BodyweightCard entries={[]} unit="LB" />);
+
+    await user.type(screen.getByLabelText(/bodyweight \(lb\)/i), '180');
+    await user.click(screen.getByRole('button', { name: 'Log' }));
+
+    const [url, init] = lastFetchCall(fetchMock);
+    expect(url).toBe('/api/bodyweight');
+    const body = JSON.parse(init?.body as string) as { weightKg: number };
+    // 180 lb = 81.65 kg.
+    expect(body.weightKg).toBeCloseTo(81.65, 1);
+    expect(refresh).toHaveBeenCalled();
+  });
+
+  it('rejects an empty or non-positive weight without calling the API', async () => {
+    const user = userEvent.setup();
+    render(<BodyweightCard entries={[]} unit="KG" />);
+
+    await user.click(screen.getByRole('button', { name: 'Log' }));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('deletes an entry through the API', async () => {
+    const user = userEvent.setup();
+    render(<BodyweightCard entries={entries} unit="KG" />);
+
+    await user.click(
+      screen.getAllByRole('button', { name: /delete entry/i })[0] as HTMLElement,
+    );
+
+    const [url, init] = lastFetchCall(fetchMock);
+    expect(url).toBe('/api/bodyweight/b2');
+    expect(init?.method).toBe('DELETE');
+    expect(refresh).toHaveBeenCalled();
+  });
+
+  it('lists entries in the display unit', () => {
+    render(<BodyweightCard entries={entries} unit="LB" />);
+    // 80 kg = 176.4 lb.
+    expect(screen.getByText(/176.4 lb/)).toBeInTheDocument();
+  });
+});

--- a/components/progress/bodyweight-card.tsx
+++ b/components/progress/bodyweight-card.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { Scale, Trash2 } from 'lucide-react';
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { WeightUnit } from '@prisma/client';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  formatWeight,
+  fromDisplayWeight,
+  roundWeight,
+  toDisplayWeight,
+  unitLabel,
+} from '@/lib/units';
+
+// One bodyweight measurement, as serialized by the Server Component boundary.
+export interface BodyweightEntryView {
+  id: string;
+  weightKg: number;
+  measuredAt: string; // ISO
+}
+
+interface Props {
+  // Entries of the trend window, newest first.
+  entries: BodyweightEntryView[];
+  unit: WeightUnit;
+  // How many recent entries get a row in the list below the chart.
+  listLimit?: number;
+}
+
+function shortDate(iso: string) {
+  return new Intl.DateTimeFormat('en-US', {
+    day: '2-digit',
+    month: '2-digit',
+  }).format(new Date(iso));
+}
+
+// Bodyweight trend card (issue #99): quick-add a measurement in the display
+// unit, see the trend over the window, delete bad entries. The profile field
+// in settings keeps working separately (corrections, not measurements).
+export function BodyweightCard({ entries, unit, listLimit = 5 }: Props) {
+  const router = useRouter();
+  const [weightField, setWeightField] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  const unitSuffix = unitLabel(unit);
+
+  // Chart data, oldest to newest, in the display unit.
+  const chartData = useMemo(
+    () =>
+      [...entries]
+        .reverse()
+        .map((e) => ({
+          label: shortDate(e.measuredAt),
+          weight: roundWeight(toDisplayWeight(e.weightKg, unit), 1),
+        })),
+    [entries, unit],
+  );
+
+  const latest = entries[0];
+
+  async function addEntry() {
+    const weight = parseFloat(weightField);
+    if (!Number.isFinite(weight) || weight <= 0) {
+      toast.error('Enter a positive bodyweight.');
+      return;
+    }
+    setBusy(true);
+    try {
+      const res = await fetch('/api/bodyweight', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ weightKg: fromDisplayWeight(weight, unit) }),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as { error?: string } | null;
+        toast.error(data?.error ?? 'Could not log the bodyweight.');
+        return;
+      }
+      toast.success('Bodyweight logged.');
+      setWeightField('');
+      router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function deleteEntry(id: string) {
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/bodyweight/${id}`, { method: 'DELETE' });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as { error?: string } | null;
+        toast.error(data?.error ?? 'Could not delete the entry.');
+        return;
+      }
+      toast.success('Entry deleted.');
+      router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h2 className="flex items-center gap-2 text-base font-semibold">
+            <Scale className="size-4" />
+            Bodyweight
+          </h2>
+          {latest && (
+            <span className="text-sm text-muted-foreground">
+              Current: {formatWeight(latest.weightKg, unit)}
+            </span>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {/* Quick add, in the display unit */}
+        <form
+          className="flex items-end gap-2"
+          onSubmit={(e) => {
+            e.preventDefault();
+            void addEntry();
+          }}
+        >
+          <div className="flex-1 space-y-1">
+            <Label htmlFor="bodyweight-input">Bodyweight ({unitSuffix})</Label>
+            <Input
+              id="bodyweight-input"
+              type="number"
+              inputMode="decimal"
+              step="0.1"
+              min="0"
+              placeholder={
+                latest
+                  ? String(roundWeight(toDisplayWeight(latest.weightKg, unit), 1))
+                  : undefined
+              }
+              value={weightField}
+              onChange={(e) => setWeightField(e.target.value)}
+            />
+          </div>
+          <Button type="submit" disabled={busy}>
+            {busy ? 'Saving...' : 'Log'}
+          </Button>
+        </form>
+
+        {/* Trend over the window */}
+        {chartData.length < 2 ? (
+          <p className="text-sm text-muted-foreground">
+            {chartData.length === 0
+              ? 'No bodyweight logged yet. Log a first measurement to start the trend.'
+              : 'Log a second measurement to see the trend.'}
+          </p>
+        ) : (
+          <div className="h-48 w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={chartData} margin={{ top: 5, right: 10, bottom: 0, left: -10 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+                <XAxis dataKey="label" tick={{ fontSize: 11 }} />
+                <YAxis
+                  tick={{ fontSize: 11 }}
+                  domain={['auto', 'auto']}
+                  tickFormatter={(v: number) => String(v)}
+                />
+                <Tooltip
+                  contentStyle={{
+                    background: 'hsl(var(--popover))',
+                    border: '1px solid hsl(var(--border))',
+                    borderRadius: 6,
+                    fontSize: 12,
+                  }}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="weight"
+                  name={`Bodyweight (${unitSuffix})`}
+                  stroke="hsl(var(--primary))"
+                  strokeWidth={2}
+                  dot={{ r: 3 }}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+
+        {/* Recent entries, deletable */}
+        {entries.length > 0 && (
+          <ul className="flex flex-col gap-1">
+            {entries.slice(0, listLimit).map((e) => (
+              <li
+                key={e.id}
+                className="flex items-center justify-between gap-3 text-sm"
+              >
+                <span>
+                  <span className="font-medium">{formatWeight(e.weightKg, unit)}</span>{' '}
+                  <span className="text-muted-foreground">on {shortDate(e.measuredAt)}</span>
+                </span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label={`Delete entry of ${shortDate(e.measuredAt)}`}
+                  onClick={() => void deleteEntry(e.id)}
+                  disabled={busy}
+                >
+                  <Trash2 className="size-4" />
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/lib/bodyweight.test.ts
+++ b/lib/bodyweight.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { currentBodyweightFromEntries } from './bodyweight';
+
+function entry(weightKg: number, iso: string) {
+  return { weightKg, measuredAt: new Date(iso) };
+}
+
+describe('currentBodyweightFromEntries', () => {
+  it('returns null when there are no entries', () => {
+    expect(currentBodyweightFromEntries([])).toBeNull();
+  });
+
+  it('returns the only entry weight', () => {
+    expect(currentBodyweightFromEntries([entry(80, '2026-06-01')])).toBe(80);
+  });
+
+  it('returns the most recent entry regardless of array order', () => {
+    const entries = [
+      entry(82, '2026-06-08'),
+      entry(79, '2026-05-01'),
+      entry(81, '2026-06-01'),
+    ];
+    expect(currentBodyweightFromEntries(entries)).toBe(82);
+    expect(currentBodyweightFromEntries([...entries].reverse())).toBe(82);
+  });
+
+  it('resolves a measuredAt tie to the later element (latest write wins)', () => {
+    const entries = [
+      entry(80, '2026-06-08T08:00:00Z'),
+      entry(80.6, '2026-06-08T08:00:00Z'),
+    ];
+    expect(currentBodyweightFromEntries(entries)).toBe(80.6);
+  });
+});

--- a/lib/bodyweight.ts
+++ b/lib/bodyweight.ts
@@ -1,0 +1,26 @@
+// Bodyweight history helpers (issue #99).
+//
+// User.bodyweight stays the single "current value" the rest of the app reads
+// (effective load on bodyweight exercises, coach payload). The BodyweightEntry
+// table is the history behind it; these pure helpers derive what the current
+// value should be after a mutation so the routes and tests share one rule.
+
+export interface BodyweightEntryLike {
+  weightKg: number;
+  measuredAt: Date;
+}
+
+// The weight of the most recent entry, or null when there is none. Ties on
+// measuredAt resolve to the later element in the array, which matches a
+// "newest first then created order" listing where the latest write wins.
+export function currentBodyweightFromEntries(
+  entries: BodyweightEntryLike[],
+): number | null {
+  let newest: BodyweightEntryLike | null = null;
+  for (const entry of entries) {
+    if (!newest || entry.measuredAt.getTime() >= newest.measuredAt.getTime()) {
+      newest = entry;
+    }
+  }
+  return newest ? newest.weightKg : null;
+}

--- a/lib/schemas/bodyweight.test.ts
+++ b/lib/schemas/bodyweight.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { bodyweightEntryInputSchema } from './bodyweight';
+
+describe('bodyweightEntryInputSchema', () => {
+  it('accepts a plain weight in kg', () => {
+    const parsed = bodyweightEntryInputSchema.parse({ weightKg: 82.4 });
+    expect(parsed.weightKg).toBe(82.4);
+    expect(parsed.note).toBeUndefined();
+  });
+
+  it('accepts an optional note', () => {
+    const parsed = bodyweightEntryInputSchema.parse({
+      weightKg: 80,
+      note: 'morning, fasted',
+    });
+    expect(parsed.note).toBe('morning, fasted');
+  });
+
+  it('coerces a numeric string', () => {
+    expect(bodyweightEntryInputSchema.parse({ weightKg: '75.5' }).weightKg).toBe(75.5);
+  });
+
+  it.each([0, -5, 501, 'abc', null, undefined])(
+    'rejects invalid weight %p',
+    (weightKg) => {
+      expect(bodyweightEntryInputSchema.safeParse({ weightKg }).success).toBe(false);
+    },
+  );
+
+  it('rejects an oversized note', () => {
+    const res = bodyweightEntryInputSchema.safeParse({
+      weightKg: 80,
+      note: 'x'.repeat(501),
+    });
+    expect(res.success).toBe(false);
+  });
+});

--- a/lib/schemas/bodyweight.ts
+++ b/lib/schemas/bodyweight.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+// Bodyweight entry input (issue #99). The weight arrives in kg (the client
+// converts from the display unit before posting, like the set form). 500 kg
+// mirrors the set schema's ceiling; nobody weighs more.
+export const bodyweightEntryInputSchema = z.object({
+  weightKg: z.coerce.number().positive().max(500),
+  note: z.string().max(500).optional(),
+});
+
+export type BodyweightEntryInput = z.infer<typeof bodyweightEntryInputSchema>;

--- a/prisma/migrations/20260610120000_add_bodyweight_entry/migration.sql
+++ b/prisma/migrations/20260610120000_add_bodyweight_entry/migration.sql
@@ -1,0 +1,19 @@
+-- Additive migration (issue #99): bodyweight measurement history. New table
+-- only, no change to existing tables. User.bodyweight stays the "current
+-- value" the rest of the app reads.
+
+-- CreateTable
+CREATE TABLE "BodyweightEntry" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "weightKg" DOUBLE PRECISION NOT NULL,
+    "measuredAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "note" TEXT,
+    CONSTRAINT "BodyweightEntry_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "BodyweightEntry_userId_measuredAt_idx" ON "BodyweightEntry"("userId", "measuredAt");
+
+-- AddForeignKey
+ALTER TABLE "BodyweightEntry" ADD CONSTRAINT "BodyweightEntry_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,6 +35,7 @@ model User {
   conversations Conversation[]
   readinessCheckins ReadinessCheckin[]
   exerciseGoals ExerciseGoal[]
+  bodyweightEntries BodyweightEntry[]
 }
 
 enum Sex {
@@ -227,6 +228,23 @@ model ExerciseGoal {
   achievedAt   DateTime?
 
   @@unique([userId, exerciseId])
+}
+
+// Bodyweight history (issue #99). Additive: User.bodyweight stays the single
+// "current value" the rest of the app reads (effective load, coach payload);
+// this table keeps the measurement history behind it. Logging an entry also
+// updates User.bodyweight; deleting the newest entry re-syncs it to the new
+// newest one (or leaves the profile value alone when no entries remain).
+model BodyweightEntry {
+  id         String   @id @default(cuid())
+  userId     String
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  // Stored in kg like every weight in the schema; converted at the edges.
+  weightKg   Float
+  measuredAt DateTime @default(now())
+  note       String?
+
+  @@index([userId, measuredAt])
 }
 
 model CoachSession {

--- a/tests/e2e/bodyweight.spec.ts
+++ b/tests/e2e/bodyweight.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+
+// Bodyweight tracking (issue #99): quick-add a measurement on the progress
+// page, see it listed as the current value, then delete it. The card renders
+// even with no training data, so a fresh user is enough.
+
+test('a lifter can log and delete a bodyweight entry on the progress page', async ({
+  page,
+}) => {
+  // Sign up (fresh user each run).
+  await page.goto('/signup');
+  await page.getByLabel('Name').fill('Bodyweight E2E');
+  await page.getByLabel('Email').fill(`e2e-bodyweight-${Date.now()}@test.dev`);
+  await page.getByLabel('Password').fill('supersecret');
+  await page.getByRole('button', { name: 'Create account' }).click();
+  await expect(page).toHaveURL('/');
+
+  await page.goto('/progress');
+  await expect(page.getByText('Bodyweight', { exact: true })).toBeVisible();
+  await expect(page.getByText(/no bodyweight logged yet/i)).toBeVisible();
+
+  // Quick-add 82.5 kg.
+  await page.getByLabel(/bodyweight \(kg\)/i).fill('82.5');
+  await page.getByRole('button', { name: 'Log', exact: true }).click();
+
+  await expect(page.getByText(/current: 82.5 kg/i)).toBeVisible();
+  // The entry shows in the recent list with a delete button.
+  const deleteButton = page.getByRole('button', { name: /delete entry/i }).first();
+  await expect(deleteButton).toBeVisible();
+
+  // Delete it again: back to the empty state.
+  await deleteButton.click();
+  await expect(page.getByText(/no bodyweight logged yet/i)).toBeVisible();
+});

--- a/tests/integration/bodyweight-route.test.ts
+++ b/tests/integration/bodyweight-route.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { db } from '@/lib/db';
+import { getCurrentUserId } from '@/lib/auth';
+
+// Auth is read through getCurrentUserId (via requireApiUserId in @/lib/api).
+// Mock it so we can act as either user without real cookies/JWTs.
+vi.mock('@/lib/auth', () => ({ getCurrentUserId: vi.fn() }));
+const mockUserId = vi.mocked(getCurrentUserId);
+
+import { GET as listEntries, POST as postEntry } from '@/app/api/bodyweight/route';
+import { DELETE as deleteEntry } from '@/app/api/bodyweight/[id]/route';
+
+function actAs(userId: string) {
+  mockUserId.mockResolvedValue(userId);
+}
+
+function jsonReq(method: string, body: unknown): Request {
+  return new Request('http://test.local/api', {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+async function seed() {
+  const [a, b] = await Promise.all([
+    db.user.create({
+      data: { email: 'owner@test.dev', passwordHash: 'x', bodyweight: 75 },
+    }),
+    db.user.create({ data: { email: 'stranger@test.dev', passwordHash: 'x' } }),
+  ]);
+  return { a, b };
+}
+
+beforeEach(() => {
+  mockUserId.mockReset();
+});
+
+describe('POST /api/bodyweight', () => {
+  it('creates an entry and syncs User.bodyweight to it', async () => {
+    const { a } = await seed();
+    actAs(a.id);
+    const res = await postEntry(jsonReq('POST', { weightKg: 81.4 }));
+    expect(res.status).toBe(201);
+    const entry = await res.json();
+    expect(entry.weightKg).toBe(81.4);
+
+    const user = await db.user.findUnique({ where: { id: a.id } });
+    expect(user?.bodyweight).toBe(81.4);
+    expect(await db.bodyweightEntry.count({ where: { userId: a.id } })).toBe(1);
+  });
+
+  it('stores the optional note', async () => {
+    const { a } = await seed();
+    actAs(a.id);
+    const res = await postEntry(
+      jsonReq('POST', { weightKg: 80, note: 'morning, fasted' }),
+    );
+    expect(res.status).toBe(201);
+    expect((await res.json()).note).toBe('morning, fasted');
+  });
+
+  it('rejects invalid input (Zod) and writes nothing', async () => {
+    const { a } = await seed();
+    actAs(a.id);
+    const res = await postEntry(jsonReq('POST', { weightKg: -5 }));
+    expect(res.status).toBe(400);
+    expect(await db.bodyweightEntry.count()).toBe(0);
+    const user = await db.user.findUnique({ where: { id: a.id } });
+    expect(user?.bodyweight).toBe(75);
+  });
+
+  it('requires auth', async () => {
+    await seed();
+    mockUserId.mockResolvedValue(null);
+    const res = await postEntry(jsonReq('POST', { weightKg: 80 }));
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /api/bodyweight', () => {
+  it("lists only the user's own entries, newest first", async () => {
+    const { a, b } = await seed();
+    actAs(a.id);
+    await postEntry(jsonReq('POST', { weightKg: 80 }));
+    await postEntry(jsonReq('POST', { weightKg: 81 }));
+
+    actAs(b.id);
+    expect(await (await listEntries()).json()).toEqual([]);
+
+    actAs(a.id);
+    const own = await (await listEntries()).json();
+    expect(own).toHaveLength(2);
+    expect(own[0].weightKg).toBe(81);
+    expect(own[1].weightKg).toBe(80);
+  });
+});
+
+describe('DELETE /api/bodyweight/[id]', () => {
+  it('re-syncs User.bodyweight to the newest remaining entry when the newest is deleted', async () => {
+    const { a } = await seed();
+    actAs(a.id);
+    // Two entries with distinct measuredAt timestamps.
+    const older = await db.bodyweightEntry.create({
+      data: { userId: a.id, weightKg: 79, measuredAt: new Date('2026-06-01T08:00:00Z') },
+    });
+    const newer = await db.bodyweightEntry.create({
+      data: { userId: a.id, weightKg: 82, measuredAt: new Date('2026-06-08T08:00:00Z') },
+    });
+    await db.user.update({ where: { id: a.id }, data: { bodyweight: 82 } });
+
+    const res = await deleteEntry(new Request('http://t/api', { method: 'DELETE' }), {
+      params: { id: newer.id },
+    });
+    expect(res.status).toBe(200);
+    const user = await db.user.findUnique({ where: { id: a.id } });
+    expect(user?.bodyweight).toBe(79);
+    expect(await db.bodyweightEntry.count({ where: { userId: a.id } })).toBe(1);
+
+    // Cleanup reference so lint does not flag the unused variable.
+    expect(older.weightKg).toBe(79);
+  });
+
+  it('keeps User.bodyweight when a non-newest entry is deleted', async () => {
+    const { a } = await seed();
+    actAs(a.id);
+    const older = await db.bodyweightEntry.create({
+      data: { userId: a.id, weightKg: 79, measuredAt: new Date('2026-06-01T08:00:00Z') },
+    });
+    await db.bodyweightEntry.create({
+      data: { userId: a.id, weightKg: 82, measuredAt: new Date('2026-06-08T08:00:00Z') },
+    });
+    await db.user.update({ where: { id: a.id }, data: { bodyweight: 82 } });
+
+    await deleteEntry(new Request('http://t/api', { method: 'DELETE' }), {
+      params: { id: older.id },
+    });
+    const user = await db.user.findUnique({ where: { id: a.id } });
+    expect(user?.bodyweight).toBe(82);
+  });
+
+  it('leaves the profile value as is when the last entry is deleted', async () => {
+    const { a } = await seed();
+    actAs(a.id);
+    const only = await (await postEntry(jsonReq('POST', { weightKg: 81 }))).json();
+
+    await deleteEntry(new Request('http://t/api', { method: 'DELETE' }), {
+      params: { id: only.id },
+    });
+    expect(await db.bodyweightEntry.count()).toBe(0);
+    const user = await db.user.findUnique({ where: { id: a.id } });
+    // The 81 written by the POST sync stays; no entry remains to re-derive from.
+    expect(user?.bodyweight).toBe(81);
+  });
+
+  it("returns 404 and keeps the entry when a stranger tries to delete it", async () => {
+    const { a, b } = await seed();
+    actAs(a.id);
+    const entry = await (await postEntry(jsonReq('POST', { weightKg: 81 }))).json();
+
+    actAs(b.id);
+    const res = await deleteEntry(new Request('http://t/api', { method: 'DELETE' }), {
+      params: { id: entry.id },
+    });
+    expect(res.status).toBe(404);
+    expect(await db.bodyweightEntry.count()).toBe(1);
+  });
+});

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -11,7 +11,7 @@ if (!process.env.DATABASE_URL) {
 // Truncates every table between tests so each starts from a clean slate.
 export async function resetDb(): Promise<void> {
   await db.$executeRawUnsafe(
-    'TRUNCATE TABLE "Message","Conversation","ReadinessCheckin","ExerciseGoal","Set","Session","ProgramExercise","Workout","Program","Exercise","CoachSession","User" RESTART IDENTITY CASCADE;',
+    'TRUNCATE TABLE "Message","Conversation","ReadinessCheckin","ExerciseGoal","BodyweightEntry","Set","Session","ProgramExercise","Workout","Program","Exercise","CoachSession","User" RESTART IDENTITY CASCADE;',
   );
 }
 


### PR DESCRIPTION
Implements bodyweight tracking per issue #99.

- Additive Prisma migration: new BodyweightEntry table only (id, userId, weightKg in kg, measuredAt, note), index on (userId, measuredAt). User.bodyweight stays the "current value" the rest of the app reads.
- POST /api/bodyweight creates an entry and syncs User.bodyweight in the same transaction; DELETE /api/bodyweight/[id] re-syncs the profile value to the newest remaining entry (left as is when none remain); GET lists newest first. All Zod-validated and ownership-scoped.
- Progress page: a Bodyweight card with a 12-week trend chart (recharts, like the other progress charts), quick add in the user's display unit (kg/lb via the existing unit helpers), and deletable recent entries. Renders even with no training data. Settings profile edits do NOT create entries (corrections, not measurements).

Closes #99

## How I tested

- bash scripts/verify.sh --full PASSED locally (prisma generate, lint, typecheck, unit, build, integration on :5434, Playwright E2E).
- Migration validated against the test Postgres: fresh `prisma migrate deploy` applies cleanly and `prisma migrate diff` against the schema reports "No difference detected".
- New tests at every layer: Zod schema unit tests, pure re-sync derivation unit tests, integration tests for POST/GET/DELETE (sync, re-sync, ownership, 401, Zod 400), component tests for the card (unit conversion, quick add, delete, empty state), and an E2E flow (sign up, log 82.5 kg on /progress, see current value, delete it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)