### PR TITLE
feat: import training history from a Strong app CSV export

### DIFF
--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -4,6 +4,7 @@ import { db } from '@/lib/db';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { SettingsClient } from '@/components/settings/settings-client';
 import { ProfileSection } from '@/components/settings/profile-section';
+import { ImportSection } from '@/components/settings/import-section';
 
 export default async function SettingsPage() {
   const auth = await requireSession();
@@ -51,6 +52,8 @@ export default async function SettingsPage() {
             unit: user?.unit ?? 'KG',
           }}
         />
+
+        <ImportSection />
 
         <SettingsClient />
       </div>

--- a/app/api/import/strong/route.ts
+++ b/app/api/import/strong/route.ts
@@ -1,0 +1,125 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { ApiError, handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
+import { rateLimit } from '@/lib/rate-limit';
+import { strongImportInputSchema } from '@/lib/schemas/import';
+import { parseStrongCsv, STRONG_CSV_MAX_BYTES } from '@/lib/import/strong-csv';
+import {
+  buildStrongImportPlan,
+  executeStrongImport,
+  setDuplicateKey,
+} from '@/lib/import/strong-import';
+
+// How many per-line errors the response reports (the count is always exact).
+const MAX_REPORTED_ERRORS = 50;
+
+// POST /api/import/strong: import a Strong app CSV export (issue #100).
+// mode=preview parses and plans without writing anything; mode=confirm
+// performs the import inside one transaction. The file content is untrusted:
+// hard caps, Zod on every value (in the parser and on the body), and no write
+// outside the transaction.
+export async function POST(req: Request) {
+  try {
+    const userId = await requireApiUserId();
+
+    const rl = rateLimit(`import:${userId}`, 10, 60_000);
+    if (!rl.ok) {
+      throw new ApiError(429, `Too many import requests. Retry in ${rl.retryAfterSec}s.`);
+    }
+
+    // Cheap size guard before the body is even read into memory.
+    const contentLength = Number(req.headers.get('content-length') ?? 0);
+    if (contentLength > STRONG_CSV_MAX_BYTES * 1.5) {
+      throw new ApiError(413, 'File too large: the limit is 5 MB.');
+    }
+
+    const data = await parseJsonBody(req, strongImportInputSchema);
+    const parsed = parseStrongCsv(data.csv, data.unit);
+    if (!parsed.ok) {
+      throw new ApiError(400, parsed.fatalError ?? 'Unreadable file.');
+    }
+
+    // Existing data on the imported days, for duplicate skipping and the
+    // "you already trained that day" preview warning.
+    const dateKeys = [...new Set(parsed.rows.map((r) => r.dateKey))].sort();
+    const existingSetKeys = new Set<string>();
+    const existingSessionDates = new Set<string>();
+    if (dateKeys.length > 0) {
+      const rangeStart = new Date(`${dateKeys[0]}T00:00:00.000Z`);
+      const rangeEnd = new Date(`${dateKeys[dateKeys.length - 1]}T00:00:00.000Z`);
+      rangeEnd.setUTCDate(rangeEnd.getUTCDate() + 1);
+      const sessions = await db.session.findMany({
+        where: { userId, startedAt: { gte: rangeStart, lt: rangeEnd } },
+        select: {
+          startedAt: true,
+          sets: {
+            select: {
+              setNumber: true,
+              weight: true,
+              reps: true,
+              exercise: { select: { name: true } },
+            },
+          },
+        },
+      });
+      for (const session of sessions) {
+        const dateKey = session.startedAt.toISOString().slice(0, 10);
+        existingSessionDates.add(dateKey);
+        for (const set of session.sets) {
+          existingSetKeys.add(
+            setDuplicateKey(dateKey, set.exercise.name, set.setNumber, set.weight, set.reps),
+          );
+        }
+      }
+    }
+
+    const exercises = await db.exercise.findMany({
+      where: { userId },
+      select: { name: true },
+    });
+    const plan = buildStrongImportPlan(
+      parsed.rows,
+      exercises.map((e) => e.name),
+      existingSetKeys,
+    );
+
+    const common = {
+      duplicatesSkipped: plan.duplicateCount,
+      cardioSkipped: parsed.cardioSkipped,
+      errorCount: parsed.errors.length,
+      errors: parsed.errors.slice(0, MAX_REPORTED_ERRORS),
+    };
+
+    if (data.mode === 'preview') {
+      return NextResponse.json({
+        mode: 'preview',
+        sessions: plan.sessions.length,
+        sets: plan.totalSets,
+        newExercises: plan.newExerciseNames,
+        existingSessionDates: [...existingSessionDates]
+          .filter((d) => dateKeys.includes(d))
+          .sort(),
+        ...common,
+      });
+    }
+
+    if (plan.totalSets === 0) {
+      throw new ApiError(400, 'Nothing to import: no valid, non-duplicate set found.');
+    }
+
+    // One transaction per import: a failure anywhere rolls back every row.
+    const result = await db.$transaction(async (tx) =>
+      executeStrongImport(tx, userId, plan),
+    );
+
+    return NextResponse.json({
+      mode: 'confirm',
+      createdSessions: result.createdSessions,
+      createdSets: result.createdSets,
+      createdExercises: result.createdExercises,
+      ...common,
+    });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/components/settings/import-section.test.tsx
+++ b/components/settings/import-section.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ImportSection } from './import-section';
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+import { toast } from 'sonner';
+
+const PREVIEW = {
+  mode: 'preview',
+  sessions: 2,
+  sets: 3,
+  newExercises: ['Bench Press'],
+  existingSessionDates: [],
+  duplicatesSkipped: 0,
+  cardioSkipped: 1,
+  errorCount: 1,
+  errors: [{ line: 4, reason: 'Invalid or missing date.' }],
+};
+
+function csvFile(content = 'Date,Workout Name\n') {
+  return new File([content], 'strong.csv', { type: 'text/csv' });
+}
+
+function fileInput(): HTMLInputElement {
+  const input = document.querySelector('input[type="file"]');
+  if (!input) throw new Error('file input not found');
+  return input as HTMLInputElement;
+}
+
+describe('ImportSection', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => PREVIEW });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('previews the picked file before any import', async () => {
+    const user = userEvent.setup();
+    render(<ImportSection />);
+
+    await user.upload(fileInput(), csvFile());
+
+    await waitFor(() => {
+      expect(screen.getByTestId('import-preview')).toBeInTheDocument();
+    });
+    // Dry run only: one POST in preview mode.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(
+      (fetchMock.mock.calls[0]?.[1] as RequestInit).body as string,
+    ) as { mode: string; unit: string };
+    expect(body.mode).toBe('preview');
+    expect(body.unit).toBe('KG');
+
+    expect(screen.getByText(/2 sessions, 3 sets to import/)).toBeInTheDocument();
+    expect(screen.getByText(/1 new exercise will be created/)).toBeInTheDocument();
+    expect(screen.getByText(/1 cardio row/)).toBeInTheDocument();
+    expect(screen.getByText(/line 4: invalid or missing date/i)).toBeInTheDocument();
+  });
+
+  it('confirms only on the explicit button, in confirm mode', async () => {
+    const user = userEvent.setup();
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, json: async () => PREVIEW })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          mode: 'confirm',
+          createdSessions: 2,
+          createdSets: 3,
+          createdExercises: 1,
+        }),
+      });
+    render(<ImportSection />);
+
+    await user.upload(fileInput(), csvFile());
+    await waitFor(() => screen.getByTestId('import-preview'));
+    await user.click(screen.getByRole('button', { name: /confirm import/i }));
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const body = JSON.parse(
+      (fetchMock.mock.calls[1]?.[1] as RequestInit).body as string,
+    ) as { mode: string };
+    expect(body.mode).toBe('confirm');
+    expect(toast.success).toHaveBeenCalled();
+  });
+
+  it('rejects an oversized file client-side without calling the API', async () => {
+    const user = userEvent.setup();
+    render(<ImportSection />);
+
+    const big = new File([new Uint8Array(5 * 1024 * 1024 + 1)], 'big.csv', {
+      type: 'text/csv',
+    });
+    await user.upload(fileInput(), big);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith('File too large: the limit is 5 MB.');
+  });
+
+  it('surfaces a server rejection and resets the picker', async () => {
+    const user = userEvent.setup();
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'Unrecognized format.' }),
+    });
+    render(<ImportSection />);
+
+    await user.upload(fileInput(), csvFile('foo,bar\n'));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Unrecognized format.');
+    });
+    expect(screen.queryByTestId('import-preview')).not.toBeInTheDocument();
+  });
+});

--- a/components/settings/import-section.tsx
+++ b/components/settings/import-section.tsx
@@ -1,0 +1,251 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { FileUp, Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+// Client-side mirror of the server cap (the server re-enforces it).
+const MAX_FILE_BYTES = 5 * 1024 * 1024;
+
+// File.text() with a FileReader fallback (jsdom and older browsers).
+async function readFileText(file: File): Promise<string> {
+  if (typeof file.text === 'function') return file.text();
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result ?? ''));
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(file);
+  });
+}
+
+interface LineError {
+  line: number;
+  reason: string;
+}
+
+interface Preview {
+  sessions: number;
+  sets: number;
+  newExercises: string[];
+  existingSessionDates: string[];
+  duplicatesSkipped: number;
+  cardioSkipped: number;
+  errorCount: number;
+  errors: LineError[];
+}
+
+// Strong CSV import (issue #100): pick the export file, dry-run preview
+// (counts + per-line errors, nothing written), then explicitly confirm.
+export function ImportSection() {
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [unit, setUnit] = useState<'KG' | 'LB'>('KG');
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [csvText, setCsvText] = useState<string | null>(null);
+  const [preview, setPreview] = useState<Preview | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  function pickFile() {
+    fileRef.current?.click();
+  }
+
+  async function onFilePicked(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0] ?? null;
+    e.target.value = '';
+    if (!file) return;
+    if (file.size > MAX_FILE_BYTES) {
+      toast.error('File too large: the limit is 5 MB.');
+      return;
+    }
+    const text = await readFileText(file);
+    setFileName(file.name);
+    setCsvText(text);
+    setPreview(null);
+    await requestPreview(text);
+  }
+
+  async function callApi(csv: string, mode: 'preview' | 'confirm') {
+    const res = await fetch('/api/import/strong', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ csv, unit, mode }),
+    });
+    const json = (await res.json().catch(() => null)) as
+      | (Preview & {
+          createdSessions?: number;
+          createdSets?: number;
+          createdExercises?: number;
+          error?: string;
+        })
+      | null;
+    if (!res.ok) {
+      throw new Error(json?.error ?? `Error ${res.status}`);
+    }
+    return json;
+  }
+
+  async function requestPreview(csv: string) {
+    setBusy(true);
+    try {
+      const json = await callApi(csv, 'preview');
+      if (json) setPreview(json);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Preview failed.');
+      setCsvText(null);
+      setFileName(null);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function confirmImport() {
+    if (!csvText) return;
+    setBusy(true);
+    try {
+      const json = await callApi(csvText, 'confirm');
+      toast.success(
+        `Imported ${json?.createdSessions ?? 0} sessions, ${json?.createdSets ?? 0} sets` +
+          ((json?.createdExercises ?? 0) > 0
+            ? `, ${json?.createdExercises} new exercises.`
+            : '.'),
+      );
+      setCsvText(null);
+      setFileName(null);
+      setPreview(null);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Import failed.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function cancel() {
+    setCsvText(null);
+    setFileName(null);
+    setPreview(null);
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <h2 className="text-base font-semibold">Import from Strong</h2>
+        <p className="text-xs text-muted-foreground">
+          Bring your training history from the Strong app: export it as CSV
+          (Settings, then Export data), preview it here, then confirm.
+        </p>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        <div className="flex items-end gap-2">
+          <div className="space-y-1">
+            <Label htmlFor="strong-unit">Strong weight unit</Label>
+            <Select value={unit} onValueChange={(v) => setUnit(v as 'KG' | 'LB')}>
+              <SelectTrigger id="strong-unit" className="h-9 w-28">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="KG">kg</SelectItem>
+                <SelectItem value="LB">lb</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <Button
+            variant="outline"
+            onClick={pickFile}
+            disabled={busy}
+            className="min-h-tap"
+          >
+            {busy ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <FileUp className="size-4" />
+            )}
+            <span className="ml-2">Choose a Strong CSV file</span>
+          </Button>
+        </div>
+        <input
+          ref={fileRef}
+          type="file"
+          accept=".csv,text/csv"
+          className="hidden"
+          onChange={onFilePicked}
+        />
+
+        {preview && (
+          <div className="rounded-md border p-3 text-sm" data-testid="import-preview">
+            <p className="font-medium">
+              Preview of <code>{fileName}</code>
+            </p>
+            <ul className="mt-2 list-disc space-y-1 pl-5">
+              <li>
+                {preview.sessions} session{preview.sessions === 1 ? '' : 's'},{' '}
+                {preview.sets} set{preview.sets === 1 ? '' : 's'} to import
+              </li>
+              {preview.newExercises.length > 0 && (
+                <li>
+                  {preview.newExercises.length} new exercise
+                  {preview.newExercises.length === 1 ? '' : 's'} will be created:{' '}
+                  {preview.newExercises.join(', ')}
+                </li>
+              )}
+              {preview.duplicatesSkipped > 0 && (
+                <li>{preview.duplicatesSkipped} exact duplicates will be skipped</li>
+              )}
+              {preview.cardioSkipped > 0 && (
+                <li>{preview.cardioSkipped} cardio rows (no reps) will be skipped</li>
+              )}
+              {preview.existingSessionDates.length > 0 && (
+                <li className="text-amber-700 dark:text-amber-400">
+                  You already have sessions on:{' '}
+                  {preview.existingSessionDates.join(', ')}
+                </li>
+              )}
+            </ul>
+
+            {preview.errorCount > 0 && (
+              <div className="mt-2">
+                <p className="font-medium text-rose-600">
+                  {preview.errorCount} line{preview.errorCount === 1 ? '' : 's'}{' '}
+                  could not be read and will be skipped:
+                </p>
+                <ul className="mt-1 max-h-40 list-disc overflow-y-auto pl-5 text-xs text-muted-foreground">
+                  {preview.errors.map((e) => (
+                    <li key={`${e.line}-${e.reason}`}>
+                      Line {e.line}: {e.reason}
+                    </li>
+                  ))}
+                  {preview.errorCount > preview.errors.length && (
+                    <li>... and {preview.errorCount - preview.errors.length} more</li>
+                  )}
+                </ul>
+              </div>
+            )}
+
+            <div className="mt-3 flex gap-2">
+              <Button
+                size="sm"
+                onClick={confirmImport}
+                disabled={busy || preview.sets === 0}
+                className="min-h-tap"
+              >
+                {busy ? <Loader2 className="size-4 animate-spin" /> : null}
+                <span className={busy ? 'ml-2' : ''}>Confirm import</span>
+              </Button>
+              <Button size="sm" variant="ghost" onClick={cancel} disabled={busy}>
+                Cancel
+              </Button>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -6,6 +6,56 @@ by the charter in [`07-autonomy.md`](07-autonomy.md).
 
 ---
 
+## 2026-06-10 (evening) - Maintainer run: shipped #99, #101, #100 (fourth ideate batch)
+
+**Context.** Maintainer tick over the fourth ideate batch, strictly serialized (lesson L7:
+next issue only after the prior PR is MERGED). All three issues trust-gated (author
+`JulienAu`, collaborator check HTTP 204). All three are complex features under the
+2026-06-10 directive, so each ran `verify.sh --full` locally before its PR, shipped tests at
+every touched layer, and validated its migration against the test Postgres. Merge budget 3;
+used 3.
+
+**Shipped.**
+- **#99 -> PR #103 (merged): bodyweight tracking.** Additive `BodyweightEntry` migration
+  (fresh `migrate deploy` + clean `migrate diff` on :5434), POST/GET/DELETE routes that keep
+  `User.bodyweight` (the "current value" the app reads) in sync with the newest entry in one
+  transaction, and a progress-page card (12-week trend chart, quick add in the display unit,
+  deletable entries). Rollback baseline `autonomy-baseline-2026-06-10b` tagged on main
+  before the merge. One local gate red (Playwright strict-mode: "Log" matched "Log out"),
+  fixed with an exact-match selector.
+- **#101 -> PR #104 (merged): goals + fatigue signals into the AI coach payload.** Additive
+  `CoachPayload.goals` (per-exercise target, e1RM progressPct, achieved - same semantics as
+  the progress page incl. effective load) and `CoachPayload.fatigue` (stalled lifts over the
+  12-week window, deload recommendation with the same human-readable reason lines the
+  banner shows, via the new shared `deloadReasonLine`). System prompt gained usage guidance;
+  the `<adjustments>` OUTPUT contract is untouched and its existing tests passed unmodified.
+  Demo provider debrief now exercises the new fields. Full gate green on the first run.
+- **#100 -> PR #105 (this PR): Strong CSV import.** Pure quote-aware parser
+  `lib/import/strong-csv.ts` treating the file as untrusted input (5 MB / 50000-row caps,
+  no eval, Zod on every row with the set schema's bounds, per-line error collection, cardio
+  rows skipped with a count, kg/lb toggle with header-suffix override), pure planner +
+  transactional executor (case-insensitive exercise matching, missing exercises created as
+  OTHER/ISOLATION via an additive enum migration, sessions grouped per (date, workout) at
+  noon UTC, exact-duplicate skip for idempotence), rate-limited Zod-validated route with
+  dry-run preview and confirm modes, settings UI (pick -> preview -> confirm with the error
+  list), and tests at every layer incl. a transaction-rollback integration test and an E2E
+  upload -> preview -> confirm -> history flow. Two local gate reds fixed: jsdom `File.text`
+  (FileReader fallback) and the catalog-coverage test (OTHER intentionally has no catalog
+  exercise).
+
+**Challenged.** This tick ran in an environment without a subagent tool, so per the charter
+(lesson L8 rule) the multi-lens reviews could NOT be executed independently pre-merge. Each
+PR merged only on green full CI after an author self-review pass; all three are flagged in
+the run report for an independent POST-MERGE review by the orchestrator as its next action
+(correctness + does-it-actually-work for all three, plus a security lens on #100's untrusted
+file input and route).
+
+**Deferred to human / orchestrator.** The post-merge independent reviews above. Note for the
+reviewer: imported sessions render as "Free session" in the history list (the Strong workout
+name lives in the session notes) - a possible polish slice, not a defect.
+
+---
+
 ## 2026-06-10 (later) - Post-merge backstop review of #95; fix #97; batch write-up
 
 **Context.** The background tick that shipped #94/#95 reported it could not spawn an

--- a/lib/exercise-catalog.test.ts
+++ b/lib/exercise-catalog.test.ts
@@ -23,6 +23,9 @@ describe('EXERCISE_CATALOG', () => {
   it('covers every muscle group at least once', () => {
     const covered = new Set(EXERCISE_CATALOG.map((e) => e.muscleGroup));
     for (const group of Object.values(MuscleGroup)) {
+      // OTHER is the fallback bucket for imported exercises (issue #100);
+      // the curated catalog intentionally has no exercise in it.
+      if (group === 'OTHER') continue;
       expect(covered, `missing exercises for ${group}`).toContain(group);
     }
   });

--- a/lib/import/strong-csv.test.ts
+++ b/lib/import/strong-csv.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseStrongCsv,
+  STRONG_CSV_MAX_BYTES,
+  STRONG_CSV_MAX_ROWS,
+} from './strong-csv';
+
+const HEADER =
+  'Date,Workout Name,Exercise Name,Set Order,Weight,Reps,Distance,Seconds';
+
+function csv(...lines: string[]) {
+  return [HEADER, ...lines].join('\n');
+}
+
+describe('parseStrongCsv happy path', () => {
+  it('parses working sets into normalized kg rows', () => {
+    const res = parseStrongCsv(
+      csv(
+        '2026-05-02 09:13:00,Push Day,Bench Press (Barbell),1,80,8,0,0',
+        '2026-05-02 09:13:00,Push Day,Bench Press (Barbell),2,80,7,0,0',
+      ),
+    );
+    expect(res.ok).toBe(true);
+    expect(res.errors).toEqual([]);
+    expect(res.rows).toEqual([
+      {
+        dateKey: '2026-05-02',
+        workoutName: 'Push Day',
+        exerciseName: 'Bench Press (Barbell)',
+        setOrder: 1,
+        weightKg: 80,
+        reps: 8,
+      },
+      {
+        dateKey: '2026-05-02',
+        workoutName: 'Push Day',
+        exerciseName: 'Bench Press (Barbell)',
+        setOrder: 2,
+        weightKg: 80,
+        reps: 7,
+      },
+    ]);
+  });
+
+  it('handles quoted fields with commas and escaped quotes', () => {
+    const res = parseStrongCsv(
+      csv('2026-05-02,"Push, heavy","Press ""Smith"" machine",1,60,10,0,0'),
+    );
+    expect(res.rows[0]?.workoutName).toBe('Push, heavy');
+    expect(res.rows[0]?.exerciseName).toBe('Press "Smith" machine');
+  });
+
+  it('tolerates extra columns and a different column order', () => {
+    const res = parseStrongCsv(
+      [
+        'Workout Name,Date,Duration,Exercise Name,Set Order,Weight,Reps,RPE',
+        'Pull,2026-05-03,1h,Row,1,70,10,8',
+      ].join('\n'),
+    );
+    expect(res.ok).toBe(true);
+    expect(res.rows[0]).toMatchObject({ exerciseName: 'Row', weightKg: 70 });
+  });
+
+  it('accepts an empty weight as 0 (bodyweight movement in Strong)', () => {
+    const res = parseStrongCsv(csv('2026-05-02,Push,Push-up,1,,15,0,0'));
+    expect(res.rows[0]?.weightKg).toBe(0);
+  });
+});
+
+describe('parseStrongCsv units', () => {
+  it('converts from lb when the toggle says the export is in lb', () => {
+    const res = parseStrongCsv(csv('2026-05-02,Push,Bench,1,225,5,0,0'), 'LB');
+    expect(res.rows[0]?.weightKg).toBeCloseTo(102.06, 2);
+  });
+
+  it('honors a kg suffix in the header over the toggle', () => {
+    const res = parseStrongCsv(
+      [
+        'Date,Workout Name,Exercise Name,Set Order,Weight (kg),Reps',
+        '2026-05-02,Push,Bench,1,80,5',
+      ].join('\n'),
+      'LB',
+    );
+    expect(res.rows[0]?.weightKg).toBe(80);
+  });
+
+  it('honors an lbs suffix in the header over the toggle', () => {
+    const res = parseStrongCsv(
+      [
+        'Date,Workout Name,Exercise Name,Set Order,Weight (lbs),Reps',
+        '2026-05-02,Push,Bench,1,225,5',
+      ].join('\n'),
+      'KG',
+    );
+    expect(res.rows[0]?.weightKg).toBeCloseTo(102.06, 2);
+  });
+});
+
+describe('parseStrongCsv malformed input', () => {
+  it('rejects an unrecognized header as fatal', () => {
+    const res = parseStrongCsv('foo,bar\n1,2');
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toMatch(/unrecognized format/i);
+    expect(res.rows).toEqual([]);
+  });
+
+  it('rejects an empty file as fatal', () => {
+    expect(parseStrongCsv('').ok).toBe(false);
+  });
+
+  it('collects per-line errors with line numbers instead of throwing', () => {
+    const res = parseStrongCsv(
+      csv(
+        'not-a-date,Push,Bench,1,80,8,0,0', // line 2: bad date
+        '2026-05-02,Push,Bench,one,80,8,0,0', // line 3: bad set order
+        '2026-05-02,Push,Bench,2,80,8,0,0', // line 4: fine
+        '2026-13-40,Push,Bench,3,80,8,0,0', // line 5: impossible date
+        '2026-05-02,Push,Bench,4,9999,8,0,0', // line 6: weight above cap
+        '2026-05-02,Push,,5,80,8,0,0', // line 7: empty exercise
+      ),
+    );
+    expect(res.ok).toBe(true);
+    expect(res.rows).toHaveLength(1);
+    expect(res.errors.map((e) => e.line)).toEqual([2, 3, 5, 6, 7]);
+  });
+
+  it('skips cardio rows (duration or distance, no reps) with a count', () => {
+    const res = parseStrongCsv(
+      csv(
+        '2026-05-02,Cardio,Running,1,0,0,5000,1800',
+        '2026-05-02,Cardio,Plank,1,0,0,0,60',
+        '2026-05-02,Push,Bench,1,80,8,0,0',
+      ),
+    );
+    expect(res.cardioSkipped).toBe(2);
+    expect(res.rows).toHaveLength(1);
+    expect(res.errors).toEqual([]);
+  });
+
+  it('reports a 0-rep row with no duration as an error, not cardio', () => {
+    const res = parseStrongCsv(csv('2026-05-02,Push,Bench,1,80,0,0,0'));
+    expect(res.cardioSkipped).toBe(0);
+    expect(res.errors).toHaveLength(1);
+  });
+});
+
+describe('parseStrongCsv caps (untrusted input)', () => {
+  it('rejects a file above the size cap', () => {
+    const big = 'a'.repeat(STRONG_CSV_MAX_BYTES + 1);
+    const res = parseStrongCsv(big);
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toMatch(/too large/i);
+  });
+
+  it('rejects a file above the row cap', () => {
+    // Tiny rows so the row cap fires before the size cap.
+    const lines = new Array(STRONG_CSV_MAX_ROWS + 1).fill('x');
+    const res = parseStrongCsv(csv(...lines));
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toMatch(/too many rows/i);
+  });
+
+  it('never evaluates content: a formula-looking cell is just a bad row', () => {
+    const res = parseStrongCsv(
+      csv('2026-05-02,Push,=cmd|calc,1,80,8,0,0'),
+    );
+    // The exercise name is kept as an inert string, never interpreted.
+    expect(res.rows[0]?.exerciseName).toBe('=cmd|calc');
+  });
+});

--- a/lib/import/strong-csv.ts
+++ b/lib/import/strong-csv.ts
@@ -1,0 +1,308 @@
+import { z } from 'zod';
+import type { WeightUnit } from '@prisma/client';
+import { lbToKg, roundWeight } from '@/lib/units';
+
+// ============================================================
+// Strong app CSV export parser (issue #100) - pure, no DB
+// ============================================================
+// CSV text in, normalized rows out. The file content is UNTRUSTED user data:
+// no eval, hard size and row caps, and every value Zod-validated before it is
+// allowed out of this module. Bad lines are collected as per-line errors
+// instead of failing the whole file; only an unrecognized header or a blown
+// cap is fatal.
+
+// Hard caps on the untrusted input.
+export const STRONG_CSV_MAX_BYTES = 5 * 1024 * 1024; // 5 MB of text
+export const STRONG_CSV_MAX_ROWS = 50000; // data rows, header excluded
+
+// One normalized working-set row. Weight is in kg, like everything stored.
+export interface StrongCsvRow {
+  // The session day, as 'YYYY-MM-DD' (Strong's export has no reliable times).
+  dateKey: string;
+  workoutName: string;
+  exerciseName: string;
+  setOrder: number;
+  weightKg: number;
+  reps: number;
+}
+
+export interface StrongCsvLineError {
+  // 1-based line number in the file (header is line 1).
+  line: number;
+  reason: string;
+}
+
+export interface StrongCsvParseResult {
+  // False when the file as a whole is unusable (bad header, cap exceeded).
+  ok: boolean;
+  fatalError: string | null;
+  rows: StrongCsvRow[];
+  errors: StrongCsvLineError[];
+  // Duration/distance-only rows (cardio) skipped with a counted notice.
+  cardioSkipped: number;
+}
+
+// Bounds mirror lib/schemas/set.ts so imported sets satisfy the same contract
+// as manually logged ones.
+const rowSchema = z.object({
+  dateKey: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  workoutName: z.string().trim().min(1).max(200),
+  exerciseName: z.string().trim().min(1).max(120),
+  setOrder: z.coerce.number().int().min(1).max(50),
+  weightKg: z.coerce.number().min(0).max(500),
+  reps: z.coerce.number().int().min(1).max(100),
+});
+
+// ------------------------------------------------------------
+// Minimal RFC4180-style CSV reader (quoted fields, "" escapes, quoted
+// newlines, CRLF). Returns one string[] per record plus the 1-based line
+// number the record starts on. No regex backtracking, single pass.
+// ------------------------------------------------------------
+function readCsvRecords(text: string): Array<{ line: number; fields: string[] }> {
+  const records: Array<{ line: number; fields: string[] }> = [];
+  let fields: string[] = [];
+  let field = '';
+  let inQuotes = false;
+  let line = 1;
+  let recordStartLine = 1;
+  let recordHasContent = false;
+
+  const pushField = () => {
+    fields.push(field);
+    field = '';
+  };
+  const pushRecord = () => {
+    pushField();
+    // Skip records that are entirely empty (blank lines).
+    if (recordHasContent || fields.length > 1 || (fields[0] ?? '') !== '') {
+      records.push({ line: recordStartLine, fields });
+    }
+    fields = [];
+    recordHasContent = false;
+    recordStartLine = line;
+  };
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]!;
+    if (inQuotes) {
+      if (ch === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        if (ch === '\n') line++;
+        field += ch;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inQuotes = true;
+      recordHasContent = true;
+    } else if (ch === ',') {
+      pushField();
+      recordHasContent = true;
+    } else if (ch === '\n') {
+      line++;
+      pushRecord();
+    } else if (ch === '\r') {
+      // Swallow; the following \n (if any) ends the record.
+      if (text[i + 1] !== '\n') {
+        line++;
+        pushRecord();
+      }
+    } else {
+      field += ch;
+      recordHasContent = true;
+    }
+  }
+  // Final record without a trailing newline.
+  if (recordHasContent || field !== '' || fields.length > 0) pushRecord();
+  return records;
+}
+
+// Normalize a header cell for matching: lowercase, trimmed, collapsed spaces.
+function headerKey(cell: string): string {
+  return cell.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+interface HeaderMap {
+  date: number;
+  workoutName: number;
+  exerciseName: number;
+  setOrder: number;
+  weight: number;
+  reps: number;
+  distance: number | null;
+  seconds: number | null;
+  // Unit forced by the header itself ("Weight (kg)" / "Weight (lbs)"), if any.
+  forcedUnit: WeightUnit | null;
+}
+
+// Recognize Strong's export header (with minor variants: extra columns are
+// fine, order does not matter, a unit suffix on Weight is honored).
+function mapHeader(cells: string[]): HeaderMap | null {
+  const keys = cells.map(headerKey);
+  const find = (...names: string[]) => {
+    for (const name of names) {
+      const idx = keys.indexOf(name);
+      if (idx !== -1) return idx;
+    }
+    return -1;
+  };
+
+  const date = find('date');
+  const workoutName = find('workout name');
+  const exerciseName = find('exercise name');
+  const setOrder = find('set order');
+  const reps = find('reps');
+  let forcedUnit: WeightUnit | null = null;
+  let weight = find('weight');
+  if (weight === -1) {
+    weight = find('weight (kg)');
+    if (weight !== -1) forcedUnit = 'KG';
+  }
+  if (weight === -1) {
+    weight = find('weight (lbs)', 'weight (lb)');
+    if (weight !== -1) forcedUnit = 'LB';
+  }
+
+  if (
+    date === -1 ||
+    workoutName === -1 ||
+    exerciseName === -1 ||
+    setOrder === -1 ||
+    weight === -1 ||
+    reps === -1
+  ) {
+    return null;
+  }
+  const distance = find('distance');
+  const seconds = find('seconds', 'duration (sec)');
+  return {
+    date,
+    workoutName,
+    exerciseName,
+    setOrder,
+    weight,
+    reps,
+    distance: distance === -1 ? null : distance,
+    seconds: seconds === -1 ? null : seconds,
+    forcedUnit,
+  };
+}
+
+// 'YYYY-MM-DD' day key from Strong's date cell ('YYYY-MM-DD HH:MM:SS' or just
+// the date). Returns null when the cell is not a real calendar date.
+function toDateKey(cell: string): string | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})([ T].*)?$/.exec(cell.trim());
+  if (!m) return null;
+  const [, y, mo, d] = m;
+  const date = new Date(Date.UTC(Number(y), Number(mo) - 1, Number(d)));
+  if (
+    date.getUTCFullYear() !== Number(y) ||
+    date.getUTCMonth() !== Number(mo) - 1 ||
+    date.getUTCDate() !== Number(d)
+  ) {
+    return null;
+  }
+  return `${y}-${mo}-${d}`;
+}
+
+function asNumber(cell: string | undefined): number {
+  if (cell === undefined) return 0;
+  const trimmed = cell.trim();
+  if (trimmed === '') return 0;
+  const n = Number(trimmed);
+  return Number.isFinite(n) ? n : NaN;
+}
+
+// Parse a Strong CSV export. `unit` is the unit the Strong app was set to
+// (user-chosen toggle, default kg); a unit suffix in the header overrides it.
+export function parseStrongCsv(
+  text: string,
+  unit: WeightUnit = 'KG',
+): StrongCsvParseResult {
+  const fail = (fatalError: string): StrongCsvParseResult => ({
+    ok: false,
+    fatalError,
+    rows: [],
+    errors: [],
+    cardioSkipped: 0,
+  });
+
+  if (text.length > STRONG_CSV_MAX_BYTES) {
+    return fail('File too large: the limit is 5 MB.');
+  }
+
+  const records = readCsvRecords(text);
+  const header = records[0];
+  if (!header) return fail('Empty file.');
+  const map = mapHeader(header.fields);
+  if (!map) {
+    return fail(
+      'Unrecognized format: expected a Strong CSV export with the columns ' +
+        'Date, Workout Name, Exercise Name, Set Order, Weight, Reps.',
+    );
+  }
+
+  const dataRecords = records.slice(1);
+  if (dataRecords.length > STRONG_CSV_MAX_ROWS) {
+    return fail(
+      `Too many rows: ${dataRecords.length} (the limit is ${STRONG_CSV_MAX_ROWS}). Split the export and import in parts.`,
+    );
+  }
+
+  const effectiveUnit = map.forcedUnit ?? unit;
+  const rows: StrongCsvRow[] = [];
+  const errors: StrongCsvLineError[] = [];
+  let cardioSkipped = 0;
+
+  for (const record of dataRecords) {
+    const get = (idx: number | null) =>
+      idx === null ? undefined : record.fields[idx];
+
+    const dateKey = toDateKey(get(map.date) ?? '');
+    if (!dateKey) {
+      errors.push({ line: record.line, reason: 'Invalid or missing date.' });
+      continue;
+    }
+
+    const reps = asNumber(get(map.reps));
+    const weightRaw = asNumber(get(map.weight));
+    const distance = asNumber(get(map.distance));
+    const seconds = asNumber(get(map.seconds));
+
+    // Cardio / duration-only rows (no reps, but distance or time): skipped
+    // with a counted notice rather than reported as errors.
+    if (!(reps >= 1) && (distance > 0 || seconds > 0)) {
+      cardioSkipped++;
+      continue;
+    }
+
+    const weightKg =
+      effectiveUnit === 'LB' ? roundWeight(lbToKg(weightRaw), 2) : weightRaw;
+
+    const parsed = rowSchema.safeParse({
+      dateKey,
+      workoutName: get(map.workoutName) ?? '',
+      exerciseName: get(map.exerciseName) ?? '',
+      setOrder: get(map.setOrder),
+      weightKg,
+      reps,
+    });
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0];
+      errors.push({
+        line: record.line,
+        reason: issue ? `${issue.path.join('.')}: ${issue.message}` : 'Invalid row.',
+      });
+      continue;
+    }
+    rows.push(parsed.data);
+  }
+
+  return { ok: true, fatalError: null, rows, errors, cardioSkipped };
+}

--- a/lib/import/strong-import.test.ts
+++ b/lib/import/strong-import.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildStrongImportPlan,
+  sessionDateFromKey,
+  setDuplicateKey,
+} from './strong-import';
+import type { StrongCsvRow } from './strong-csv';
+
+function row(over: Partial<StrongCsvRow> = {}): StrongCsvRow {
+  return {
+    dateKey: '2026-05-02',
+    workoutName: 'Push',
+    exerciseName: 'Bench',
+    setOrder: 1,
+    weightKg: 80,
+    reps: 8,
+    ...over,
+  };
+}
+
+describe('buildStrongImportPlan', () => {
+  it('groups rows by (date, workout name) into sessions', () => {
+    const plan = buildStrongImportPlan(
+      [
+        row({ setOrder: 1 }),
+        row({ setOrder: 2 }),
+        row({ dateKey: '2026-05-03', workoutName: 'Pull', exerciseName: 'Row' }),
+        row({ dateKey: '2026-05-02', workoutName: 'Evening', exerciseName: 'Curl' }),
+      ],
+      [],
+      new Set(),
+    );
+    expect(plan.sessions.map((s) => `${s.dateKey}|${s.workoutName}`)).toEqual([
+      '2026-05-02|Push',
+      '2026-05-02|Evening',
+      '2026-05-03|Pull',
+    ]);
+    expect(plan.totalSets).toBe(4);
+  });
+
+  it('matches existing exercises case-insensitively and lists only missing ones', () => {
+    const plan = buildStrongImportPlan(
+      [row({ exerciseName: 'bench' }), row({ exerciseName: 'New Lift', setOrder: 2 })],
+      ['Bench'],
+      new Set(),
+    );
+    expect(plan.newExerciseNames).toEqual(['New Lift']);
+  });
+
+  it('deduplicates new exercise names case-insensitively within the file', () => {
+    const plan = buildStrongImportPlan(
+      [
+        row({ exerciseName: 'New Lift', setOrder: 1 }),
+        row({ exerciseName: 'new lift', setOrder: 2 }),
+      ],
+      [],
+      new Set(),
+    );
+    expect(plan.newExerciseNames).toEqual(['New Lift']);
+  });
+
+  it('skips exact duplicates of existing sets and counts them', () => {
+    const existing = new Set([setDuplicateKey('2026-05-02', 'Bench', 1, 80, 8)]);
+    const plan = buildStrongImportPlan(
+      [row({ setOrder: 1 }), row({ setOrder: 2 })],
+      ['Bench'],
+      existing,
+    );
+    expect(plan.duplicateCount).toBe(1);
+    expect(plan.totalSets).toBe(1);
+    expect(plan.sessions[0]?.sets.map((s) => s.setOrder)).toEqual([2]);
+  });
+
+  it('skips exact duplicate rows within the file itself', () => {
+    const plan = buildStrongImportPlan([row(), row()], [], new Set());
+    expect(plan.duplicateCount).toBe(1);
+    expect(plan.totalSets).toBe(1);
+  });
+
+  it('creates no session when every set of it is a duplicate', () => {
+    const existing = new Set([setDuplicateKey('2026-05-02', 'Bench', 1, 80, 8)]);
+    const plan = buildStrongImportPlan([row()], ['Bench'], existing);
+    expect(plan.sessions).toEqual([]);
+    expect(plan.totalSets).toBe(0);
+  });
+});
+
+describe('sessionDateFromKey', () => {
+  it('pins the session to noon UTC of its day', () => {
+    expect(sessionDateFromKey('2026-05-02').toISOString()).toBe(
+      '2026-05-02T12:00:00.000Z',
+    );
+  });
+});

--- a/lib/import/strong-import.ts
+++ b/lib/import/strong-import.ts
@@ -1,0 +1,195 @@
+import type { Prisma, PrismaClient } from '@prisma/client';
+import type { StrongCsvRow } from '@/lib/import/strong-csv';
+
+// ============================================================
+// Strong import planning + execution (issue #100)
+// ============================================================
+// buildStrongImportPlan is pure: it groups parsed rows into sessions, matches
+// exercises case-insensitively against the user's catalog, and skips exact
+// duplicates. executeStrongImport performs the writes through the transaction
+// client it is given, so the route can wrap one import in one transaction and
+// a failure rolls everything back.
+
+export interface PlannedSet {
+  exerciseName: string;
+  setOrder: number;
+  weightKg: number;
+  reps: number;
+}
+
+export interface PlannedSession {
+  dateKey: string; // YYYY-MM-DD
+  workoutName: string;
+  sets: PlannedSet[];
+}
+
+export interface StrongImportPlan {
+  sessions: PlannedSession[];
+  // New exercise names to create (original casing of first occurrence),
+  // sorted.
+  newExerciseNames: string[];
+  totalSets: number;
+  // Exact duplicates (same day, exercise, set order, weight, reps as an
+  // existing set or an earlier row of this file), skipped.
+  duplicateCount: number;
+}
+
+// Key for exact-duplicate detection.
+export function setDuplicateKey(
+  dateKey: string,
+  exerciseName: string,
+  setOrder: number,
+  weightKg: number,
+  reps: number,
+): string {
+  return `${dateKey}|${exerciseName.trim().toLowerCase()}|${setOrder}|${weightKg}|${reps}`;
+}
+
+export function buildStrongImportPlan(
+  rows: StrongCsvRow[],
+  existingExerciseNames: string[],
+  existingSetKeys: ReadonlySet<string>,
+): StrongImportPlan {
+  const known = new Set(existingExerciseNames.map((n) => n.trim().toLowerCase()));
+  const newByLower = new Map<string, string>();
+  const sessionsByKey = new Map<string, PlannedSession>();
+  const seenKeys = new Set<string>(existingSetKeys);
+  let totalSets = 0;
+  let duplicateCount = 0;
+
+  for (const row of rows) {
+    const dupKey = setDuplicateKey(
+      row.dateKey,
+      row.exerciseName,
+      row.setOrder,
+      row.weightKg,
+      row.reps,
+    );
+    if (seenKeys.has(dupKey)) {
+      duplicateCount++;
+      continue;
+    }
+    seenKeys.add(dupKey);
+
+    const lower = row.exerciseName.trim().toLowerCase();
+    if (!known.has(lower) && !newByLower.has(lower)) {
+      newByLower.set(lower, row.exerciseName.trim());
+    }
+
+    const sessionKey = `${row.dateKey}|${row.workoutName}`;
+    let session = sessionsByKey.get(sessionKey);
+    if (!session) {
+      session = { dateKey: row.dateKey, workoutName: row.workoutName, sets: [] };
+      sessionsByKey.set(sessionKey, session);
+    }
+    session.sets.push({
+      exerciseName: row.exerciseName,
+      setOrder: row.setOrder,
+      weightKg: row.weightKg,
+      reps: row.reps,
+    });
+    totalSets++;
+  }
+
+  const sessions = [...sessionsByKey.values()].sort((a, b) =>
+    a.dateKey.localeCompare(b.dateKey),
+  );
+  for (const s of sessions) {
+    s.sets.sort(
+      (a, b) =>
+        a.exerciseName.localeCompare(b.exerciseName) || a.setOrder - b.setOrder,
+    );
+  }
+
+  return {
+    sessions,
+    newExerciseNames: [...newByLower.values()].sort((a, b) => a.localeCompare(b)),
+    totalSets,
+    duplicateCount,
+  };
+}
+
+// Honest default: Strong's export has no start/end times, so the session is
+// pinned to noon UTC of its day.
+export function sessionDateFromKey(dateKey: string): Date {
+  return new Date(`${dateKey}T12:00:00.000Z`);
+}
+
+export interface StrongImportResult {
+  createdSessions: number;
+  createdSets: number;
+  createdExercises: number;
+}
+
+type Db = PrismaClient | Prisma.TransactionClient;
+
+// Performs the writes for a plan through the given client. Call it inside
+// db.$transaction so a mid-import failure rolls back every row.
+export async function executeStrongImport(
+  tx: Db,
+  userId: string,
+  plan: StrongImportPlan,
+): Promise<StrongImportResult> {
+  // Resolve the user's exercises case-insensitively, creating the missing
+  // ones (OTHER / ISOLATION; the user can re-categorize later).
+  const existing = await tx.exercise.findMany({
+    where: { userId },
+    select: { id: true, name: true },
+  });
+  const idByLower = new Map(existing.map((e) => [e.name.trim().toLowerCase(), e.id]));
+
+  let createdExercises = 0;
+  for (const name of plan.newExerciseNames) {
+    const lower = name.trim().toLowerCase();
+    if (idByLower.has(lower)) continue;
+    const created = await tx.exercise.create({
+      data: {
+        userId,
+        name,
+        muscleGroup: 'OTHER',
+        category: 'ISOLATION',
+        notes: 'Imported from Strong. Adjust the muscle group and category.',
+      },
+    });
+    idByLower.set(lower, created.id);
+    createdExercises++;
+  }
+
+  let createdSessions = 0;
+  let createdSets = 0;
+  for (const session of plan.sessions) {
+    if (session.sets.length === 0) continue;
+    const startedAt = sessionDateFromKey(session.dateKey);
+    const created = await tx.session.create({
+      data: {
+        userId,
+        startedAt,
+        finishedAt: startedAt,
+        notes: `Imported from Strong - ${session.workoutName}`,
+      },
+    });
+    createdSessions++;
+
+    await tx.set.createMany({
+      data: session.sets.map((s) => {
+        const exerciseId = idByLower.get(s.exerciseName.trim().toLowerCase());
+        if (!exerciseId) {
+          // Cannot happen for a plan built by buildStrongImportPlan; guards
+          // against a malformed plan reaching the DB.
+          throw new Error(`Unresolved exercise: ${s.exerciseName}`);
+        }
+        return {
+          sessionId: created.id,
+          exerciseId,
+          setNumber: s.setOrder,
+          weight: s.weightKg,
+          reps: s.reps,
+          completedAt: startedAt,
+        };
+      }),
+    });
+    createdSets += session.sets.length;
+  }
+
+  return { createdSessions, createdSets, createdExercises };
+}

--- a/lib/schemas/exercise.ts
+++ b/lib/schemas/exercise.ts
@@ -36,6 +36,7 @@ export const MUSCLE_GROUP_LABELS: Record<MuscleGroup, string> = {
   CALVES: 'Calves',
   ABS: 'Abs',
   LOWER_BACK: 'Lower back',
+  OTHER: 'Other',
 };
 
 export const CATEGORY_LABELS: Record<ExerciseCategory, string> = {

--- a/lib/schemas/import.test.ts
+++ b/lib/schemas/import.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { strongImportInputSchema } from './import';
+import { STRONG_CSV_MAX_BYTES } from '@/lib/import/strong-csv';
+
+describe('strongImportInputSchema', () => {
+  it('accepts a csv with a mode and defaults the unit to KG', () => {
+    const parsed = strongImportInputSchema.parse({ csv: 'a,b', mode: 'preview' });
+    expect(parsed.unit).toBe('KG');
+    expect(parsed.mode).toBe('preview');
+  });
+
+  it('accepts the LB unit and the confirm mode', () => {
+    const parsed = strongImportInputSchema.parse({
+      csv: 'a,b',
+      unit: 'LB',
+      mode: 'confirm',
+    });
+    expect(parsed.unit).toBe('LB');
+    expect(parsed.mode).toBe('confirm');
+  });
+
+  it('rejects a missing or empty csv', () => {
+    expect(strongImportInputSchema.safeParse({ mode: 'preview' }).success).toBe(false);
+    expect(
+      strongImportInputSchema.safeParse({ csv: '', mode: 'preview' }).success,
+    ).toBe(false);
+  });
+
+  it('rejects an oversized csv (5 MB cap)', () => {
+    const res = strongImportInputSchema.safeParse({
+      csv: 'a'.repeat(STRONG_CSV_MAX_BYTES + 1),
+      mode: 'preview',
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it('rejects an unknown mode or unit', () => {
+    expect(
+      strongImportInputSchema.safeParse({ csv: 'a', mode: 'apply' }).success,
+    ).toBe(false);
+    expect(
+      strongImportInputSchema.safeParse({ csv: 'a', unit: 'ST', mode: 'preview' }).success,
+    ).toBe(false);
+  });
+});

--- a/lib/schemas/import.ts
+++ b/lib/schemas/import.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+import { STRONG_CSV_MAX_BYTES } from '@/lib/import/strong-csv';
+
+// Strong CSV import request (issue #100). The csv field carries the raw file
+// text (untrusted): the size cap is enforced here AND on the content-length
+// before parsing. `unit` is the unit the Strong app was set to when exporting
+// (a unit suffix in the CSV header overrides it); `mode` separates the
+// read-only dry-run preview from the transactional confirm.
+export const strongImportInputSchema = z.object({
+  csv: z.string().min(1).max(STRONG_CSV_MAX_BYTES, 'File too large: the limit is 5 MB.'),
+  unit: z.enum(['KG', 'LB']).default('KG'),
+  mode: z.enum(['preview', 'confirm']),
+});
+
+export type StrongImportInput = z.infer<typeof strongImportInputSchema>;

--- a/prisma/migrations/20260610150000_add_muscle_group_other/migration.sql
+++ b/prisma/migrations/20260610150000_add_muscle_group_other/migration.sql
@@ -1,0 +1,6 @@
+-- Additive migration (issue #100): an OTHER fallback muscle group for
+-- imported exercises that cannot be auto-classified. Enum value only, no
+-- table or data change.
+
+-- AlterEnum
+ALTER TYPE "MuscleGroup" ADD VALUE 'OTHER';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -123,6 +123,9 @@ enum MuscleGroup {
   CALVES
   ABS
   LOWER_BACK
+  // Fallback bucket for imported exercises that could not be classified
+  // (issue #100). The user can re-categorize them afterwards.
+  OTHER
 }
 
 enum ExerciseCategory {

--- a/tests/e2e/import.spec.ts
+++ b/tests/e2e/import.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+// Strong CSV import (issue #100): upload an export in settings, check the
+// dry-run preview, confirm, and find the imported session in the history.
+
+const STRONG_CSV = [
+  'Date,Workout Name,Exercise Name,Set Order,Weight,Reps,Distance,Seconds',
+  '2026-05-02 09:00:00,Push Day,Bench Press,1,80,8,0,0',
+  '2026-05-02 09:00:00,Push Day,Bench Press,2,80,7,0,0',
+  'broken-line,Push Day,Bench Press,3,80,6,0,0',
+].join('\n');
+
+test('a lifter can preview and confirm a Strong CSV import', async ({ page }) => {
+  // Sign up (fresh user each run).
+  await page.goto('/signup');
+  await page.getByLabel('Name').fill('Import E2E');
+  await page.getByLabel('Email').fill(`e2e-import-${Date.now()}@test.dev`);
+  await page.getByLabel('Password').fill('supersecret');
+  await page.getByRole('button', { name: 'Create account' }).click();
+  await expect(page).toHaveURL('/');
+
+  await page.goto('/settings');
+  await expect(page.getByText('Import from Strong')).toBeVisible();
+
+  // Upload the file: the dry-run preview appears, nothing imported yet.
+  await page
+    .locator('input[type="file"][accept=".csv,text/csv"]')
+    .setInputFiles({
+      name: 'strong.csv',
+      mimeType: 'text/csv',
+      buffer: Buffer.from(STRONG_CSV, 'utf-8'),
+    });
+
+  const preview = page.getByTestId('import-preview');
+  await expect(preview).toBeVisible();
+  await expect(preview).toContainText('1 session, 2 sets to import');
+  await expect(preview).toContainText('1 new exercise will be created: Bench Press');
+  await expect(preview).toContainText('Line 4');
+
+  // Confirm and find the imported session in the history.
+  await page.getByRole('button', { name: /confirm import/i }).click();
+  await expect(page.getByTestId('import-preview')).not.toBeVisible();
+
+  await page.goto('/history');
+  await expect(page.getByText('May 02, 2026')).toBeVisible();
+  await expect(page.getByText('2 sets')).toBeVisible();
+});

--- a/tests/integration/import-route.test.ts
+++ b/tests/integration/import-route.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { db } from '@/lib/db';
+import { getCurrentUserId } from '@/lib/auth';
+import {
+  buildStrongImportPlan,
+  executeStrongImport,
+} from '@/lib/import/strong-import';
+
+vi.mock('@/lib/auth', () => ({ getCurrentUserId: vi.fn() }));
+const mockUserId = vi.mocked(getCurrentUserId);
+
+import { POST as postImport } from '@/app/api/import/strong/route';
+
+function actAs(userId: string) {
+  mockUserId.mockResolvedValue(userId);
+}
+
+function importReq(body: unknown): Request {
+  return new Request('http://test.local/api/import/strong', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+const CSV = [
+  'Date,Workout Name,Exercise Name,Set Order,Weight,Reps,Distance,Seconds',
+  '2026-05-02 09:00:00,Push Day,Bench Press,1,80,8,0,0',
+  '2026-05-02 09:00:00,Push Day,Bench Press,2,80,7,0,0',
+  '2026-05-03 18:00:00,Pull Day,Imported Row,1,70,10,0,0',
+  '2026-05-03 18:05:00,Pull Day,Running,1,0,0,5000,1800',
+].join('\n');
+
+async function seedUser(email = 'importer@test.dev') {
+  return db.user.create({ data: { email, passwordHash: 'x' } });
+}
+
+beforeEach(() => {
+  mockUserId.mockReset();
+});
+
+describe('POST /api/import/strong (preview)', () => {
+  it('returns counts and per-line info without writing anything', async () => {
+    const user = await seedUser();
+    actAs(user.id);
+
+    const res = await postImport(importReq({ csv: CSV, mode: 'preview' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      mode: 'preview',
+      sessions: 2,
+      sets: 3,
+      newExercises: ['Bench Press', 'Imported Row'],
+      duplicatesSkipped: 0,
+      cardioSkipped: 1,
+      errorCount: 0,
+    });
+
+    expect(await db.session.count()).toBe(0);
+    expect(await db.set.count()).toBe(0);
+    expect(await db.exercise.count()).toBe(0);
+  });
+
+  it('warns about dates that already have sessions', async () => {
+    const user = await seedUser();
+    await db.session.create({
+      data: { userId: user.id, startedAt: new Date('2026-05-02T07:00:00.000Z') },
+    });
+    actAs(user.id);
+
+    const body = await (
+      await postImport(importReq({ csv: CSV, mode: 'preview' }))
+    ).json();
+    expect(body.existingSessionDates).toEqual(['2026-05-02']);
+  });
+
+  it('rejects an unrecognized header with a clear message', async () => {
+    const user = await seedUser();
+    actAs(user.id);
+    const res = await postImport(
+      importReq({ csv: 'foo,bar\n1,2', mode: 'preview' }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/unrecognized format/i);
+  });
+
+  it('requires auth', async () => {
+    mockUserId.mockResolvedValue(null);
+    const res = await postImport(importReq({ csv: CSV, mode: 'preview' }));
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('POST /api/import/strong (confirm)', () => {
+  it('creates exercises, sessions and sets transactionally', async () => {
+    const user = await seedUser();
+    actAs(user.id);
+
+    const res = await postImport(importReq({ csv: CSV, mode: 'confirm' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      mode: 'confirm',
+      createdSessions: 2,
+      createdSets: 3,
+      createdExercises: 2,
+      cardioSkipped: 1,
+    });
+
+    const sessions = await db.session.findMany({
+      where: { userId: user.id },
+      orderBy: { startedAt: 'asc' },
+      include: { sets: true },
+    });
+    expect(sessions).toHaveLength(2);
+    // Honest defaults: noon UTC, finished, workout name kept in the notes.
+    expect(sessions[0]?.startedAt.toISOString()).toBe('2026-05-02T12:00:00.000Z');
+    expect(sessions[0]?.finishedAt?.toISOString()).toBe('2026-05-02T12:00:00.000Z');
+    expect(sessions[0]?.notes).toBe('Imported from Strong - Push Day');
+    expect(sessions[0]?.sets).toHaveLength(2);
+
+    const created = await db.exercise.findMany({ where: { userId: user.id } });
+    expect(created.map((e) => e.muscleGroup)).toEqual(['OTHER', 'OTHER']);
+    expect(created.map((e) => e.category)).toEqual(['ISOLATION', 'ISOLATION']);
+  });
+
+  it('matches existing exercises case-insensitively instead of duplicating them', async () => {
+    const user = await seedUser();
+    const bench = await db.exercise.create({
+      data: { userId: user.id, name: 'bench press', muscleGroup: 'CHEST', category: 'COMPOUND' },
+    });
+    actAs(user.id);
+
+    const body = await (
+      await postImport(importReq({ csv: CSV, mode: 'confirm' }))
+    ).json();
+    expect(body.createdExercises).toBe(1); // only "Imported Row"
+
+    const benchSets = await db.set.count({ where: { exerciseId: bench.id } });
+    expect(benchSets).toBe(2);
+  });
+
+  it("never matches or touches another user's exercises", async () => {
+    const user = await seedUser();
+    const other = await seedUser('other@test.dev');
+    await db.exercise.create({
+      data: { userId: other.id, name: 'Bench Press', muscleGroup: 'CHEST', category: 'COMPOUND' },
+    });
+    actAs(user.id);
+
+    await postImport(importReq({ csv: CSV, mode: 'confirm' }));
+    // The importer got their own new exercise; the stranger's data is intact.
+    expect(
+      await db.exercise.count({ where: { userId: user.id, name: 'Bench Press' } }),
+    ).toBe(1);
+    expect(await db.set.count({ where: { session: { userId: other.id } } })).toBe(0);
+  });
+
+  it('skips exact duplicates on re-import (idempotence)', async () => {
+    const user = await seedUser();
+    actAs(user.id);
+
+    await postImport(importReq({ csv: CSV, mode: 'confirm' }));
+    const res = await postImport(importReq({ csv: CSV, mode: 'confirm' }));
+    // Everything is a duplicate now: nothing to import.
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/nothing to import/i);
+
+    expect(await db.session.count({ where: { userId: user.id } })).toBe(2);
+    expect(await db.set.count({ where: { session: { userId: user.id } } })).toBe(3);
+  });
+
+  it('rejects invalid input (Zod) and writes nothing', async () => {
+    const user = await seedUser();
+    actAs(user.id);
+    const res = await postImport(importReq({ csv: CSV, mode: 'apply' }));
+    expect(res.status).toBe(400);
+    expect(await db.session.count()).toBe(0);
+  });
+});
+
+describe('transaction rollback', () => {
+  it('persists nothing when the transaction fails after the import writes', async () => {
+    const user = await seedUser();
+    const plan = buildStrongImportPlan(
+      [
+        {
+          dateKey: '2026-05-02',
+          workoutName: 'Push',
+          exerciseName: 'Bench',
+          setOrder: 1,
+          weightKg: 80,
+          reps: 8,
+        },
+      ],
+      [],
+      new Set(),
+    );
+
+    await expect(
+      db.$transaction(async (tx) => {
+        const result = await executeStrongImport(tx, user.id, plan);
+        expect(result.createdSets).toBe(1);
+        // Induced failure AFTER all writes: if any write escaped the
+        // transaction client, the assertions below would catch it.
+        throw new Error('induced failure');
+      }),
+    ).rejects.toThrow('induced failure');
+
+    expect(await db.exercise.count({ where: { userId: user.id } })).toBe(0);
+    expect(await db.session.count({ where: { userId: user.id } })).toBe(0);
+    expect(await db.set.count()).toBe(0);
+  });
+});


### PR DESCRIPTION
Implements issue #100, scoped to Strong's CSV format only. Security posture: the uploaded file content is untrusted data end to end.

- Pure parser lib/import/strong-csv.ts: quote-aware RFC4180-style reader (handles quoted commas, escaped quotes, quoted newlines, CRLF), recognized-header gate with a clear rejection message, 5 MB size cap and 50000-row cap, per-line error collection (line number + reason) instead of first-error abort, cardio/duration-only rows skipped with a count, kg/lb unit toggle with a Weight (kg)/(lbs) header-suffix override, and Zod validation of every row with the same bounds as the set schema. No eval, no dynamic interpretation of any cell.
- Planner + executor lib/import/strong-import.ts: groups rows into one finished session per (date, workout name) at noon UTC (honest default, Strong exports carry no reliable times; the workout name is kept in the session notes), matches exercises case-insensitively against the user's catalog, creates missing ones as OTHER/ISOLATION (new additive enum value + migration), and skips exact duplicates (same day, exercise, set order, weight, reps) for idempotent re-imports. All writes go through the transaction client: one transaction per import, rollback on any failure.
- Route POST /api/import/strong: Zod-validated (lib/schemas/import.ts), ownership-scoped, rate-limited (10/min/user), content-length guard before reading the body, mode=preview is a pure dry run (counts, new exercises, duplicate/cardio notices, capped error list, already-trained-that-day warning), mode=confirm performs the transactional import.
- Settings UI: file picker + Strong-unit toggle -> dry-run preview with the error list -> explicit Confirm button.

Closes #100

## How I tested

- bash scripts/verify.sh --full PASSED locally (lint, typecheck, unit, build, integration on :5434, Playwright E2E).
- Migration validated against the test Postgres: prisma migrate deploy applies cleanly, prisma migrate diff reports no difference.
- Parser unit tests: happy path, quoted/escaped fields, column-order and extra-column variants, lb conversion and header-suffix override, malformed lines with exact line numbers, cardio skip, both caps, formula-like cells stay inert strings.
- Planner unit tests: grouping, case-insensitive matching, in-file and against-DB duplicate skip, all-duplicate session elision.
- Integration tests: preview writes nothing, confirm creates exercises/sessions/sets with the documented defaults, case-insensitive match to the user's own catalog only (no cross-user touch), idempotent re-import (400 "nothing to import", counts unchanged), unrecognized header 400, auth 401, and a transaction-rollback test proving no write escapes the transaction client.
- Component tests: preview before import, confirm only on the explicit button, client-side size cap, server rejection surfaced.
- E2E: sign up -> settings -> upload a fixture with one broken line -> preview shows counts + the line error -> confirm -> history shows the imported session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)