### PR TITLE
fix: serialize bodyweight sync on the user row and align validation bounds

### DIFF
--- a/app/api/bodyweight/[id]/route.ts
+++ b/app/api/bodyweight/[id]/route.ts
@@ -21,10 +21,13 @@ export async function DELETE(_req: Request, { params }: Params) {
     }
 
     await db.$transaction(async (tx) => {
+      // Lock the user row first so the re-sync serializes with concurrent
+      // bodyweight mutations (issue #107), matching the POST route.
+      await tx.$queryRaw`SELECT id FROM "User" WHERE id = ${userId} FOR UPDATE`;
       await tx.bodyweightEntry.delete({ where: { id: params.id } });
       const remaining = await tx.bodyweightEntry.findMany({
         where: { userId },
-        orderBy: { measuredAt: 'asc' },
+        orderBy: [{ measuredAt: 'asc' }, { id: 'asc' }],
         select: { weightKg: true, measuredAt: true },
       });
       const current = currentBodyweightFromEntries(remaining);

--- a/app/api/bodyweight/route.ts
+++ b/app/api/bodyweight/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { bodyweightEntryInputSchema } from '@/lib/schemas/bodyweight';
 import { handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
+import { currentBodyweightFromEntries } from '@/lib/bodyweight';
 
 // GET /api/bodyweight: the user's bodyweight history, newest first.
 export async function GET() {
@@ -17,22 +18,34 @@ export async function GET() {
   }
 }
 
-// POST /api/bodyweight: log a measurement. The new entry is stamped "now", so
-// it is the newest by construction and User.bodyweight (the current value the
-// rest of the app reads) syncs to it in the same transaction.
+// POST /api/bodyweight: log a measurement. User.bodyweight (the current value
+// the rest of the app reads) re-syncs to the newest entry in the same
+// transaction. The user row is locked first so concurrent mutations
+// serialize: "stamped now, so newest by construction" does not hold at
+// ReadCommitted, where the commit order on the user row can disagree with the
+// measuredAt order (issue #107).
 export async function POST(req: Request) {
   try {
     const userId = await requireApiUserId();
     const data = await parseJsonBody(req, bodyweightEntryInputSchema);
 
     const entry = await db.$transaction(async (tx) => {
+      await tx.$queryRaw`SELECT id FROM "User" WHERE id = ${userId} FOR UPDATE`;
       const created = await tx.bodyweightEntry.create({
         data: { userId, weightKg: data.weightKg, note: data.note ?? null },
       });
-      await tx.user.update({
-        where: { id: userId },
-        data: { bodyweight: data.weightKg },
+      const entries = await tx.bodyweightEntry.findMany({
+        where: { userId },
+        orderBy: [{ measuredAt: 'asc' }, { id: 'asc' }],
+        select: { weightKg: true, measuredAt: true },
       });
+      const current = currentBodyweightFromEntries(entries);
+      if (current !== null) {
+        await tx.user.update({
+          where: { id: userId },
+          data: { bodyweight: current },
+        });
+      }
       return created;
     });
     return NextResponse.json(entry, { status: 201 });

--- a/lib/bodyweight.ts
+++ b/lib/bodyweight.ts
@@ -11,8 +11,9 @@ export interface BodyweightEntryLike {
 }
 
 // The weight of the most recent entry, or null when there is none. Ties on
-// measuredAt resolve to the later element in the array, which matches a
-// "newest first then created order" listing where the latest write wins.
+// measuredAt resolve to the later element in the array; the routes order
+// their queries by (measuredAt asc, id asc), so a tie deterministically goes
+// to the highest id, i.e. the latest insert (issue #107).
 export function currentBodyweightFromEntries(
   entries: BodyweightEntryLike[],
 ): number | null {

--- a/lib/schemas/bodyweight.test.ts
+++ b/lib/schemas/bodyweight.test.ts
@@ -20,12 +20,17 @@ describe('bodyweightEntryInputSchema', () => {
     expect(bodyweightEntryInputSchema.parse({ weightKg: '75.5' }).weightKg).toBe(75.5);
   });
 
-  it.each([0, -5, 501, 'abc', null, undefined])(
+  it.each([0, -5, 19.9, 301, 'abc', null, undefined])(
     'rejects invalid weight %p',
     (weightKg) => {
       expect(bodyweightEntryInputSchema.safeParse({ weightKg }).success).toBe(false);
     },
   );
+
+  it('accepts the profile-route bounds (20-300 kg)', () => {
+    expect(bodyweightEntryInputSchema.safeParse({ weightKg: 20 }).success).toBe(true);
+    expect(bodyweightEntryInputSchema.safeParse({ weightKg: 300 }).success).toBe(true);
+  });
 
   it('rejects an oversized note', () => {
     const res = bodyweightEntryInputSchema.safeParse({

--- a/lib/schemas/bodyweight.ts
+++ b/lib/schemas/bodyweight.ts
@@ -1,10 +1,12 @@
 import { z } from 'zod';
 
 // Bodyweight entry input (issue #99). The weight arrives in kg (the client
-// converts from the display unit before posting, like the set form). 500 kg
-// mirrors the set schema's ceiling; nobody weighs more.
+// converts from the display unit before posting, like the set form). The
+// bounds match the profile route's bodyweight field (20-300 kg): an entry
+// syncs into User.bodyweight, so it must never accept a value the profile
+// would reject (issue #107).
 export const bodyweightEntryInputSchema = z.object({
-  weightKg: z.coerce.number().positive().max(500),
+  weightKg: z.coerce.number().min(20).max(300),
   note: z.string().max(500).optional(),
 });
 

--- a/tests/integration/bodyweight-route.test.ts
+++ b/tests/integration/bodyweight-route.test.ts
@@ -96,6 +96,26 @@ describe('GET /api/bodyweight', () => {
   });
 });
 
+describe('POST re-derivation (issue #107)', () => {
+  it('does not clobber User.bodyweight when an existing entry is measured later', async () => {
+    const { a } = await seed();
+    actAs(a.id);
+    // An entry dated in the future relative to the POST stamp - the stand-in
+    // for the race where a concurrent transaction with a later measuredAt
+    // commits first. The POST must re-derive, not assume it is the newest.
+    await db.bodyweightEntry.create({
+      data: { userId: a.id, weightKg: 90, measuredAt: new Date('2099-01-01T08:00:00Z') },
+    });
+    await db.user.update({ where: { id: a.id }, data: { bodyweight: 90 } });
+
+    const res = await postEntry(jsonReq('POST', { weightKg: 82 }));
+    expect(res.status).toBe(201);
+    const user = await db.user.findUnique({ where: { id: a.id } });
+    expect(user?.bodyweight).toBe(90);
+    expect(await db.bodyweightEntry.count({ where: { userId: a.id } })).toBe(2);
+  });
+});
+
 describe('DELETE /api/bodyweight/[id]', () => {
   it('re-syncs User.bodyweight to the newest remaining entry when the newest is deleted', async () => {
     const { a } = await seed();


### PR DESCRIPTION
Closes #107 (the REAL finding + two ride-along NITs from the independent post-merge review of PR #103).

- Race window: both bodyweight mutations now take a SELECT ... FOR UPDATE on the user row at the top of their transaction and re-derive User.bodyweight from the entries (POST previously wrote its own value on the assumption it was newest, which ReadCommitted does not guarantee under concurrency). New integration test pins the re-derivation: a POST no longer clobbers the profile value when an existing entry is measured later.
- Deterministic tie-break: newest-entry queries order by (measuredAt asc, id asc).
- Bounds: entry weight aligned to the profile route's 20-300 kg so the sync can never write a value the profile would reject; schema tests updated for both boundaries.

## How I tested

- bash scripts/verify.sh --full - GREEN-GATE PASSED (unit, integration incl. the new re-derivation test, build, E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)