### PR TITLE
feat: start a deload week in one tap from the deload recommendation

### DIFF
--- a/app/(app)/progress/page.tsx
+++ b/app/(app)/progress/page.tsx
@@ -19,6 +19,7 @@ import {
 import {
   DELOAD_READINESS_LOOKBACK,
   DELOAD_READINESS_MAX_AGE_DAYS,
+  isDeloadActive,
   recommendDeload,
 } from '@/lib/deload';
 import { ProgressDashboard } from '@/components/progress/progress-dashboard';
@@ -62,7 +63,7 @@ export default async function ProgressPage({
     }),
     db.user.findUnique({
       where: { id: auth.userId },
-      select: { bodyweight: true, unit: true, weeklyFrequency: true },
+      select: { bodyweight: true, unit: true, weeklyFrequency: true, deloadUntil: true },
     }),
   ]);
   const bodyweight = user?.bodyweight ?? null;
@@ -290,6 +291,11 @@ export default async function ProgressPage({
     recentReadiness: recentCheckins.map((c) => c.readiness),
   });
 
+  // Active planned deload week (issue #112): only a future deloadUntil counts;
+  // an expired one reads as inactive without any cleanup write.
+  const deloadActive = isDeloadActive(user?.deloadUntil ?? null, new Date());
+  const deloadUntilIso = deloadActive ? user!.deloadUntil!.toISOString() : null;
+
   return (
     <main className="flex-1 px-4 py-6">
       <div className="mx-auto flex max-w-3xl flex-col gap-6">
@@ -316,7 +322,9 @@ export default async function ProgressPage({
           />
         ) : (
           <>
-            {deload.recommended && <DeloadBanner reasons={deload.reasons} />}
+            {(deload.recommended || deloadActive) && (
+              <DeloadBanner reasons={deload.reasons} deloadUntil={deloadUntilIso} />
+            )}
             <ConsistencyCard
               weeks={consistency.weeks}
               currentStreak={consistency.currentStreak}

--- a/app/(app)/session/[id]/page.tsx
+++ b/app/(app)/session/[id]/page.tsx
@@ -3,6 +3,7 @@ import { db } from '@/lib/db';
 import { requireSession } from '@/lib/auth';
 import { getLastPerformances, type LastPerformance } from '@/lib/last-performance';
 import { READINESS_RECENCY_HOURS, type ReadinessSignal } from '@/lib/progression';
+import { isDeloadActive } from '@/lib/deload';
 import { SessionRunner, type SerializedLastPerformance } from '@/components/session/session-runner';
 
 interface Props {
@@ -39,7 +40,10 @@ export default async function SessionRunPage({ params }: Props) {
   const exerciseIds = session.workout.exercises.map((pe) => pe.exerciseId);
   const [lastPerformances, user, latestCheckin] = await Promise.all([
     getLastPerformances(auth.userId, exerciseIds, session.id),
-    db.user.findUnique({ where: { id: auth.userId }, select: { unit: true } }),
+    db.user.findUnique({
+      where: { id: auth.userId },
+      select: { unit: true, deloadUntil: true },
+    }),
     db.readinessCheckin.findFirst({
       where: { userId: auth.userId },
       orderBy: { createdAt: 'desc' },
@@ -52,12 +56,16 @@ export default async function SessionRunPage({ params }: Props) {
   }
 
   const readiness = buildReadinessSignal(latestCheckin);
+  // Planned deload week (issue #112): resolved against the clock here so the
+  // client never reasons about dates; an expired deloadUntil has no effect.
+  const deloadActive = isDeloadActive(user?.deloadUntil ?? null, new Date());
 
   return (
     <SessionRunner
       session={session}
       lastPerformances={lastPerfRecord}
       readiness={readiness}
+      deloadActive={deloadActive}
       unit={user?.unit ?? 'KG'}
     />
   );

--- a/app/api/deload/route.ts
+++ b/app/api/deload/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
+import { DELOAD_DURATION_DAYS } from '@/lib/deload';
+import { deloadStartSchema } from '@/lib/schemas/deload';
+
+// One-tap planned deload week (issue #112). Both handlers operate strictly on
+// the authenticated user's own row (requireApiUserId), so ownership is
+// enforced by construction - there is no way to address another user.
+
+// POST /api/deload: starts a deload week ending DELOAD_DURATION_DAYS from now.
+// Re-posting while one is active simply restarts the 7-day window.
+export async function POST(req: Request) {
+  try {
+    const userId = await requireApiUserId();
+    await parseJsonBody(req, deloadStartSchema);
+    const deloadUntil = new Date(
+      Date.now() + DELOAD_DURATION_DAYS * 24 * 60 * 60 * 1000,
+    );
+    await db.user.update({
+      where: { id: userId },
+      data: { deloadUntil },
+    });
+    return NextResponse.json(
+      { deloadUntil: deloadUntil.toISOString() },
+      { status: 201 },
+    );
+  } catch (err) {
+    return handleApiError(err);
+  }
+}
+
+// DELETE /api/deload: ends the deload now (clears deloadUntil). Idempotent -
+// deleting with no active deload is a no-op success.
+export async function DELETE() {
+  try {
+    const userId = await requireApiUserId();
+    await db.user.update({
+      where: { id: userId },
+      data: { deloadUntil: null },
+    });
+    return NextResponse.json({ deloadUntil: null });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/components/progress/deload-banner.test.tsx
+++ b/components/progress/deload-banner.test.tsx
@@ -1,10 +1,25 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { DeloadBanner } from './deload-banner';
 
-describe('DeloadBanner', () => {
-  it('renders nothing without reasons', () => {
-    const { container } = render(<DeloadBanner reasons={[]} />);
+// next/navigation is a client hook; stub the router used for refresh-on-action.
+const refresh = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh }),
+}));
+
+beforeEach(() => {
+  refresh.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('DeloadBanner (recommendation state)', () => {
+  it('renders nothing without reasons and without an active deload', () => {
+    const { container } = render(<DeloadBanner reasons={[]} deloadUntil={null} />);
     expect(container).toBeEmptyDOMElement();
   });
 
@@ -14,6 +29,7 @@ describe('DeloadBanner', () => {
         reasons={[
           { kind: 'stalled-lifts', exerciseNames: ['Bench press', 'Squat'] },
         ]}
+        deloadUntil={null}
       />,
     );
     expect(screen.getByText('A deload week looks due')).toBeInTheDocument();
@@ -28,6 +44,7 @@ describe('DeloadBanner', () => {
         reasons={[
           { kind: 'low-readiness', averageReadiness: 1.7, checkins: 5 },
         ]}
+        deloadUntil={null}
       />,
     );
     expect(
@@ -44,8 +61,70 @@ describe('DeloadBanner', () => {
           { kind: 'stalled-lifts', exerciseNames: ['Squat', 'Deadlift'] },
           { kind: 'low-readiness', averageReadiness: 2, checkins: 4 },
         ]}
+        deloadUntil={null}
       />,
     );
     expect(screen.getAllByRole('listitem')).toHaveLength(2);
+  });
+
+  it('starts the deload via POST /api/deload and refreshes', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ deloadUntil: '2026-06-18T00:00:00.000Z' }), {
+        status: 201,
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const user = userEvent.setup();
+    render(
+      <DeloadBanner
+        reasons={[{ kind: 'low-readiness', averageReadiness: 2, checkins: 4 }]}
+        deloadUntil={null}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Start a deload week' }));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/deload',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(refresh).toHaveBeenCalled();
+  });
+});
+
+describe('DeloadBanner (active state)', () => {
+  it('shows the end date and an end button while a deload is active', () => {
+    render(<DeloadBanner reasons={[]} deloadUntil="2026-06-18T12:00:00.000Z" />);
+    expect(screen.getByText('Deload week in progress')).toBeInTheDocument();
+    expect(screen.getByText(/Until Jun 18/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'End deload now' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Start a deload week' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('takes precedence over the recommendation copy when both apply', () => {
+    render(
+      <DeloadBanner
+        reasons={[{ kind: 'stalled-lifts', exerciseNames: ['Squat', 'Bench'] }]}
+        deloadUntil="2026-06-18T12:00:00.000Z"
+      />,
+    );
+    expect(screen.getByText('Deload week in progress')).toBeInTheDocument();
+    expect(screen.queryByText('A deload week looks due')).not.toBeInTheDocument();
+  });
+
+  it('ends the deload via DELETE /api/deload and refreshes', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ deloadUntil: null }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const user = userEvent.setup();
+    render(<DeloadBanner reasons={[]} deloadUntil="2026-06-18T12:00:00.000Z" />);
+
+    await user.click(screen.getByRole('button', { name: 'End deload now' }));
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/deload', { method: 'DELETE' });
+    expect(refresh).toHaveBeenCalled();
   });
 });

--- a/components/progress/deload-banner.tsx
+++ b/components/progress/deload-banner.tsx
@@ -1,16 +1,95 @@
-import { BatteryLow } from 'lucide-react';
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { BatteryCharging, BatteryLow } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { deloadReasonLine, type DeloadReason } from '@/lib/deload';
 
 interface Props {
   reasons: DeloadReason[];
+  // End of the active planned deload week (ISO string), or null when none is
+  // running. The server only passes a future timestamp here.
+  deloadUntil: string | null;
 }
 
-// Display-only banner shown on the progress page when recommendDeload fires.
-// Lists the concrete reasons and explains what a deload week is; it changes
-// nothing in the program or the suggestions.
-export function DeloadBanner({ reasons }: Props) {
-  if (reasons.length === 0) return null;
+// Banner shown on the progress page when recommendDeload fires or a planned
+// deload week is running (issue #112). One tap starts the deload week (the
+// suggestion engine then steps loads down ~10%); while active it shows the end
+// date and lets the user end it early.
+export function DeloadBanner({ reasons, deloadUntil }: Props) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const active = deloadUntil != null;
+
+  if (!active && reasons.length === 0) return null;
+
+  async function startDeload() {
+    setBusy(true);
+    try {
+      const res = await fetch('/api/deload', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as { error?: string } | null;
+        toast.error(data?.error ?? 'Could not start the deload week.');
+        return;
+      }
+      toast.success('Deload week started. Load suggestions step down for 7 days.');
+      router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function endDeload() {
+    setBusy(true);
+    try {
+      const res = await fetch('/api/deload', { method: 'DELETE' });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as { error?: string } | null;
+        toast.error(data?.error ?? 'Could not end the deload.');
+        return;
+      }
+      toast.success('Deload ended. Suggestions are back to normal progression.');
+      router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (active) {
+    const endDate = new Intl.DateTimeFormat('en-US', {
+      day: '2-digit',
+      month: 'short',
+    }).format(new Date(deloadUntil!));
+    return (
+      <Card className="border-emerald-500/50 bg-emerald-500/5">
+        <CardHeader className="pb-3">
+          <div className="flex items-center gap-2">
+            <BatteryCharging className="size-4 text-emerald-600" />
+            <h2 className="text-base font-semibold">Deload week in progress</h2>
+          </div>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3 text-sm">
+          <p className="text-muted-foreground">
+            Until {endDate}, your load suggestions step down by about 10% so you
+            keep moving while recovering. Normal progression resumes
+            automatically afterwards.
+          </p>
+          <div>
+            <Button variant="outline" size="sm" onClick={endDeload} disabled={busy}>
+              End deload now
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
 
   return (
     <Card className="border-amber-500/50 bg-amber-500/5">
@@ -22,18 +101,23 @@ export function DeloadBanner({ reasons }: Props) {
           </h2>
         </div>
       </CardHeader>
-      <CardContent className="flex flex-col gap-2 text-sm">
+      <CardContent className="flex flex-col gap-3 text-sm">
         <ul className="list-disc space-y-1 pl-5">
           {reasons.map((reason) => (
             <li key={reason.kind}>{deloadReasonLine(reason)}</li>
           ))}
         </ul>
         <p className="text-xs text-muted-foreground">
-          Accumulated fatigue can mask progress. For one week, roughly halve
-          your working sets or reduce the load by about 10%, keep moving, then
-          resume your normal program. Your plan and suggestions are unchanged;
-          this is only a recommendation.
+          Accumulated fatigue can mask progress. Starting a deload week reduces
+          your suggested loads by about 10% for 7 days, then normal progression
+          resumes. You can end it early at any time; nothing else in your
+          program changes.
         </p>
+        <div>
+          <Button size="sm" onClick={startDeload} disabled={busy}>
+            Start a deload week
+          </Button>
+        </div>
       </CardContent>
     </Card>
   );

--- a/components/session/exercise-card.test.tsx
+++ b/components/session/exercise-card.test.tsx
@@ -45,9 +45,15 @@ const lastPerf: SerializedLastPerformance = {
   repsAtMaxWeight: 10,
 };
 
-function renderCard(readiness: ReadinessSignal | null) {
+function renderCard(readiness: ReadinessSignal | null, deloadActive = false) {
   return render(
-    <ExerciseCard programExercise={pe} lastPerformance={lastPerf} readiness={readiness} unit="KG" />,
+    <ExerciseCard
+      programExercise={pe}
+      lastPerformance={lastPerf}
+      readiness={readiness}
+      deloadActive={deloadActive}
+      unit="KG"
+    />,
   );
 }
 
@@ -81,5 +87,13 @@ describe('ExerciseCard readiness explainer', () => {
     renderCard({ readiness: 1, soreness: null, ageHours: READINESS_RECENCY_HOURS + 1 });
     expect(screen.queryByText(/Held -/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Lighter -/)).not.toBeInTheDocument();
+  });
+
+  it('explains the planned deload week when one is active', () => {
+    // No readiness signal at all: the planned deload alone drives the note,
+    // and the suggested load steps down 10% from the 100 kg working weight.
+    renderCard(null, true);
+    expect(screen.getByText('Lighter - planned deload week')).toBeInTheDocument();
+    expect(screen.getByText('90 kg')).toBeInTheDocument();
   });
 });

--- a/components/session/exercise-card.tsx
+++ b/components/session/exercise-card.tsx
@@ -21,19 +21,23 @@ interface Props {
   programExercise: ProgramExercise & { exercise: Exercise };
   lastPerformance: SerializedLastPerformance | undefined;
   readiness: ReadinessSignal | null;
+  // True while a planned deload week is active (issue #112).
+  deloadActive: boolean;
   unit: WeightUnit;
 }
 
-// Short, plain-language explainer shown next to the suggested load when a recent
-// readiness/soreness check-in made the suggestion more conservative. Returns
-// null for the normal (non-readiness) reasons so the UI is unchanged then. The
-// note names the likelier cause - reported soreness for the trained muscle, or
-// low overall readiness - so the adjustment reads as deliberate, not arbitrary.
+// Short, plain-language explainer shown next to the suggested load when a
+// planned deload week or a recent readiness/soreness check-in made the
+// suggestion more conservative. Returns null for the normal reasons so the UI
+// is unchanged then. The note names the likelier cause - the planned deload,
+// reported soreness for the trained muscle, or low overall readiness - so the
+// adjustment reads as deliberate, not arbitrary.
 function readinessExplainer(
   reason: SuggestionReason,
   readiness: ReadinessSignal | null,
   muscleGroup: MuscleGroup,
 ): string | null {
+  if (reason === 'planned-deload') return 'Lighter - planned deload week';
   if (reason !== 'readiness-hold' && reason !== 'readiness-deload') return null;
   const verb = reason === 'readiness-deload' ? 'Lighter' : 'Held';
   const groupSoreness = readiness?.soreness?.[muscleGroup];
@@ -54,12 +58,20 @@ function helpText(suggestion: SuggestionResult, unit: WeightUnit): string {
       return `A recent readiness check-in flagged poor recovery, so the load stays at ${working} instead of increasing today. Push the reps, not the weight.`;
     case 'readiness-deload':
       return `A recent readiness check-in flagged very poor recovery, so the load steps down from ${working} for a lighter session. It will climb back as recovery improves.`;
+    case 'planned-deload':
+      return `You are in a planned deload week, so the load steps down about 10% from ${working}. Normal progression resumes when the week ends (you can end it early on the progress page).`;
     default:
       return `Keep the same load and try to beat your reps. Progression unlocks once all working sets reach ${suggestion.targetRepsMax} reps.`;
   }
 }
 
-export function ExerciseCard({ programExercise, lastPerformance, readiness, unit }: Props) {
+export function ExerciseCard({
+  programExercise,
+  lastPerformance,
+  readiness,
+  deloadActive,
+  unit,
+}: Props) {
   const [notesOpen, setNotesOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
   const exo = programExercise.exercise;
@@ -69,7 +81,12 @@ export function ExerciseCard({ programExercise, lastPerformance, readiness, unit
       ? `${programExercise.targetRepsMin}`
       : `${programExercise.targetRepsMin}-${programExercise.targetRepsMax}`;
 
-  const suggestion = suggestNextWeight(programExercise, lastPerformance?.sets ?? [], readiness);
+  const suggestion = suggestNextWeight(
+    programExercise,
+    lastPerformance?.sets ?? [],
+    readiness,
+    deloadActive,
+  );
   const readinessNote = readinessExplainer(suggestion.reason, readiness, exo.muscleGroup);
   const lastDate = lastPerformance
     ? new Intl.DateTimeFormat('en-US', { day: '2-digit', month: '2-digit' }).format(

--- a/components/session/session-runner.tsx
+++ b/components/session/session-runner.tsx
@@ -15,6 +15,7 @@ import type {
 } from '@prisma/client';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { toast } from 'sonner';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Progress } from '@/components/ui/progress';
 import { acquireWakeLock, bindWakeLockToVisibility, releaseWakeLock } from '@/lib/wake-lock';
@@ -57,6 +58,9 @@ type SessionRunnerProps = {
   // Latest in-window readiness check-in (or null). Drives whether the load
   // suggestion is held/reduced and the matching explainer in the UI.
   readiness: ReadinessSignal | null;
+  // True while the user runs a planned deload week (issue #112): suggestions
+  // step down and the runner shows a "Deload week" badge.
+  deloadActive: boolean;
   unit: WeightUnit;
 };
 
@@ -65,7 +69,13 @@ type Mode =
   | { kind: 'rest'; endsAt: number; totalSec: number; nextExerciseIdx: number | null }
   | { kind: 'summary' };
 
-export function SessionRunner({ session, lastPerformances, readiness, unit }: SessionRunnerProps) {
+export function SessionRunner({
+  session,
+  lastPerformances,
+  readiness,
+  deloadActive,
+  unit,
+}: SessionRunnerProps) {
   const router = useRouter();
   const workout = session.workout!;
   const programExercises = workout.exercises;
@@ -304,6 +314,11 @@ export function SessionRunner({ session, lastPerformances, readiness, unit }: Se
             <p className="text-sm font-medium">
               Exercise {currentIdx + 1}/{programExercises.length} · {currentPE.exercise.name}
             </p>
+            {deloadActive && (
+              <Badge variant="secondary" className="mt-1 text-emerald-700 dark:text-emerald-400">
+                Deload week
+              </Badge>
+            )}
           </div>
           <Button
             variant="ghost"
@@ -325,6 +340,7 @@ export function SessionRunner({ session, lastPerformances, readiness, unit }: Se
           programExercise={currentPE}
           lastPerformance={lastPerf}
           readiness={effectiveReadiness}
+          deloadActive={deloadActive}
           unit={unit}
         />
 
@@ -342,6 +358,7 @@ export function SessionRunner({ session, lastPerformances, readiness, unit }: Se
             existingSets={currentSets}
             lastPerformance={lastPerf}
             readiness={effectiveReadiness}
+            deloadActive={deloadActive}
             unit={unit}
             onSubmit={handleValidate}
           />

--- a/components/session/set-input.test.tsx
+++ b/components/session/set-input.test.tsx
@@ -39,6 +39,7 @@ function renderSetInput(unit: 'KG' | 'LB' = 'KG') {
       existingSets={[]}
       lastPerformance={undefined}
       readiness={null}
+      deloadActive={false}
       unit={unit}
       onSubmit={onSubmit}
     />,

--- a/components/session/set-input.tsx
+++ b/components/session/set-input.tsx
@@ -28,6 +28,8 @@ interface Props {
   existingSets: PendingSet[];
   lastPerformance: SerializedLastPerformance | undefined;
   readiness: ReadinessSignal | null;
+  // True while a planned deload week is active (issue #112).
+  deloadActive: boolean;
   unit: WeightUnit;
   onSubmit: (values: {
     weight: number;
@@ -55,19 +57,28 @@ export function SetInput({
   existingSets,
   lastPerformance,
   readiness,
+  deloadActive,
   unit,
   onSubmit,
 }: Props) {
   // Pre-fill: last set of this exercise in the current session,
   // otherwise the last performance, otherwise defaults.
-  const initial = computeInitial(programExercise, existingSets, lastPerformance, readiness);
+  const initial = computeInitial(
+    programExercise,
+    existingSets,
+    lastPerformance,
+    readiness,
+    deloadActive,
+  );
   const [form, setForm] = useState<FormState>(initial);
   const [submitting, setSubmitting] = useState(false);
   const [quickEntry, setQuickEntry] = useState('');
 
   // Re-init when the exercise changes or a set changes.
   useEffect(() => {
-    setForm(computeInitial(programExercise, existingSets, lastPerformance, readiness));
+    setForm(
+      computeInitial(programExercise, existingSets, lastPerformance, readiness, deloadActive),
+    );
     setQuickEntry('');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [programExercise.id, existingSets.length]);
@@ -310,6 +321,7 @@ function computeInitial(
   existingSets: PendingSet[],
   lastPerf: SerializedLastPerformance | undefined,
   readiness: ReadinessSignal | null,
+  deloadActive: boolean,
 ): FormState {
   // 1. If a set already exists for this exercise in the current session,
   //    reuse its values (idea: you aim for the same load, adjust the reps).
@@ -328,7 +340,7 @@ function computeInitial(
   //    progressing, aim for the bottom of the rep range with the heavier
   //    load; otherwise try to beat the previous reps (at least match them).
   if (lastPerf) {
-    const suggestion = suggestNextWeight(pe, lastPerf.sets, readiness);
+    const suggestion = suggestNextWeight(pe, lastPerf.sets, readiness, deloadActive);
     const initialReps =
       suggestion.reason === 'progression'
         ? pe.targetRepsMin

--- a/lib/coach.ts
+++ b/lib/coach.ts
@@ -12,6 +12,7 @@ import {
   DELOAD_READINESS_LOOKBACK,
   DELOAD_READINESS_MAX_AGE_DAYS,
   deloadReasonLine,
+  isDeloadActive,
   recommendDeload,
 } from '@/lib/deload';
 import { COACH_SYSTEM_PROMPT } from '@/lib/prompts/coach-system-prompt';
@@ -89,6 +90,10 @@ interface FatigueSummary {
   deloadRecommended: boolean;
   // Short human-readable reasons (same lines the progress page shows).
   deloadReasons: string[];
+  // True while the user runs a planned deload week (issue #112), so the coach
+  // supports the deload already underway instead of recommending one. Additive
+  // input signal; the output contract is unchanged.
+  deloadActive: boolean;
 }
 
 interface ReadinessSummary {
@@ -173,6 +178,7 @@ export async function buildCoachPayload(userId: string): Promise<CoachPayload> {
       bodyweight: true,
       goal: true,
       weeklyFrequency: true,
+      deloadUntil: true,
     },
   });
   const bodyweight = user?.bodyweight ?? null;
@@ -292,7 +298,12 @@ export async function buildCoachPayload(userId: string): Promise<CoachPayload> {
     activeProgram,
     latestReadiness,
     goals,
-    fatigue,
+    fatigue: {
+      ...fatigue,
+      // Planned deload week (issue #112): additive flag; an expired
+      // deloadUntil reads as inactive.
+      deloadActive: isDeloadActive(user?.deloadUntil ?? null, now),
+    },
     recentProgress: recentProgress.sort((a, b) =>
       a.exerciseName.localeCompare(b.exerciseName),
     ),
@@ -494,7 +505,9 @@ async function fetchFatigueSummary(
   userId: string,
   bodyweight: number | null,
   now: Date,
-): Promise<FatigueSummary> {
+  // deloadActive is derived from the user row in buildCoachPayload, so this
+  // helper returns everything but that flag.
+): Promise<Omit<FatigueSummary, 'deloadActive'>> {
   const since = new Date(now);
   since.setUTCHours(0, 0, 0, 0);
   since.setUTCDate(since.getUTCDate() - FATIGUE_WINDOW_WEEKS * 7);

--- a/lib/deload.test.ts
+++ b/lib/deload.test.ts
@@ -5,6 +5,7 @@ import {
   DELOAD_READINESS_THRESHOLD,
   DELOAD_STALLED_LIFTS_MIN,
   deloadReasonLine,
+  isDeloadActive,
   recommendDeload,
 } from './deload';
 
@@ -124,5 +125,24 @@ describe('deloadReasonLine', () => {
     expect(
       deloadReasonLine({ kind: 'low-readiness', averageReadiness: 2.3, checkins: 4 }),
     ).toBe('Your readiness has averaged 2.3/5 over your last 4 check-ins.');
+  });
+});
+
+// One-tap planned deload week (issue #112): activity window semantics.
+describe('isDeloadActive', () => {
+  const now = new Date('2026-06-11T12:00:00Z');
+
+  it('is inactive when deloadUntil is null', () => {
+    expect(isDeloadActive(null, now)).toBe(false);
+  });
+
+  it('is active while deloadUntil is in the future', () => {
+    expect(isDeloadActive(new Date('2026-06-18T12:00:00Z'), now)).toBe(true);
+    expect(isDeloadActive(new Date('2026-06-11T12:00:01Z'), now)).toBe(true);
+  });
+
+  it('expires: a past or exactly-now deloadUntil has no effect', () => {
+    expect(isDeloadActive(new Date('2026-06-04T12:00:00Z'), now)).toBe(false);
+    expect(isDeloadActive(new Date('2026-06-11T12:00:00Z'), now)).toBe(false);
   });
 });

--- a/lib/deload.ts
+++ b/lib/deload.ts
@@ -32,6 +32,17 @@ export const DELOAD_READINESS_MAX_AGE_DAYS = 14;
 // window, justify a planned week of reduced load instead.
 export const DELOAD_READINESS_THRESHOLD = READINESS_HOLD_AT_OR_BELOW;
 
+// Length of a one-tap planned deload week (issue #112): POST /api/deload sets
+// User.deloadUntil this many days ahead.
+export const DELOAD_DURATION_DAYS = 7;
+
+// Whether a planned deload is currently active. Null or a timestamp at/in the
+// past means no active deload, so an expired deloadUntil silently returns the
+// app to normal progression without any cleanup write.
+export function isDeloadActive(deloadUntil: Date | null, now: Date): boolean {
+  return deloadUntil != null && deloadUntil.getTime() > now.getTime();
+}
+
 export type DeloadReason =
   | { kind: 'stalled-lifts'; exerciseNames: string[] }
   | { kind: 'low-readiness'; averageReadiness: number; checkins: number };

--- a/lib/progression.test.ts
+++ b/lib/progression.test.ts
@@ -319,3 +319,64 @@ describe('readinessForSuggestion - auto-regulation preference gate (issue #61)',
     expect(gatedOn.weight).toBe(+(80 * (1 - READINESS_DELOAD_FRACTION)).toFixed(2));
   });
 });
+
+// Planned deload week (issue #112). The boolean is resolved by the caller from
+// User.deloadUntil (lib/deload.ts isDeloadActive); these tests pin the
+// step-down, its precedence over progression/hold, and the no-stacking rule
+// against a simultaneous readiness deload.
+describe('suggestNextWeight planned deload', () => {
+  const progressingSets = [
+    { weight: 80, reps: 10, rir: 2 },
+    { weight: 80, reps: 10, rir: 2 },
+    { weight: 80, reps: 10, rir: 2 },
+  ];
+
+  it('steps the working load down 10% with the planned-deload reason', () => {
+    const res = suggestNextWeight(makePe(compoundExo), progressingSets, null, true);
+    expect(res).toMatchObject({
+      weight: 72,
+      reason: 'planned-deload',
+      workingWeight: 80,
+      targetRepsMax: 10,
+    });
+  });
+
+  it('takes precedence over a programmed increment', () => {
+    // Without the deload these sets progress to 82.5.
+    const baseline = suggestNextWeight(makePe(compoundExo), progressingSets);
+    expect(baseline.reason).toBe('progression');
+    const deload = suggestNextWeight(makePe(compoundExo), progressingSets, null, true);
+    expect(deload.reason).toBe('planned-deload');
+    expect(deload.weight).toBeLessThan(baseline.weight!);
+  });
+
+  it('does not stack with a readiness deload: one 10% reduction, never both', () => {
+    const drained: ReadinessSignal = { readiness: 1, soreness: null, ageHours: 1 };
+    const readinessOnly = suggestNextWeight(makePe(compoundExo), progressingSets, drained);
+    expect(readinessOnly.reason).toBe('readiness-deload');
+    const both = suggestNextWeight(makePe(compoundExo), progressingSets, drained, true);
+    // The same single reduction is applied (80 * 0.9 = 72, not 80 * 0.81).
+    expect(both.weight).toBe(readinessOnly.weight);
+    expect(both.weight).toBe(+(80 * (1 - READINESS_DELOAD_FRACTION)).toFixed(2));
+    expect(both.reason).toBe('planned-deload');
+  });
+
+  it('wins over a readiness hold (the larger reduction applies)', () => {
+    const poor: ReadinessSignal = { readiness: 2, soreness: null, ageHours: 1 };
+    const holdOnly = suggestNextWeight(makePe(compoundExo), progressingSets, poor);
+    expect(holdOnly).toMatchObject({ reason: 'readiness-hold', weight: 80 });
+    const withDeload = suggestNextWeight(makePe(compoundExo), progressingSets, poor, true);
+    expect(withDeload).toMatchObject({ reason: 'planned-deload', weight: 72 });
+  });
+
+  it('inactive (false/omitted) leaves the suggestion byte-identical to before', () => {
+    const before = suggestNextWeight(makePe(compoundExo), progressingSets);
+    const explicit = suggestNextWeight(makePe(compoundExo), progressingSets, null, false);
+    expect(explicit).toEqual(before);
+  });
+
+  it('still reports no-history when there are no previous sets', () => {
+    const res = suggestNextWeight(makePe(compoundExo), [], null, true);
+    expect(res).toEqual({ weight: null, reason: 'no-history' });
+  });
+});

--- a/lib/progression.ts
+++ b/lib/progression.ts
@@ -19,7 +19,8 @@ export type SuggestionReason =
   | 'same-as-last'
   | 'progression'
   | 'readiness-hold'
-  | 'readiness-deload';
+  | 'readiness-deload'
+  | 'planned-deload';
 
 export interface SuggestionResult {
   weight: number | null;
@@ -83,6 +84,10 @@ export function suggestNextWeight(
   programExercise: ProgramExercise & { exercise: Exercise },
   lastSets: Pick<Set, 'weight' | 'reps' | 'rir'>[],
   readiness?: ReadinessSignal | null,
+  // True while the user runs a planned deload week (issue #112). The caller
+  // resolves User.deloadUntil against the clock (lib/deload.ts isDeloadActive)
+  // so this module stays deterministic.
+  plannedDeload?: boolean,
 ): SuggestionResult {
   if (lastSets.length === 0) {
     return { weight: null, reason: 'no-history' };
@@ -112,6 +117,20 @@ export function suggestNextWeight(
         workingWeight,
         targetRepsMax,
       };
+
+  // Planned deload week (issue #112): one conservative step-down from the
+  // working load, taking precedence over a programmed increment and over a
+  // readiness hold. A simultaneous readiness deload is the SAME single 10%
+  // reduction (both use READINESS_DELOAD_FRACTION of the working load), so the
+  // two never stack - the larger single reduction is applied, never both.
+  if (plannedDeload) {
+    return {
+      weight: +(workingWeight * (1 - READINESS_DELOAD_FRACTION)).toFixed(2),
+      reason: 'planned-deload',
+      workingWeight,
+      targetRepsMax,
+    };
+  }
 
   const recovery = assessRecovery(readiness, programExercise.exercise.muscleGroup);
   if (recovery === 'ok') {

--- a/lib/prompts/coach-system-prompt.test.ts
+++ b/lib/prompts/coach-system-prompt.test.ts
@@ -47,6 +47,12 @@ describe('coach system prompt positioning', () => {
       /deloadRecommended is true, prefer recovery-oriented advice/i,
     );
   });
+
+  // Issue #112: planned deload week is an INPUT-side signal too.
+  it('tells the coach not to recommend a deload while one is already active', () => {
+    expect(COACH_SYSTEM_PROMPT).toMatch(/fatigue\.deloadActive/);
+    expect(COACH_SYSTEM_PROMPT).toMatch(/do not\s+recommend starting a deload then/i);
+  });
 });
 
 describe('program generation prompt positioning', () => {

--- a/lib/prompts/coach-system-prompt.ts
+++ b/lib/prompts/coach-system-prompt.ts
@@ -42,6 +42,10 @@ fatigue.deloadReasons (the same recommendation the app shows the user). When
 deloadRecommended is true, prefer recovery-oriented advice - hold or reduce loads
 and volume, echo the provided reasons - over load increases; do not prescribe a
 load increase on a stalled exercise without addressing the stall.
+fatigue.deloadActive is true while the user is already running a planned deload
+week (the app is stepping their suggested loads down about 10%): do not
+recommend starting a deload then - support executing the one underway and frame
+suggestions around returning to normal loads when it ends.
 
 Be concise (max 600 words), actionable, factual. Cite studies when relevant
 (Schoenfeld, Helms, Israetel). Do not make up data that is not in the payload.

--- a/lib/schemas/deload.test.ts
+++ b/lib/schemas/deload.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { deloadStartSchema } from './deload';
+
+describe('deloadStartSchema', () => {
+  it('accepts the bare empty object the UI sends', () => {
+    expect(deloadStartSchema.safeParse({}).success).toBe(true);
+  });
+
+  it('rejects unexpected fields (no client-chosen duration)', () => {
+    expect(deloadStartSchema.safeParse({ days: 30 }).success).toBe(false);
+    expect(deloadStartSchema.safeParse({ deloadUntil: '2099-01-01' }).success).toBe(false);
+  });
+
+  it('rejects non-object bodies', () => {
+    expect(deloadStartSchema.safeParse(null).success).toBe(false);
+    expect(deloadStartSchema.safeParse('start').success).toBe(false);
+    expect(deloadStartSchema.safeParse(7).success).toBe(false);
+  });
+});

--- a/lib/schemas/deload.ts
+++ b/lib/schemas/deload.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+// One-tap planned deload week (issue #112). Starting a deload takes no
+// parameters - the duration is fixed server-side (lib/deload.ts
+// DELOAD_DURATION_DAYS) - so the input schema is a strict empty object: it
+// accepts the bare `{}` the UI sends and rejects any attempt to smuggle in a
+// custom duration or other fields.
+export const deloadStartSchema = z.object({}).strict();
+
+export type DeloadStartInput = z.infer<typeof deloadStartSchema>;

--- a/prisma/migrations/20260611000000_add_deload_until/migration.sql
+++ b/prisma/migrations/20260611000000_add_deload_until/migration.sql
@@ -1,0 +1,6 @@
+-- Additive migration (issue #112): one-tap planned deload week. One nullable
+-- column on User, no change to any other table or row. Null (every existing
+-- user) means "no planned deload", which is the current behavior.
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "deloadUntil" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,10 @@ model User {
   // Preferred weight unit for display and input. Data is always stored in kg;
   // this only affects the presentation layer. Default keeps existing users on kg.
   unit            WeightUnit @default(KG)
+  // End of the user's planned deload week (issue #112). While this timestamp
+  // is in the future, load suggestions apply the planned-deload step-down.
+  // Null or in the past = no planned deload (backward-safe additive column).
+  deloadUntil     DateTime?
   createdAt    DateTime   @default(now())
   programs      Program[]
   sessions      Session[]

--- a/tests/e2e/deload.spec.ts
+++ b/tests/e2e/deload.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// One-tap planned deload week (issue #112): the deload recommendation banner
+// gains a "Start a deload week" button; while active the banner shows the end
+// date and an early-exit button. Data is seeded through the authenticated API
+// (the browser context shares cookies with page.request).
+
+async function seedLoggedSet(page: Page) {
+  // One exercise, one program/workout, one finished session with a set, so the
+  // progress page renders its dashboard (the banner lives inside it).
+  const exerciseRes = await page.request.post('/api/exercises', {
+    data: { name: 'Deload Bench', muscleGroup: 'CHEST', category: 'COMPOUND' },
+  });
+  expect(exerciseRes.ok()).toBeTruthy();
+  const exercise = await exerciseRes.json();
+
+  const programRes = await page.request.post('/api/programs', {
+    data: { name: 'E2E Deload Program', phase: 'Base' },
+  });
+  expect(programRes.ok()).toBeTruthy();
+  const program = await programRes.json();
+
+  const workoutRes = await page.request.post(`/api/programs/${program.id}/workouts`, {
+    data: { name: 'Day A' },
+  });
+  expect(workoutRes.ok()).toBeTruthy();
+  const workout = await workoutRes.json();
+
+  const sessionRes = await page.request.post('/api/sessions', {
+    data: { workoutId: workout.id },
+  });
+  expect(sessionRes.ok()).toBeTruthy();
+  const session = await sessionRes.json();
+
+  const setRes = await page.request.post(`/api/sessions/${session.id}/sets`, {
+    data: { exerciseId: exercise.id, setNumber: 1, weight: 90, reps: 5 },
+  });
+  expect(setRes.ok()).toBeTruthy();
+
+  const finishRes = await page.request.put(`/api/sessions/${session.id}`, {
+    data: { finish: true },
+  });
+  expect(finishRes.ok()).toBeTruthy();
+}
+
+async function seedLowReadiness(page: Page) {
+  // Three drained check-ins trigger the chronic low-readiness deload
+  // recommendation (average 1 over >= 3 recent check-ins).
+  for (let i = 0; i < 3; i += 1) {
+    const res = await page.request.post('/api/readiness', {
+      data: { readiness: 1, sleepQuality: 1 },
+    });
+    expect(res.ok()).toBeTruthy();
+  }
+}
+
+test('a lifter can start a planned deload week from the banner and end it early', async ({
+  page,
+}) => {
+  // Sign up (fresh user each run).
+  await page.goto('/signup');
+  await page.getByLabel('Name').fill('Deload E2E');
+  await page.getByLabel('Email').fill(`e2e-deload-${Date.now()}@test.dev`);
+  await page.getByLabel('Password').fill('supersecret');
+  await page.getByRole('button', { name: 'Create account' }).click();
+  await expect(page).toHaveURL('/');
+
+  await seedLoggedSet(page);
+  await seedLowReadiness(page);
+
+  // The recommendation banner shows with the one-tap action.
+  await page.goto('/progress');
+  await expect(page.getByText('A deload week looks due')).toBeVisible();
+  await page.getByRole('button', { name: 'Start a deload week' }).click();
+
+  // Active state: end date copy and the early-exit button.
+  await expect(page.getByText('Deload week in progress')).toBeVisible();
+  await expect(page.getByText(/Until /)).toBeVisible();
+  await expect(page.getByText('A deload week looks due')).not.toBeVisible();
+
+  // End it early: the banner falls back to the recommendation (the low
+  // readiness signals are still present).
+  await page.getByRole('button', { name: 'End deload now' }).click();
+  await expect(page.getByText('A deload week looks due')).toBeVisible();
+  await expect(page.getByText('Deload week in progress')).not.toBeVisible();
+});

--- a/tests/integration/core.test.ts
+++ b/tests/integration/core.test.ts
@@ -377,7 +377,25 @@ describe('buildCoachPayload fatigue (issue #101)', () => {
       stalledExercises: [],
       deloadRecommended: false,
       deloadReasons: [],
+      deloadActive: false,
     });
+  });
+
+  // Issue #112: the planned deload week surfaces as an additive input flag.
+  it('reports deloadActive while a planned deload week is running, and not after it expires', async () => {
+    const user = await makeUser('fatigue-deload-active@test.dev');
+
+    await db.user.update({
+      where: { id: user.id },
+      data: { deloadUntil: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000) },
+    });
+    expect((await buildCoachPayload(user.id)).fatigue.deloadActive).toBe(true);
+
+    await db.user.update({
+      where: { id: user.id },
+      data: { deloadUntil: new Date(Date.now() - 24 * 60 * 60 * 1000) },
+    });
+    expect((await buildCoachPayload(user.id)).fatigue.deloadActive).toBe(false);
   });
 
   it('flags stalled lifts and recommends a deload at two stalls', async () => {

--- a/tests/integration/deload-route.test.ts
+++ b/tests/integration/deload-route.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { db } from '@/lib/db';
+import { getCurrentUserId } from '@/lib/auth';
+import { DELOAD_DURATION_DAYS } from '@/lib/deload';
+
+// Auth is read through getCurrentUserId (via requireApiUserId in @/lib/api).
+// Mock it so we can act as a given user without real cookies/JWTs.
+vi.mock('@/lib/auth', () => ({ getCurrentUserId: vi.fn() }));
+const mockUserId = vi.mocked(getCurrentUserId);
+
+import { POST, DELETE } from '@/app/api/deload/route';
+
+function actAs(userId: string | null) {
+  mockUserId.mockResolvedValue(userId);
+}
+
+function postReq(body: unknown = {}): Request {
+  return new Request('http://test.local/api/deload', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+async function makeUser(email: string) {
+  return db.user.create({ data: { email, passwordHash: 'x' } });
+}
+
+beforeEach(() => {
+  mockUserId.mockReset();
+});
+
+describe('POST /api/deload', () => {
+  it('starts a deload week ending about 7 days from now for the caller', async () => {
+    const user = await makeUser('deload-start@test.dev');
+    actAs(user.id);
+
+    const before = Date.now();
+    const res = await POST(postReq());
+    const after = Date.now();
+    expect(res.status).toBe(201);
+
+    const updated = await db.user.findUniqueOrThrow({ where: { id: user.id } });
+    expect(updated.deloadUntil).not.toBeNull();
+    const expectedMs = DELOAD_DURATION_DAYS * 24 * 60 * 60 * 1000;
+    expect(updated.deloadUntil!.getTime()).toBeGreaterThanOrEqual(before + expectedMs);
+    expect(updated.deloadUntil!.getTime()).toBeLessThanOrEqual(after + expectedMs);
+
+    const body = (await res.json()) as { deloadUntil: string };
+    expect(new Date(body.deloadUntil).getTime()).toBe(updated.deloadUntil!.getTime());
+  });
+
+  it("only touches the caller's own row, never another user's", async () => {
+    const owner = await makeUser('deload-owner@test.dev');
+    const stranger = await makeUser('deload-stranger@test.dev');
+    actAs(owner.id);
+
+    const res = await POST(postReq());
+    expect(res.status).toBe(201);
+
+    const untouched = await db.user.findUniqueOrThrow({ where: { id: stranger.id } });
+    expect(untouched.deloadUntil).toBeNull();
+  });
+
+  it('rejects a body with unexpected fields (no client-chosen duration)', async () => {
+    const user = await makeUser('deload-strict@test.dev');
+    actAs(user.id);
+
+    const res = await POST(postReq({ days: 90 }));
+    expect(res.status).toBe(400);
+    const unchanged = await db.user.findUniqueOrThrow({ where: { id: user.id } });
+    expect(unchanged.deloadUntil).toBeNull();
+  });
+
+  it('returns 401 when unauthenticated and persists nothing', async () => {
+    const user = await makeUser('deload-anon@test.dev');
+    actAs(null);
+
+    const res = await POST(postReq());
+    expect(res.status).toBe(401);
+    const unchanged = await db.user.findUniqueOrThrow({ where: { id: user.id } });
+    expect(unchanged.deloadUntil).toBeNull();
+  });
+});
+
+describe('DELETE /api/deload', () => {
+  it('clears the active deload for the caller only', async () => {
+    const future = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000);
+    const owner = await makeUser('deload-end@test.dev');
+    const stranger = await makeUser('deload-end-other@test.dev');
+    await db.user.update({ where: { id: owner.id }, data: { deloadUntil: future } });
+    await db.user.update({ where: { id: stranger.id }, data: { deloadUntil: future } });
+    actAs(owner.id);
+
+    const res = await DELETE();
+    expect(res.status).toBe(200);
+
+    const cleared = await db.user.findUniqueOrThrow({ where: { id: owner.id } });
+    expect(cleared.deloadUntil).toBeNull();
+    // The other user's planned deload is untouched.
+    const other = await db.user.findUniqueOrThrow({ where: { id: stranger.id } });
+    expect(other.deloadUntil?.getTime()).toBe(future.getTime());
+  });
+
+  it('is idempotent: deleting with no active deload still succeeds', async () => {
+    const user = await makeUser('deload-noop@test.dev');
+    actAs(user.id);
+
+    const res = await DELETE();
+    expect(res.status).toBe(200);
+    expect((await res.json()).deloadUntil).toBeNull();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    actAs(null);
+    const res = await DELETE();
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
Closes #112.

One-tap planned deload week, consent-first: the existing deload recommendation banner gains a "Start a deload week" button; the suggestion engine then carries it out for 7 days.

## What changed

- **Additive migration**: one nullable `User.deloadUntil` column, nothing else. Validated on the test DB: `prisma migrate deploy` applied cleanly and `prisma migrate diff` against the schema reports "No difference detected".
- **API**: `POST /api/deload` (Zod strict empty body, sets `deloadUntil = now + 7 days`) and `DELETE /api/deload` (clears it, idempotent). Both operate only on the authenticated user's own row.
- **Progression**: new `'planned-deload'` member of the `SuggestionReason` union. While active, `suggestNextWeight` steps the working load down by the existing `READINESS_DELOAD_FRACTION` (10%), taking precedence over a programmed increment and over a readiness hold, and never stacking with a readiness deload (one 10% reduction, never 19%). Expiry is pure: a past `deloadUntil` has no effect (`isDeloadActive`).
- **UI**: banner shows the end date and "End deload now" while active; the session runner shows a "Deload week" badge; the suggestion badge explains "Lighter - planned deload week" with long-form help text; the set input pre-fills the reduced load.
- **Coach payload**: `fatigue.deloadActive` (additive input signal; the `<adjustments>` output contract is untouched) plus an input-side prompt sentence so the coach supports the deload underway instead of recommending one.

## How I tested

`bash scripts/verify.sh --full` passed locally (prisma generate, lint, typecheck, unit, build, integration, E2E - the complex-feature gate). New tests at every touched layer:

- unit: planned-deload reason, precedence, no-stacking, expiry, schema strictness, prompt pinning, banner start/end actions, exercise-card explainer
- integration: deload route (set/clear, ownership, strict body, 401), coach payload `deloadActive` active/expired
- E2E: full banner flow - recommendation -> start -> active state -> end early (also serves as the run-it verification in the production build)