### PR TITLE
feat: give the AI coach the user's goals and fatigue signals

### DIFF
--- a/components/progress/deload-banner.tsx
+++ b/components/progress/deload-banner.tsx
@@ -1,23 +1,9 @@
 import { BatteryLow } from 'lucide-react';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
-import type { DeloadReason } from '@/lib/deload';
+import { deloadReasonLine, type DeloadReason } from '@/lib/deload';
 
 interface Props {
   reasons: DeloadReason[];
-}
-
-function reasonLine(reason: DeloadReason): string {
-  switch (reason.kind) {
-    case 'stalled-lifts': {
-      const count = reason.exerciseNames.length;
-      const names = reason.exerciseNames.join(', ');
-      return count === 1
-        ? `1 lift has stalled: ${names}.`
-        : `${count} lifts have stalled: ${names}.`;
-    }
-    case 'low-readiness':
-      return `Your readiness has averaged ${reason.averageReadiness}/5 over your last ${reason.checkins} check-ins.`;
-  }
 }
 
 // Display-only banner shown on the progress page when recommendDeload fires.
@@ -39,7 +25,7 @@ export function DeloadBanner({ reasons }: Props) {
       <CardContent className="flex flex-col gap-2 text-sm">
         <ul className="list-disc space-y-1 pl-5">
           {reasons.map((reason) => (
-            <li key={reason.kind}>{reasonLine(reason)}</li>
+            <li key={reason.kind}>{deloadReasonLine(reason)}</li>
           ))}
         </ul>
         <p className="text-xs text-muted-foreground">

--- a/lib/coach.ts
+++ b/lib/coach.ts
@@ -3,9 +3,17 @@ import {
   applyBodyweight,
   best1RM,
   exerciseProgress,
+  isStalled,
   isoWeekStart,
   totalVolume,
 } from '@/lib/stats';
+import { goalProgress } from '@/lib/goals';
+import {
+  DELOAD_READINESS_LOOKBACK,
+  DELOAD_READINESS_MAX_AGE_DAYS,
+  deloadReasonLine,
+  recommendDeload,
+} from '@/lib/deload';
 import { COACH_SYSTEM_PROMPT } from '@/lib/prompts/coach-system-prompt';
 import { getLlmProvider } from '@/lib/llm';
 
@@ -36,6 +44,15 @@ export interface CoachPayload {
   // null when there is no recent check-in. The coach reasons over this but its
   // output contract (the <adjustments> block) is unchanged.
   latestReadiness: ReadinessSummary | null;
+  // The user's per-exercise target goals (issue #101), with progress computed
+  // exactly like the progress page: best bodyweight-adjusted e1RM over the
+  // full history vs the target's e1RM. Input signal only; the output contract
+  // (the <adjustments> block) is unchanged.
+  goals: GoalSummary[];
+  // Derived fatigue signals (issue #101): stalled lifts per lib/stats.ts
+  // isStalled over the progress page's 12-week window, plus the program-level
+  // deload recommendation from lib/deload.ts with its human-readable reasons.
+  fatigue: FatigueSummary;
   // For each program exercise: the progression over the last 8 weeks
   // (max loads + 1RM per session, effective values with bodyweight included).
   recentProgress: Array<{
@@ -53,6 +70,25 @@ export interface CoachPayload {
       estimated1RM: number;
     }>;
   }>;
+}
+
+interface GoalSummary {
+  exerciseName: string;
+  // Target load in kg (effective load for bodyweight exercises).
+  targetWeight: number;
+  targetReps: number;
+  // 0-100, fraction of the way to the goal on the e1RM scale (lib/goals.ts
+  // goalProgress), same semantics as the progress page.
+  progressPct: number;
+  achieved: boolean;
+}
+
+interface FatigueSummary {
+  // Names of the lifts currently flagged by lib/stats.ts isStalled, sorted.
+  stalledExercises: string[];
+  deloadRecommended: boolean;
+  // Short human-readable reasons (same lines the progress page shows).
+  deloadReasons: string[];
 }
 
 interface ReadinessSummary {
@@ -141,12 +177,21 @@ export async function buildCoachPayload(userId: string): Promise<CoachPayload> {
   });
   const bodyweight = user?.bodyweight ?? null;
 
-  const [currentWeek, previousWeek, activeProgram, latestReadiness, recentSets] =
-    await Promise.all([
+  const [
+    currentWeek,
+    previousWeek,
+    activeProgram,
+    latestReadiness,
+    goals,
+    fatigue,
+    recentSets,
+  ] = await Promise.all([
     weekSummary(userId, currentWeekStart, addDays(currentWeekStart, 7), bodyweight),
     weekSummary(userId, previousWeekStart, currentWeekStart, bodyweight),
     fetchActiveProgram(userId),
     fetchLatestReadiness(userId, now),
+    fetchGoalsSummary(userId, bodyweight),
+    fetchFatigueSummary(userId, bodyweight, now),
     db.set.findMany({
       where: {
         isWarmup: false,
@@ -246,6 +291,8 @@ export async function buildCoachPayload(userId: string): Promise<CoachPayload> {
     weekPrevious: previousWeek.sessions.length === 0 ? null : previousWeek,
     activeProgram,
     latestReadiness,
+    goals,
+    fatigue,
     recentProgress: recentProgress.sort((a, b) =>
       a.exerciseName.localeCompare(b.exerciseName),
     ),
@@ -381,6 +428,141 @@ async function fetchActiveProgram(userId: string): Promise<ProgramSummary | null
         targetRIR: pe.targetRIR,
       })),
     })),
+  };
+}
+
+// The user's exercise goals with progress on the e1RM scale (issue #101),
+// computed exactly like the progress page: best bodyweight-adjusted e1RM over
+// the FULL set history of each goal exercise vs the target's e1RM.
+async function fetchGoalsSummary(
+  userId: string,
+  bodyweight: number | null,
+): Promise<GoalSummary[]> {
+  const goals = await db.exerciseGoal.findMany({
+    where: { userId },
+    orderBy: { createdAt: 'desc' },
+    include: {
+      exercise: { select: { id: true, name: true, usesBodyweight: true } },
+    },
+  });
+  if (goals.length === 0) return [];
+
+  const sets = await db.set.findMany({
+    where: {
+      exerciseId: { in: goals.map((g) => g.exerciseId) },
+      isWarmup: false,
+      session: { userId },
+    },
+    select: { exerciseId: true, weight: true, reps: true, isWarmup: true },
+  });
+  const setsByExercise = new Map<string, typeof sets>();
+  for (const s of sets) {
+    const arr = setsByExercise.get(s.exerciseId);
+    if (arr) arr.push(s);
+    else setsByExercise.set(s.exerciseId, [s]);
+  }
+
+  return goals.map((goal) => {
+    const exerciseSets = setsByExercise.get(goal.exerciseId) ?? [];
+    const adjusted = applyBodyweight(
+      exerciseSets.map((s) => ({
+        ...s,
+        usesBodyweight: goal.exercise.usesBodyweight,
+      })),
+      bodyweight,
+    );
+    const best = best1RM(adjusted);
+    const target = { targetWeight: goal.targetWeight, targetReps: goal.targetReps };
+    return {
+      exerciseName: goal.exercise.name,
+      targetWeight: goal.targetWeight,
+      targetReps: goal.targetReps,
+      progressPct: Math.round(goalProgress(best, target) * 100),
+      achieved: goal.achievedAt != null,
+    };
+  });
+}
+
+// The same window the progress page judges stalls over (last 12 weeks).
+const FATIGUE_WINDOW_WEEKS = 12;
+
+// Derived fatigue signals (issue #101), mirroring the progress page: stalled
+// lifts per isStalled over the per-session e1RM series of the last 12 weeks,
+// and the program-level deload recommendation fed by those stalls plus the
+// recent readiness check-ins.
+async function fetchFatigueSummary(
+  userId: string,
+  bodyweight: number | null,
+  now: Date,
+): Promise<FatigueSummary> {
+  const since = new Date(now);
+  since.setUTCHours(0, 0, 0, 0);
+  since.setUTCDate(since.getUTCDate() - FATIGUE_WINDOW_WEEKS * 7);
+  const readinessSince = addDays(now, -DELOAD_READINESS_MAX_AGE_DAYS);
+
+  const [sets, recentCheckins] = await Promise.all([
+    db.set.findMany({
+      where: {
+        isWarmup: false,
+        completedAt: { gte: since },
+        session: { userId },
+      },
+      select: {
+        weight: true,
+        reps: true,
+        isWarmup: true,
+        sessionId: true,
+        exerciseId: true,
+        exercise: { select: { name: true, usesBodyweight: true } },
+        session: { select: { startedAt: true } },
+      },
+    }),
+    db.readinessCheckin.findMany({
+      where: { userId, createdAt: { gte: readinessSince } },
+      orderBy: { createdAt: 'desc' },
+      take: DELOAD_READINESS_LOOKBACK,
+      select: { readiness: true },
+    }),
+  ]);
+
+  const setsByExercise = new Map<string, typeof sets>();
+  for (const s of sets) {
+    const arr = setsByExercise.get(s.exerciseId);
+    if (arr) arr.push(s);
+    else setsByExercise.set(s.exerciseId, [s]);
+  }
+
+  const stalledExercises: string[] = [];
+  for (const exerciseSets of setsByExercise.values()) {
+    const first = exerciseSets[0];
+    if (!first) continue;
+    const points = exerciseProgress(
+      applyBodyweight(
+        exerciseSets.map((s) => ({
+          weight: s.weight,
+          reps: s.reps,
+          isWarmup: s.isWarmup,
+          sessionId: s.sessionId,
+          sessionStartedAt: s.session.startedAt,
+          usesBodyweight: first.exercise.usesBodyweight,
+        })),
+        bodyweight,
+      ),
+    );
+    if (isStalled(points.map((p) => p.estimated1RM))) {
+      stalledExercises.push(first.exercise.name);
+    }
+  }
+  stalledExercises.sort((a, b) => a.localeCompare(b));
+
+  const recommendation = recommendDeload({
+    stalledExerciseNames: stalledExercises,
+    recentReadiness: recentCheckins.map((c) => c.readiness),
+  });
+  return {
+    stalledExercises,
+    deloadRecommended: recommendation.recommended,
+    deloadReasons: recommendation.reasons.map(deloadReasonLine),
   };
 }
 

--- a/lib/deload.test.ts
+++ b/lib/deload.test.ts
@@ -4,6 +4,7 @@ import {
   DELOAD_READINESS_MIN_CHECKINS,
   DELOAD_READINESS_THRESHOLD,
   DELOAD_STALLED_LIFTS_MIN,
+  deloadReasonLine,
   recommendDeload,
 } from './deload';
 
@@ -103,5 +104,25 @@ describe('recommendDeload', () => {
     expect(result.reasons).toEqual([
       { kind: 'low-readiness', averageReadiness: 1.7, checkins: 3 },
     ]);
+  });
+});
+
+describe('deloadReasonLine', () => {
+  it('formats a single stalled lift', () => {
+    expect(
+      deloadReasonLine({ kind: 'stalled-lifts', exerciseNames: ['Bench'] }),
+    ).toBe('1 lift has stalled: Bench.');
+  });
+
+  it('formats several stalled lifts', () => {
+    expect(
+      deloadReasonLine({ kind: 'stalled-lifts', exerciseNames: ['Bench', 'Squat'] }),
+    ).toBe('2 lifts have stalled: Bench, Squat.');
+  });
+
+  it('formats chronically low readiness', () => {
+    expect(
+      deloadReasonLine({ kind: 'low-readiness', averageReadiness: 2.3, checkins: 4 }),
+    ).toBe('Your readiness has averaged 2.3/5 over your last 4 check-ins.');
   });
 });

--- a/lib/deload.ts
+++ b/lib/deload.ts
@@ -41,6 +41,23 @@ export interface DeloadRecommendation {
   reasons: DeloadReason[];
 }
 
+// One short human-readable line per reason. Shared by the progress-page
+// banner and the coach payload (issue #101) so the user and the AI coach read
+// the exact same explanation.
+export function deloadReasonLine(reason: DeloadReason): string {
+  switch (reason.kind) {
+    case 'stalled-lifts': {
+      const count = reason.exerciseNames.length;
+      const names = reason.exerciseNames.join(', ');
+      return count === 1
+        ? `1 lift has stalled: ${names}.`
+        : `${count} lifts have stalled: ${names}.`;
+    }
+    case 'low-readiness':
+      return `Your readiness has averaged ${reason.averageReadiness}/5 over your last ${reason.checkins} check-ins.`;
+  }
+}
+
 export interface DeloadInput {
   // Names of the lifts currently flagged by isStalled, any order.
   stalledExerciseNames: string[];

--- a/lib/llm/demo.test.ts
+++ b/lib/llm/demo.test.ts
@@ -25,6 +25,11 @@ describe('demo provider', () => {
       messages: [{ role: 'user', content: 'x' }],
     });
     expect(debrief.text).toContain('<adjustments>');
+    // Issue #101: the canned debrief demonstrates the goals + fatigue payload
+    // fields so the no-key flow shows the behavior.
+    expect(debrief.text).toMatch(/of the way to your .* target/i);
+    expect(debrief.text).toMatch(/stalled/i);
+    expect(debrief.text).toMatch(/deload/i);
 
     const program = await p.complete({
       system: 'Respond with a SINGLE JSON object and nothing else.',

--- a/lib/llm/demo.ts
+++ b/lib/llm/demo.ts
@@ -22,14 +22,17 @@ Solid week: 3 sessions logged, total working volume up about 4% versus last week
 - Barbell bench press: 70 kg x 8 at RIR 2 on the top set, estimated 1RM up again.
 - Pronated pull-ups: clean reps across all sets, ready for added load.
 
+**Goal check**
+- Barbell bench press: 92% of the way to your 80 kg x 8 target on the estimated-1RM scale. One more clean progression and it should fall.
+
 **Watch (possible plateau)**
-- Cable lateral raises have been flat for 3 weeks at the same load and reps.
+- Cable lateral raises are flagged as stalled: estimated 1RM flat over the last 3 sessions at the same load and reps.
 
 **Fatigue signals**
-- RIR is holding around 2, no red flags this week.
+- RIR is holding around 2 and no deload is recommended this week, so keep pushing.
 
 **Suggestions for next week**
-- Push bench to 72.5 kg for the first working sets.
+- Push bench to 72.5 kg for the first working sets - that lines up with your stated goal.
 - Bias a little more side-delt volume.
 
 **Points of attention**

--- a/lib/prompts/coach-system-prompt.test.ts
+++ b/lib/prompts/coach-system-prompt.test.ts
@@ -34,6 +34,19 @@ describe('coach system prompt positioning', () => {
     expect(COACH_SYSTEM_PROMPT).toContain('"suggestedRepsMin"');
     expect(COACH_SYSTEM_PROMPT).toContain('"suggestedRestSec"');
   });
+
+  // Issue #101: goals and fatigue signals are INPUT-side guidance only.
+  it('tells the coach how to use the goals payload and forbids inventing goals', () => {
+    expect(COACH_SYSTEM_PROMPT).toMatch(/"goals" lists each per-exercise target/i);
+    expect(COACH_SYSTEM_PROMPT).toMatch(/NEVER invent a goal that is not in the\s+payload/i);
+  });
+
+  it('tells the coach to prefer recovery over load increases on a deload recommendation', () => {
+    expect(COACH_SYSTEM_PROMPT).toMatch(/fatigue\.stalledExercises/);
+    expect(COACH_SYSTEM_PROMPT).toMatch(
+      /deloadRecommended is true, prefer recovery-oriented advice/i,
+    );
+  });
 });
 
 describe('program generation prompt positioning', () => {

--- a/lib/prompts/coach-system-prompt.ts
+++ b/lib/prompts/coach-system-prompt.ts
@@ -31,6 +31,18 @@ high soreness in a trained muscle group are reasons to hold or reduce volume/loa
 strong readiness can justify pushing. Treat it as one signal among the training
 data, never the only one, and only when it is recent.
 
+The payload also carries the user's stated target goals and derived fatigue
+signals. "goals" lists each per-exercise target (exerciseName, targetWeight x
+targetReps, progressPct on the estimated-1RM scale, achieved). Anchor your advice
+on these stated goals: relate progress and suggestions to the nearest unachieved
+goal, celebrate a freshly achieved one, and NEVER invent a goal that is not in the
+payload. "fatigue" gives you fatigue.stalledExercises (lifts whose estimated 1RM
+has been flat over the recent sessions), fatigue.deloadRecommended and
+fatigue.deloadReasons (the same recommendation the app shows the user). When
+deloadRecommended is true, prefer recovery-oriented advice - hold or reduce loads
+and volume, echo the provided reasons - over load increases; do not prescribe a
+load increase on a stalled exercise without addressing the stall.
+
 Be concise (max 600 words), actionable, factual. Cite studies when relevant
 (Schoenfeld, Helms, Israetel). Do not make up data that is not in the payload.
 

--- a/tests/integration/core.test.ts
+++ b/tests/integration/core.test.ts
@@ -251,3 +251,183 @@ describe('buildCoachPayload readiness (issue #38)', () => {
     expect(payload.latestReadiness).toBeNull();
   });
 });
+
+describe('buildCoachPayload goals (issue #101)', () => {
+  it('surfaces each goal with e1RM progress and achievement', async () => {
+    const user = await makeUser('goals-payload@test.dev');
+    const bench = await db.exercise.create({
+      data: { userId: user.id, name: 'Bench', muscleGroup: 'CHEST', category: 'COMPOUND' },
+    });
+    const session = await db.session.create({ data: { userId: user.id } });
+    await db.set.create({
+      data: { sessionId: session.id, exerciseId: bench.id, setNumber: 1, weight: 100, reps: 5 },
+    });
+    // Unachieved 120x5 target: best e1RM 116.7 vs target e1RM 140 -> 83%.
+    await db.exerciseGoal.create({
+      data: { userId: user.id, exerciseId: bench.id, targetWeight: 120, targetReps: 5 },
+    });
+
+    const payload = await buildCoachPayload(user.id);
+    expect(payload.goals).toEqual([
+      {
+        exerciseName: 'Bench',
+        targetWeight: 120,
+        targetReps: 5,
+        progressPct: 83,
+        achieved: false,
+      },
+    ]);
+  });
+
+  it('marks an achieved goal and caps progress at 100', async () => {
+    const user = await makeUser('goals-achieved@test.dev');
+    const bench = await db.exercise.create({
+      data: { userId: user.id, name: 'Bench', muscleGroup: 'CHEST', category: 'COMPOUND' },
+    });
+    const session = await db.session.create({ data: { userId: user.id } });
+    await db.set.create({
+      data: { sessionId: session.id, exerciseId: bench.id, setNumber: 1, weight: 100, reps: 5 },
+    });
+    await db.exerciseGoal.create({
+      data: {
+        userId: user.id,
+        exerciseId: bench.id,
+        targetWeight: 90,
+        targetReps: 5,
+        achievedAt: new Date(),
+      },
+    });
+
+    const payload = await buildCoachPayload(user.id);
+    expect(payload.goals[0]?.achieved).toBe(true);
+    expect(payload.goals[0]?.progressPct).toBe(100);
+  });
+
+  it('uses the effective load for bodyweight exercises', async () => {
+    const user = await db.user.create({
+      data: { email: 'goals-bw@test.dev', passwordHash: 'x', bodyweight: 80 },
+    });
+    const pullups = await db.exercise.create({
+      data: {
+        userId: user.id,
+        name: 'Pull-up',
+        muscleGroup: 'BACK_WIDTH',
+        category: 'COMPOUND',
+        usesBodyweight: true,
+      },
+    });
+    const session = await db.session.create({ data: { userId: user.id } });
+    // +20 added at bodyweight 80 = 100 effective; target 100x5 effective.
+    await db.set.create({
+      data: { sessionId: session.id, exerciseId: pullups.id, setNumber: 1, weight: 20, reps: 5 },
+    });
+    await db.exerciseGoal.create({
+      data: { userId: user.id, exerciseId: pullups.id, targetWeight: 100, targetReps: 5 },
+    });
+
+    const payload = await buildCoachPayload(user.id);
+    expect(payload.goals[0]?.progressPct).toBe(100);
+  });
+
+  it("does not leak another user's goals and is empty without goals", async () => {
+    const userA = await makeUser('goals-a@test.dev');
+    const userB = await makeUser('goals-b@test.dev');
+    const benchB = await db.exercise.create({
+      data: { userId: userB.id, name: 'B Bench', muscleGroup: 'CHEST', category: 'COMPOUND' },
+    });
+    await db.exerciseGoal.create({
+      data: { userId: userB.id, exerciseId: benchB.id, targetWeight: 100, targetReps: 5 },
+    });
+
+    const payload = await buildCoachPayload(userA.id);
+    expect(payload.goals).toEqual([]);
+  });
+});
+
+describe('buildCoachPayload fatigue (issue #101)', () => {
+  // Three sessions on distinct days with an identical top set: e1RM flat over
+  // the full stall lookback -> isStalled flags the lift.
+  async function seedStalledLift(userId: string, name: string) {
+    const exercise = await db.exercise.create({
+      data: { userId, name, muscleGroup: 'CHEST', category: 'COMPOUND' },
+    });
+    for (let i = 0; i < 3; i++) {
+      const startedAt = new Date(Date.now() - (10 - i) * 24 * 60 * 60 * 1000);
+      const session = await db.session.create({
+        data: { userId, startedAt, finishedAt: startedAt },
+      });
+      await db.set.create({
+        data: {
+          sessionId: session.id,
+          exerciseId: exercise.id,
+          setNumber: 1,
+          weight: 100,
+          reps: 5,
+          completedAt: startedAt,
+        },
+      });
+    }
+    return exercise;
+  }
+
+  it('reports no fatigue for a fresh user', async () => {
+    const user = await makeUser('fatigue-fresh@test.dev');
+    const payload = await buildCoachPayload(user.id);
+    expect(payload.fatigue).toEqual({
+      stalledExercises: [],
+      deloadRecommended: false,
+      deloadReasons: [],
+    });
+  });
+
+  it('flags stalled lifts and recommends a deload at two stalls', async () => {
+    const user = await makeUser('fatigue-stalls@test.dev');
+    await seedStalledLift(user.id, 'Bench');
+    await seedStalledLift(user.id, 'Squat');
+
+    const payload = await buildCoachPayload(user.id);
+    expect(payload.fatigue.stalledExercises).toEqual(['Bench', 'Squat']);
+    expect(payload.fatigue.deloadRecommended).toBe(true);
+    expect(payload.fatigue.deloadReasons).toEqual([
+      '2 lifts have stalled: Bench, Squat.',
+    ]);
+  });
+
+  it('does not recommend a deload on a single stalled lift', async () => {
+    const user = await makeUser('fatigue-single@test.dev');
+    await seedStalledLift(user.id, 'Bench');
+
+    const payload = await buildCoachPayload(user.id);
+    expect(payload.fatigue.stalledExercises).toEqual(['Bench']);
+    expect(payload.fatigue.deloadRecommended).toBe(false);
+  });
+
+  it('recommends a deload on chronically low readiness', async () => {
+    const user = await makeUser('fatigue-readiness@test.dev');
+    for (let i = 0; i < 3; i++) {
+      await db.readinessCheckin.create({
+        data: {
+          userId: user.id,
+          readiness: 2,
+          sleepQuality: 3,
+          createdAt: new Date(Date.now() - i * 24 * 60 * 60 * 1000),
+        },
+      });
+    }
+
+    const payload = await buildCoachPayload(user.id);
+    expect(payload.fatigue.deloadRecommended).toBe(true);
+    expect(payload.fatigue.deloadReasons).toEqual([
+      'Your readiness has averaged 2/5 over your last 3 check-ins.',
+    ]);
+  });
+
+  it("does not count another user's stalls", async () => {
+    const userA = await makeUser('fatigue-a@test.dev');
+    const userB = await makeUser('fatigue-b@test.dev');
+    await seedStalledLift(userB.id, 'B Bench');
+
+    const payload = await buildCoachPayload(userA.id);
+    expect(payload.fatigue.stalledExercises).toEqual([]);
+  });
+});


### PR DESCRIPTION
Implements issue #101: the coach payload now carries what the user is aiming for and where they are plateauing, input-side only.

- CoachPayload gains two additive sections in lib/coach.ts:
  - goals: per-exercise targets (exerciseName, targetWeight x targetReps, progressPct 0-100 on the e1RM scale via lib/goals.ts goalProgress, achieved), computed like the progress page - best bodyweight-adjusted e1RM over the full history, effective load for bodyweight exercises.
  - fatigue: stalledExercises (lib/stats.ts isStalled over the progress page's 12-week window), deloadRecommended and deloadReasons (lib/deload.ts recommendDeload; the reason strings are shared with the progress banner via a new deloadReasonLine helper, so the user and the coach read the same explanation).
- Coach system prompt: a short section telling the coach to anchor advice on the stated goals, never invent goals, and prefer recovery-oriented advice when deloadRecommended is true. The adjustments OUTPUT contract is untouched: existing lib/coach-adjustments.test.ts and the contract assertions in coach-system-prompt.test.ts pass unmodified; new prompt tests pin the added guidance.
- Demo provider: the canned debrief now references goal progress, a stalled lift, and the deload signal, so the no-key flow exercises the new fields (asserted in lib/llm/demo.test.ts).

Closes #101

## How I tested

- bash scripts/verify.sh --full PASSED locally (lint, typecheck, unit, build, integration on :5434, Playwright E2E) on the first run.
- New unit tests: deloadReasonLine formatting; demo debrief exercises the new fields; prompt guidance pinned (existing output-contract tests unmodified).
- New integration tests (tests/integration/core.test.ts): goals progress 83% for 100x5 vs a 120x5 target, achieved + capped at 100, effective load for weighted pull-ups, cross-user isolation; fatigue empty for a fresh user, two stalled lifts -> deload recommended with the exact reason line, single stall -> no deload, chronic low readiness -> deload, cross-user isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)