### PR TITLE
feat: ask the coach mid-session with live session context

### DIFF
--- a/app/(app)/chat/page.tsx
+++ b/app/(app)/chat/page.tsx
@@ -8,8 +8,28 @@ import {
   type ConversationSummary,
 } from '@/components/coach/chat-client';
 
-export default async function ChatPage() {
+interface SearchParams {
+  sessionId?: string;
+}
+
+export default async function ChatPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
   const auth = await requireSession();
+
+  // In-session chat (issue #111): the session runner links here with
+  // ?sessionId=... . Only forward an id that belongs to the caller; anything
+  // else degrades to a normal chat (the API re-checks ownership anyway).
+  let sessionId: string | null = null;
+  if (searchParams.sessionId) {
+    const owned = await db.session.findFirst({
+      where: { id: searchParams.sessionId, userId: auth.userId },
+      select: { id: true },
+    });
+    sessionId = owned?.id ?? null;
+  }
 
   const conversations = await db.conversation.findMany({
     where: { userId: auth.userId },
@@ -18,7 +38,9 @@ export default async function ChatPage() {
     select: { id: true, title: true, updatedAt: true },
   });
 
-  const active = conversations[0] ?? null;
+  // With a live session attached, start on a fresh conversation so the
+  // mid-workout question is not appended to an old thread.
+  const active = sessionId ? null : (conversations[0] ?? null);
   let initialMessages: ChatMessage[] = [];
   if (active) {
     const msgs = await db.message.findMany({
@@ -57,6 +79,7 @@ export default async function ChatPage() {
           initialConversations={initialConversations}
           initialActiveId={active?.id ?? null}
           initialMessages={initialMessages}
+          sessionId={sessionId}
           hasApiKey={provider.isConfigured()}
           providerLabel={provider.label}
           apiKeyEnvVar={provider.apiKeyEnvVar}

--- a/app/api/coach/chat/route.ts
+++ b/app/api/coach/chat/route.ts
@@ -4,13 +4,16 @@ import { db } from '@/lib/db';
 import { ApiError, handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
 import { rateLimit } from '@/lib/rate-limit';
 import { getLlmProvider, LlmError } from '@/lib/llm';
-import { buildCoachPayload } from '@/lib/coach';
+import { buildCoachPayload, buildCurrentSessionContext } from '@/lib/coach';
 import { CHAT_SYSTEM_PROMPT } from '@/lib/prompts/chat-system-prompt';
 import { deriveConversationTitle } from '@/lib/chat';
 
 const bodySchema = z.object({
   conversationId: z.string().cuid().optional(),
   message: z.string().trim().min(1).max(4000),
+  // In-session chat (issue #111): attaches the live workout as context. The
+  // session must belong to the caller; a foreign or unknown id is ignored.
+  sessionId: z.string().cuid().optional(),
 });
 
 // POST /api/coach/chat: appends a user message and streams the assistant reply
@@ -28,7 +31,7 @@ export async function POST(req: Request) {
       );
     }
 
-    const { conversationId: existingId, message } = await parseJsonBody(req, bodySchema);
+    const { conversationId: existingId, message, sessionId } = await parseJsonBody(req, bodySchema);
 
     let conversationId: string;
     if (existingId) {
@@ -62,6 +65,13 @@ export async function POST(req: Request) {
     }));
 
     const payload = await buildCoachPayload(userId);
+    // In-session context (issue #111): additive payload section, input-side
+    // only. Ownership is enforced in the builder (null for a foreign id), so
+    // the chat silently stays a normal chat on a bad sessionId.
+    if (sessionId) {
+      const currentSession = await buildCurrentSessionContext(userId, sessionId);
+      if (currentSession) payload.currentSession = currentSession;
+    }
     const system = `${CHAT_SYSTEM_PROMPT}\n\n# Trainee's current training data (JSON)\n${JSON.stringify(payload, null, 2)}`;
 
     const provider = getLlmProvider();

--- a/components/coach/chat-client.tsx
+++ b/components/coach/chat-client.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { Loader2, MessageSquarePlus, Send } from 'lucide-react';
+import { Dumbbell, Loader2, MessageSquarePlus, Send } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
@@ -23,6 +23,9 @@ interface Props {
   initialConversations: ConversationSummary[];
   initialActiveId: string | null;
   initialMessages: ChatMessage[];
+  // Live session attached from the session runner (issue #111), or null for a
+  // normal chat. Sent with each message so the coach sees the workout so far.
+  sessionId?: string | null;
   hasApiKey: boolean;
   providerLabel: string;
   apiKeyEnvVar: string;
@@ -32,6 +35,7 @@ export function ChatClient({
   initialConversations,
   initialActiveId,
   initialMessages,
+  sessionId = null,
   hasApiKey,
   providerLabel,
   apiKeyEnvVar,
@@ -74,7 +78,11 @@ export function ChatClient({
       const res = await fetch('/api/coach/chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ conversationId: activeId ?? undefined, message: text }),
+        body: JSON.stringify({
+          conversationId: activeId ?? undefined,
+          message: text,
+          sessionId: sessionId ?? undefined,
+        }),
       });
 
       if (!res.ok || !res.body) {
@@ -155,6 +163,17 @@ export function ChatClient({
         </div>
       )}
 
+      {sessionId && (
+        <div className="flex items-center gap-2 rounded-md border border-primary/30 bg-primary/5 p-3 text-sm">
+          <Dumbbell className="size-4 shrink-0 text-primary" />
+          <p className="text-xs text-muted-foreground">
+            <span className="font-medium text-foreground">Live session attached.</span>{' '}
+            The coach sees the sets you have logged so far and your program
+            targets for this workout.
+          </p>
+        </div>
+      )}
+
       <div className="flex items-center gap-2 overflow-x-auto pb-1">
         <Button
           type="button"
@@ -189,8 +208,9 @@ export function ChatClient({
       >
         {messages.length === 0 ? (
           <p className="m-auto max-w-sm text-center text-sm text-muted-foreground">
-            Ask your coach anything: how to break a plateau, whether your volume
-            is on track, how to adjust around an injury...
+            {sessionId
+              ? 'Mid-workout question? Ask about your next set, a load that feels off, or whether to swap an exercise.'
+              : 'Ask your coach anything: how to break a plateau, whether your volume is on track, how to adjust around an injury...'}
           </p>
         ) : (
           messages.map((m, i) => (

--- a/components/session/session-runner.tsx
+++ b/components/session/session-runner.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { ChevronLeft, ChevronRight, Flag, X } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Flag, MessageSquare, X } from 'lucide-react';
 import type {
   Exercise,
   Program,
@@ -376,6 +376,16 @@ export function SessionRunner({
             onAdd30={handleAdd30s}
           />
         )}
+
+        {/* In-session coach access (issue #111): opens the chat with this
+            session attached so the advice is grounded in the live workout.
+            Always available, never auto-triggered. */}
+        <Button variant="outline" size="sm" asChild className="min-h-tap">
+          <Link href={`/chat?sessionId=${session.id}`}>
+            <MessageSquare className="size-4" />
+            <span className="ml-2">Ask the coach</span>
+          </Link>
+        </Button>
 
         <div className="flex items-center justify-between gap-2 border-t border-border pt-4">
           <Button

--- a/lib/coach.ts
+++ b/lib/coach.ts
@@ -2,11 +2,13 @@ import { db } from '@/lib/db';
 import {
   applyBodyweight,
   best1RM,
+  effectiveWeight,
   exerciseProgress,
   isStalled,
   isoWeekStart,
   totalVolume,
 } from '@/lib/stats';
+import { READINESS_RECENCY_HOURS } from '@/lib/progression';
 import { goalProgress } from '@/lib/goals';
 import {
   DELOAD_READINESS_LOOKBACK,
@@ -54,6 +56,10 @@ export interface CoachPayload {
   // isStalled over the progress page's 12-week window, plus the program-level
   // deload recommendation from lib/deload.ts with its human-readable reasons.
   fatigue: FatigueSummary;
+  // The workout the user is in RIGHT NOW (issue #111), attached only when the
+  // chat is opened from the session runner with a session the user owns.
+  // Additive and input-side only; the output contract is unchanged.
+  currentSession?: CurrentSessionContext;
   // For each program exercise: the progression over the last 8 weeks
   // (max loads + 1RM per session, effective values with bodyweight included).
   recentProgress: Array<{
@@ -94,6 +100,46 @@ interface FatigueSummary {
   // supports the deload already underway instead of recommending one. Additive
   // input signal; the output contract is unchanged.
   deloadActive: boolean;
+}
+
+// Compact snapshot of the workout in progress (issue #111): what was logged so
+// far against the program targets, plus a fresh readiness check-in when one
+// exists. No history dump - the rest of the payload already carries recent
+// progress. Weights are effective loads (bodyweight included when applicable),
+// consistent with the rest of the payload.
+export interface CurrentSessionContext {
+  workoutName: string | null;
+  startedAt: string;
+  exercises: Array<{
+    exerciseName: string;
+    muscleGroup: string;
+    usesBodyweight: boolean;
+    // Program targets for this exercise in the running workout; null for an
+    // exercise logged ad hoc outside the plan.
+    target: {
+      targetSets: number;
+      targetRepsMin: number;
+      targetRepsMax: number;
+      targetRIR: number;
+      restSec: number;
+    } | null;
+    // Sets logged so far in this session, in order.
+    setsLogged: Array<{
+      setNumber: number;
+      weight: number;
+      reps: number;
+      rir: number | null;
+      isWarmup: boolean;
+      isDropSet: boolean;
+    }>;
+  }>;
+  // Today's readiness check-in (same recency window that auto-regulates the
+  // load suggestions), or null.
+  readinessToday: {
+    readiness: number;
+    sleepQuality: number;
+    soreness: Record<string, number> | null;
+  } | null;
 }
 
 interface ReadinessSummary {
@@ -613,6 +659,133 @@ async function fetchLatestReadiness(
     sleepQuality: checkin.sleepQuality,
     soreness,
     note: checkin.note,
+  };
+}
+
+// ============================================================
+// Live session context for the in-session chat (issue #111)
+// ============================================================
+
+// Builds the compact currentSession section. Ownership-checked: returns null
+// when the session does not exist or belongs to another user, so a tampered
+// sessionId silently degrades to a normal chat instead of erroring or leaking.
+export async function buildCurrentSessionContext(
+  userId: string,
+  sessionId: string,
+  now: Date = new Date(),
+): Promise<CurrentSessionContext | null> {
+  const [session, user] = await Promise.all([
+    db.session.findFirst({
+      where: { id: sessionId, userId },
+      include: {
+        workout: {
+          include: {
+            exercises: {
+              orderBy: { order: 'asc' },
+              include: {
+                exercise: {
+                  select: { id: true, name: true, muscleGroup: true, usesBodyweight: true },
+                },
+              },
+            },
+          },
+        },
+        sets: {
+          orderBy: [{ exerciseId: 'asc' }, { setNumber: 'asc' }],
+          include: {
+            exercise: {
+              select: { id: true, name: true, muscleGroup: true, usesBodyweight: true },
+            },
+          },
+        },
+      },
+    }),
+    db.user.findUnique({ where: { id: userId }, select: { bodyweight: true } }),
+  ]);
+  if (!session) return null;
+  const bodyweight = user?.bodyweight ?? null;
+
+  const setsByExercise = new Map<string, typeof session.sets>();
+  for (const s of session.sets) {
+    const arr = setsByExercise.get(s.exerciseId);
+    if (arr) arr.push(s);
+    else setsByExercise.set(s.exerciseId, [s]);
+  }
+
+  const serializeSets = (sets: typeof session.sets, usesBodyweight: boolean) =>
+    sets.map((s) => ({
+      setNumber: s.setNumber,
+      // Effective load, consistent with the rest of the payload.
+      weight: effectiveWeight(s.weight, usesBodyweight, bodyweight),
+      reps: s.reps,
+      rir: s.rir,
+      isWarmup: s.isWarmup,
+      isDropSet: s.isDropSet,
+    }));
+
+  // Planned exercises first, in workout order, then anything logged ad hoc.
+  const exercises: CurrentSessionContext['exercises'] = [];
+  const covered = new Set<string>();
+  for (const pe of session.workout?.exercises ?? []) {
+    covered.add(pe.exerciseId);
+    exercises.push({
+      exerciseName: pe.exercise.name,
+      muscleGroup: pe.exercise.muscleGroup,
+      usesBodyweight: pe.exercise.usesBodyweight,
+      target: {
+        targetSets: pe.targetSets,
+        targetRepsMin: pe.targetRepsMin,
+        targetRepsMax: pe.targetRepsMax,
+        targetRIR: pe.targetRIR,
+        restSec: pe.restSec,
+      },
+      setsLogged: serializeSets(
+        setsByExercise.get(pe.exerciseId) ?? [],
+        pe.exercise.usesBodyweight,
+      ),
+    });
+  }
+  for (const [exerciseId, sets] of setsByExercise) {
+    if (covered.has(exerciseId)) continue;
+    const first = sets[0];
+    if (!first) continue;
+    exercises.push({
+      exerciseName: first.exercise.name,
+      muscleGroup: first.exercise.muscleGroup,
+      usesBodyweight: first.exercise.usesBodyweight,
+      target: null,
+      setsLogged: serializeSets(sets, first.exercise.usesBodyweight),
+    });
+  }
+
+  // Today's check-in: same recency window that auto-regulates the in-session
+  // load suggestions, so the chat and the runner read the same signal.
+  const readinessSince = new Date(now.getTime() - READINESS_RECENCY_HOURS * 60 * 60 * 1000);
+  const checkin = await db.readinessCheckin.findFirst({
+    where: { userId, createdAt: { gte: readinessSince } },
+    orderBy: { createdAt: 'desc' },
+  });
+  let readinessToday: CurrentSessionContext['readinessToday'] = null;
+  if (checkin) {
+    let soreness: Record<string, number> | null = null;
+    if (checkin.soreness && typeof checkin.soreness === 'object' && !Array.isArray(checkin.soreness)) {
+      const entries = Object.entries(checkin.soreness as Record<string, unknown>).filter(
+        ([, v]) => typeof v === 'number',
+      ) as Array<[string, number]>;
+      if (entries.length > 0) soreness = Object.fromEntries(entries);
+    }
+    readinessToday = {
+      readiness: checkin.readiness,
+      sleepQuality: checkin.sleepQuality,
+      soreness,
+    };
+  }
+
+  return {
+    workoutName: session.workout?.name ?? null,
+    startedAt: session.startedAt.toISOString(),
+    exercises,
+    readinessToday,
   };
 }
 

--- a/lib/llm/demo.test.ts
+++ b/lib/llm/demo.test.ts
@@ -43,4 +43,29 @@ describe('demo provider', () => {
     });
     expect(chat.text.toLowerCase()).toContain('volume');
   });
+
+  // Issue #111: a live session in the appended payload selects the in-session
+  // canned answer, so the no-key flow demonstrates mid-workout coaching.
+  it('serves the in-session answer when the payload carries a currentSession section', async () => {
+    process.env.LLM_PROVIDER = 'demo';
+    const p = getLlmProvider();
+
+    const inSession = await p.complete({
+      // Mimics the chat route: stable prompt (mentions currentSession without
+      // quotes) + JSON payload where the quoted key appears.
+      system:
+        'You are GymCoach. When the JSON contains a currentSession section...\n{ "currentSession": { "workoutName": "Push" } }',
+      messages: [{ role: 'user', content: 'shoulder feels off' }],
+    });
+    expect(inSession.text).toContain('live session');
+    expect(inSession.text).not.toContain('<adjustments>');
+
+    // Without the quoted JSON key (prompt prose alone) it stays the normal
+    // chat answer - the marker must not false-positive on the stable prompt.
+    const normal = await p.complete({
+      system: 'You are GymCoach. When the JSON contains a currentSession section...',
+      messages: [{ role: 'user', content: 'x' }],
+    });
+    expect(normal.text.toLowerCase()).toContain('volume');
+  });
 });

--- a/lib/llm/demo.ts
+++ b/lib/llm/demo.ts
@@ -65,6 +65,16 @@ Solid week: 3 sessions logged, total working volume up about 4% versus last week
 ]
 </adjustments>`;
 
+// In-session chat (issue #111): canned answer keyed to the live-session
+// context so the no-key flow demonstrates mid-workout coaching.
+const CHAT_IN_SESSION = `Got it - looking at your live session.
+
+- **Right now**: your logged sets are at or above target reps, so the load is well chosen. Keep it for the remaining sets and stop at RIR 2.
+- **Shoulder caution**: if a press feels off, drop the load about 10% for the next set or swap to the next exercise in your plan and come back; never push through joint pain.
+- **Rest**: take the full programmed rest before the next set - rushing it costs reps.
+
+Log how the next set feels and ask me again if it does not improve.`;
+
 const CHAT = `Short version: your bench is moving and your chest volume is in a good spot.
 
 - **Bench press**: estimated 1RM is trending up (about +6% over the last 8 weeks) while your RIR stays around 2, so the stimulus is sustainable. Keep adding ~2.5 kg once you hit the top of the rep range on all sets.
@@ -121,6 +131,10 @@ const DEMO_PROGRAM = {
 function cannedResponse(system: string): string {
   if (system.includes('<adjustments>')) return DEBRIEF; // weekly debrief prompt
   if (system.includes('SINGLE JSON object')) return JSON.stringify(DEMO_PROGRAM, null, 2); // program generation prompt
+  // In-session chat: the appended payload JSON carries a "currentSession" key
+  // only when a live session is attached (the quoted form cannot appear in the
+  // stable prompt text, which mentions currentSession without quotes).
+  if (system.includes('"currentSession"')) return CHAT_IN_SESSION;
   return CHAT; // conversational coach
 }
 

--- a/lib/prompts/chat-system-prompt.test.ts
+++ b/lib/prompts/chat-system-prompt.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { CHAT_SYSTEM_PROMPT } from './chat-system-prompt';
+
+// Issue #111: the in-session context guidance is INPUT-side only. The chat
+// stays free-form text; it must never grow a structured output contract.
+
+describe('chat system prompt', () => {
+  it('tells the coach how to use the live currentSession section', () => {
+    expect(CHAT_SYSTEM_PROMPT).toMatch(/currentSession/);
+    expect(CHAT_SYSTEM_PROMPT).toMatch(/mid-workout/i);
+    expect(CHAT_SYSTEM_PROMPT).toMatch(/immediately actionable/i);
+    expect(CHAT_SYSTEM_PROMPT).toMatch(/staying within the user's program/i);
+  });
+
+  it('defines no structured output contract (free-form text only)', () => {
+    expect(CHAT_SYSTEM_PROMPT).not.toContain('<adjustments>');
+    expect(CHAT_SYSTEM_PROMPT).not.toMatch(/JSON object/i);
+  });
+});

--- a/lib/prompts/chat-system-prompt.ts
+++ b/lib/prompts/chat-system-prompt.ts
@@ -4,4 +4,6 @@ export const CHAT_SYSTEM_PROMPT = `You are GymCoach, an evidence-based strength 
 
 You are given the trainee's current training data as JSON (their profile, this week and last week of sessions, the active program, and recent per-exercise progression). Ground your answers in that data and be specific. Do not invent data that is not present; if something is missing, say so and ask.
 
+When the JSON contains a currentSession section, the trainee is talking to you FROM THE GYM, mid-workout: it shows the workout name, the sets logged so far against each exercise's program targets, and today's readiness check-in when there is one. Anchor your answer on that live session and make it immediately actionable for the next set or exercise - hold or reduce a load, adjust the rep target, reorder or skip an exercise, stop if something hurts - while staying within the user's program. Keep it short; the trainee is resting between sets.
+
 Be concise and practical, with short paragraphs and bullet lists when useful. Keep research citations brief when relevant (e.g. Schoenfeld, Helms, Israetel). Reply in the language the trainee writes in.`;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,7 +19,9 @@ export default defineConfig({
     trace: 'on-first-retry',
   },
   webServer: {
-    command: `DATABASE_URL='${TEST_DB}' JWT_SECRET='e2e-test-secret-at-least-32-characters' next start -p ${PORT}`,
+    // LLM_PROVIDER=demo serves canned coach responses, so the AI flows (chat,
+    // in-session chat) are E2E-testable without any API key (issue #111).
+    command: `DATABASE_URL='${TEST_DB}' JWT_SECRET='e2e-test-secret-at-least-32-characters' LLM_PROVIDER='demo' next start -p ${PORT}`,
     url: `http://localhost:${PORT}/login`,
     timeout: 120_000,
     reuseExistingServer: !process.env.CI,

--- a/tests/e2e/session-chat.spec.ts
+++ b/tests/e2e/session-chat.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// Ask the coach mid-session (issue #111): from the session runner, the lifter
+// opens the chat with the live session attached and gets an answer grounded in
+// it. The E2E server runs LLM_PROVIDER=demo, so the streamed reply is the
+// canned in-session response - which proves the currentSession section reached
+// the provider (the demo keys on the quoted "currentSession" payload marker).
+
+async function seedRunningSession(page: Page): Promise<string> {
+  const exerciseRes = await page.request.post('/api/exercises', {
+    data: { name: 'Chat Bench', muscleGroup: 'CHEST', category: 'COMPOUND' },
+  });
+  expect(exerciseRes.ok()).toBeTruthy();
+  const exercise = await exerciseRes.json();
+
+  const programRes = await page.request.post('/api/programs', {
+    data: { name: 'E2E Chat Program', phase: 'Base' },
+  });
+  expect(programRes.ok()).toBeTruthy();
+  const program = await programRes.json();
+
+  const workoutRes = await page.request.post(`/api/programs/${program.id}/workouts`, {
+    data: { name: 'Push day' },
+  });
+  expect(workoutRes.ok()).toBeTruthy();
+  const workout = await workoutRes.json();
+
+  const peRes = await page.request.post(`/api/workouts/${workout.id}/program-exercises`, {
+    data: {
+      exerciseId: exercise.id,
+      targetSets: 3,
+      targetRepsMin: 6,
+      targetRepsMax: 10,
+      targetRIR: 2,
+      restSec: 90,
+    },
+  });
+  expect(peRes.ok()).toBeTruthy();
+
+  const sessionRes = await page.request.post('/api/sessions', {
+    data: { workoutId: workout.id },
+  });
+  expect(sessionRes.ok()).toBeTruthy();
+  const session = await sessionRes.json();
+  return session.id as string;
+}
+
+test('a lifter can ask the coach mid-session with the live workout attached', async ({
+  page,
+}) => {
+  // Sign up through the API (fresh user each run; the response cookie lands in
+  // the shared browser context). A unique X-Forwarded-For keeps this spec in
+  // its own register rate-limit bucket: the suite's parallel UI signups
+  // already use up the 5/min per-IP budget, and this flow is not about signup.
+  const registerRes = await page.request.post('/api/auth/register', {
+    headers: { 'x-forwarded-for': '10.111.0.1' },
+    data: {
+      displayName: 'Chat E2E',
+      email: `e2e-session-chat-${Date.now()}@test.dev`,
+      password: 'supersecret',
+    },
+  });
+  expect(registerRes.ok()).toBeTruthy();
+  await page.goto('/');
+
+  const sessionId = await seedRunningSession(page);
+
+  // The session runner offers the in-session coach entry point.
+  await page.goto(`/session/${sessionId}`);
+  await expect(page.getByText('Chat Bench').first()).toBeVisible();
+  await page.getByRole('link', { name: 'Ask the coach' }).click();
+
+  // Chat opens with the live session attached and a fresh conversation.
+  await expect(page).toHaveURL(new RegExp(`/chat\\?sessionId=${sessionId}`));
+  await expect(page.getByText('Live session attached.')).toBeVisible();
+
+  // Ask a mid-workout question: the demo provider streams the in-session
+  // canned answer, proving the currentSession context reached the LLM call.
+  await page.getByPlaceholder('Message your coach...').fill('My shoulder feels off, what now?');
+  await page.getByPlaceholder('Message your coach...').press('Enter');
+  await expect(page.getByText('looking at your live session')).toBeVisible({ timeout: 15_000 });
+});

--- a/tests/integration/session-context.test.ts
+++ b/tests/integration/session-context.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from 'vitest';
+import { db } from '@/lib/db';
+import { buildCurrentSessionContext } from '@/lib/coach';
+import { READINESS_RECENCY_HOURS } from '@/lib/progression';
+
+// In-session chat context (issue #111): the compact currentSession section the
+// chat route attaches to the coach payload. Pure DB-derivation tests - the
+// route only forwards the result, and ownership lives in the builder.
+
+async function makeUser(email: string, bodyweight: number | null = null) {
+  return db.user.create({ data: { email, passwordHash: 'x', bodyweight } });
+}
+
+// One program -> workout with one planned exercise (bench), one ad-hoc
+// exercise (pull-ups, usesBodyweight) logged into the session on top of it.
+async function seedLiveSession(userId: string) {
+  const bench = await db.exercise.create({
+    data: { userId, name: 'Bench', muscleGroup: 'CHEST', category: 'COMPOUND' },
+  });
+  const pullups = await db.exercise.create({
+    data: {
+      userId,
+      name: 'Pull-ups',
+      muscleGroup: 'BACK_WIDTH',
+      category: 'COMPOUND',
+      usesBodyweight: true,
+    },
+  });
+  const program = await db.program.create({
+    data: { userId, name: 'P', phase: 'Base', isActive: true },
+  });
+  const workout = await db.workout.create({
+    data: { programId: program.id, name: 'Push day', order: 1 },
+  });
+  await db.programExercise.create({
+    data: {
+      workoutId: workout.id,
+      exerciseId: bench.id,
+      order: 1,
+      targetSets: 3,
+      targetRepsMin: 6,
+      targetRepsMax: 10,
+      targetRIR: 2,
+      restSec: 150,
+    },
+  });
+  const session = await db.session.create({
+    data: {
+      userId,
+      workoutId: workout.id,
+      startedAt: new Date('2026-06-11T10:00:00Z'),
+    },
+  });
+  await db.set.create({
+    data: {
+      sessionId: session.id,
+      exerciseId: bench.id,
+      setNumber: 1,
+      weight: 80,
+      reps: 8,
+      rir: 2,
+    },
+  });
+  await db.set.create({
+    data: {
+      sessionId: session.id,
+      exerciseId: bench.id,
+      setNumber: 2,
+      weight: 80,
+      reps: 7,
+      rir: 1,
+      isDropSet: false,
+    },
+  });
+  await db.set.create({
+    data: {
+      sessionId: session.id,
+      exerciseId: pullups.id,
+      setNumber: 1,
+      weight: 0,
+      reps: 10,
+      isWarmup: false,
+    },
+  });
+  return { session, workout, bench, pullups };
+}
+
+describe('buildCurrentSessionContext', () => {
+  it('returns the compact live-session shape: workout, targets, sets logged in order', async () => {
+    const user = await makeUser('ctx-shape@test.dev');
+    const { session } = await seedLiveSession(user.id);
+
+    const ctx = await buildCurrentSessionContext(user.id, session.id);
+    expect(ctx).not.toBeNull();
+    expect(ctx!.workoutName).toBe('Push day');
+    expect(ctx!.startedAt).toBe('2026-06-11T10:00:00.000Z');
+    expect(ctx!.readinessToday).toBeNull();
+
+    // Planned exercise first (with its program targets), ad-hoc one after
+    // (target null).
+    expect(ctx!.exercises.map((e) => e.exerciseName)).toEqual(['Bench', 'Pull-ups']);
+    const [benchCtx, pullupsCtx] = ctx!.exercises;
+    expect(benchCtx!.target).toEqual({
+      targetSets: 3,
+      targetRepsMin: 6,
+      targetRepsMax: 10,
+      targetRIR: 2,
+      restSec: 150,
+    });
+    expect(benchCtx!.setsLogged).toEqual([
+      { setNumber: 1, weight: 80, reps: 8, rir: 2, isWarmup: false, isDropSet: false },
+      { setNumber: 2, weight: 80, reps: 7, rir: 1, isWarmup: false, isDropSet: false },
+    ]);
+    expect(pullupsCtx!.target).toBeNull();
+    expect(pullupsCtx!.setsLogged).toHaveLength(1);
+  });
+
+  it('reports effective loads for bodyweight exercises when the bodyweight is known', async () => {
+    const user = await makeUser('ctx-bodyweight@test.dev', 82);
+    const { session } = await seedLiveSession(user.id);
+
+    const ctx = await buildCurrentSessionContext(user.id, session.id);
+    const pullupsCtx = ctx!.exercises.find((e) => e.exerciseName === 'Pull-ups');
+    // 0 added load + 82 kg bodyweight = 82 effective.
+    expect(pullupsCtx!.setsLogged[0]!.weight).toBe(82);
+    // Non-bodyweight loads are untouched.
+    const benchCtx = ctx!.exercises.find((e) => e.exerciseName === 'Bench');
+    expect(benchCtx!.setsLogged[0]!.weight).toBe(80);
+  });
+
+  it("ownership: returns null for another user's session and for an unknown id", async () => {
+    const owner = await makeUser('ctx-owner@test.dev');
+    const stranger = await makeUser('ctx-stranger@test.dev');
+    const { session } = await seedLiveSession(owner.id);
+
+    expect(await buildCurrentSessionContext(stranger.id, session.id)).toBeNull();
+    expect(await buildCurrentSessionContext(owner.id, 'cl0000000000000000000000')).toBeNull();
+  });
+
+  it('includes a fresh readiness check-in and ignores a stale one', async () => {
+    const user = await makeUser('ctx-readiness@test.dev');
+    const { session } = await seedLiveSession(user.id);
+    const now = new Date('2026-06-11T12:00:00Z');
+
+    // Stale: outside the recency window that auto-regulates suggestions.
+    await db.readinessCheckin.create({
+      data: {
+        userId: user.id,
+        readiness: 1,
+        sleepQuality: 1,
+        createdAt: new Date(now.getTime() - (READINESS_RECENCY_HOURS + 2) * 60 * 60 * 1000),
+      },
+    });
+    let ctx = await buildCurrentSessionContext(user.id, session.id, now);
+    expect(ctx!.readinessToday).toBeNull();
+
+    // Fresh: this morning's check-in rides along, soreness coerced to a map.
+    await db.readinessCheckin.create({
+      data: {
+        userId: user.id,
+        readiness: 3,
+        sleepQuality: 4,
+        soreness: { CHEST: 4 },
+        createdAt: new Date(now.getTime() - 2 * 60 * 60 * 1000),
+      },
+    });
+    ctx = await buildCurrentSessionContext(user.id, session.id, now);
+    expect(ctx!.readinessToday).toEqual({
+      readiness: 3,
+      sleepQuality: 4,
+      soreness: { CHEST: 4 },
+    });
+  });
+
+  it('handles a session without a workout (free session): no targets, sets still listed', async () => {
+    const user = await makeUser('ctx-free@test.dev');
+    const exercise = await db.exercise.create({
+      data: { userId: user.id, name: 'Curl', muscleGroup: 'BICEPS', category: 'ISOLATION' },
+    });
+    const session = await db.session.create({ data: { userId: user.id } });
+    await db.set.create({
+      data: { sessionId: session.id, exerciseId: exercise.id, setNumber: 1, weight: 20, reps: 12 },
+    });
+
+    const ctx = await buildCurrentSessionContext(user.id, session.id);
+    expect(ctx!.workoutName).toBeNull();
+    expect(ctx!.exercises).toEqual([
+      {
+        exerciseName: 'Curl',
+        muscleGroup: 'BICEPS',
+        usesBodyweight: false,
+        target: null,
+        setsLogged: [
+          { setNumber: 1, weight: 20, reps: 12, rir: null, isWarmup: false, isDropSet: false },
+        ],
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #111.

The AI half of the last roadmap item ("In-session AI suggestions"): the lifter can ask the coach a question during a workout and the coach answers with the live session in front of it. No new chat implementation - this connects the session runner to the existing streaming chat.

## What changed

- **Entry point**: "Ask the coach" button in the session runner -> `/chat?sessionId=...`. Always available during a session; nothing auto-triggers.
- **Payload**: `buildCurrentSessionContext` (lib/coach.ts) builds an additive, compact `currentSession` section - workout name, started-at, per-exercise sets logged so far (effective loads, bodyweight included) against the program targets, plus today's readiness check-in (same recency window as the load suggestions). Ownership-checked: a foreign or unknown sessionId returns null and the chat silently stays a normal chat. The chat route accepts an optional Zod-validated `sessionId` (cuid) and attaches the section; the chat page only forwards an owned session id and starts a fresh conversation when one is attached.
- **Prompt**: input-side paragraph only, telling the coach the trainee is mid-workout and advice must be immediately actionable within the program. NO structured output contract anywhere in chat - the `<adjustments>` contract and every other output contract are untouched, proven by the existing contract tests passing unmodified.
- **Demo provider**: new canned in-session answer keyed to the quoted `"currentSession"` payload marker, so the no-key flow exercises the feature. The Playwright web server now runs `LLM_PROVIDER='demo'`, which makes the full streamed flow E2E-testable.

## How I tested

`bash scripts/verify.sh --full` passed locally. New tests at every touched layer:

- unit: chat prompt pinning (currentSession guidance present, no output contract), demo provider routing (in-session marker, no false positive on the stable prompt text)
- integration: `buildCurrentSessionContext` shape (targets, set order, ad-hoc exercises), effective bodyweight loads, ownership (foreign/unknown id -> null), readiness recency window, free sessions without a workout
- E2E: full flow - session runner -> Ask the coach -> "Live session attached" -> send a question -> the demo in-session answer streams back (proves the section reached the provider); the new spec registers via API with its own rate-limit bucket so the suite stays under the signup limit

One existing-file test change worth noting: none of the existing assertions were modified; only new tests were added.