### PR TITLE
feat: import training history from a Hevy CSV export

### DIFF
--- a/app/api/import/hevy/route.ts
+++ b/app/api/import/hevy/route.ts
@@ -1,0 +1,137 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { ApiError, handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
+import { rateLimit } from '@/lib/rate-limit';
+import { hevyImportInputSchema } from '@/lib/schemas/import';
+import { HEVY_CSV_MAX_BYTES, parseHevyCsv } from '@/lib/import/hevy-csv';
+import {
+  buildStrongImportPlan,
+  executeStrongImport,
+  setDuplicateKey,
+} from '@/lib/import/strong-import';
+
+// How many per-line errors the response reports (the count is always exact).
+const MAX_REPORTED_ERRORS = 50;
+
+// POST /api/import/hevy: import a Hevy app CSV export (issue #113). Mirrors
+// /api/import/strong - which stays untouched - with the Hevy parser in front
+// of the shared planner/executor. mode=preview parses and plans without
+// writing anything; mode=confirm performs the import inside one transaction.
+// The file content is untrusted: hard caps, Zod on every value (in the parser
+// and on the body), and no write outside the transaction.
+export async function POST(req: Request) {
+  try {
+    const userId = await requireApiUserId();
+
+    // Shared budget with the Strong route: one import allowance per user.
+    const rl = rateLimit(`import:${userId}`, 10, 60_000);
+    if (!rl.ok) {
+      throw new ApiError(429, `Too many import requests. Retry in ${rl.retryAfterSec}s.`);
+    }
+
+    // Cheap early reject on a declared oversize. The header is advisory only
+    // (absent on chunked bodies, possibly malformed); the real control is the
+    // streamed byte cap inside parseJsonBody below.
+    const contentLength = Number(req.headers.get('content-length') ?? 0);
+    if (contentLength > HEVY_CSV_MAX_BYTES * 1.5) {
+      throw new ApiError(413, 'File too large: the limit is 5 MB.');
+    }
+
+    const data = await parseJsonBody(req, hevyImportInputSchema, {
+      // 1.5x leaves room for the JSON envelope and string escaping around the
+      // 5 MB CSV payload itself (which the schema caps exactly).
+      maxBytes: HEVY_CSV_MAX_BYTES * 1.5,
+    });
+    const parsed = parseHevyCsv(data.csv);
+    if (!parsed.ok) {
+      throw new ApiError(400, parsed.fatalError ?? 'Unreadable file.');
+    }
+
+    // Existing data on the imported days, for duplicate skipping and the
+    // "you already trained that day" preview warning.
+    const dateKeys = [...new Set(parsed.rows.map((r) => r.dateKey))].sort();
+    const existingSetKeys = new Set<string>();
+    const existingSessionDates = new Set<string>();
+    if (dateKeys.length > 0) {
+      const rangeStart = new Date(`${dateKeys[0]}T00:00:00.000Z`);
+      const rangeEnd = new Date(`${dateKeys[dateKeys.length - 1]}T00:00:00.000Z`);
+      rangeEnd.setUTCDate(rangeEnd.getUTCDate() + 1);
+      const sessions = await db.session.findMany({
+        where: { userId, startedAt: { gte: rangeStart, lt: rangeEnd } },
+        select: {
+          startedAt: true,
+          sets: {
+            select: {
+              setNumber: true,
+              weight: true,
+              reps: true,
+              exercise: { select: { name: true } },
+            },
+          },
+        },
+      });
+      for (const session of sessions) {
+        const dateKey = session.startedAt.toISOString().slice(0, 10);
+        existingSessionDates.add(dateKey);
+        for (const set of session.sets) {
+          existingSetKeys.add(
+            setDuplicateKey(dateKey, set.exercise.name, set.setNumber, set.weight, set.reps),
+          );
+        }
+      }
+    }
+
+    const exercises = await db.exercise.findMany({
+      where: { userId },
+      select: { name: true },
+    });
+    const plan = buildStrongImportPlan(
+      parsed.rows,
+      exercises.map((e) => e.name),
+      existingSetKeys,
+    );
+
+    const common = {
+      duplicatesSkipped: plan.duplicateCount,
+      cardioSkipped: parsed.cardioSkipped,
+      errorCount: parsed.errors.length,
+      errors: parsed.errors.slice(0, MAX_REPORTED_ERRORS),
+    };
+
+    if (data.mode === 'preview') {
+      return NextResponse.json({
+        mode: 'preview',
+        sessions: plan.sessions.length,
+        sets: plan.totalSets,
+        newExercises: plan.newExerciseNames,
+        existingSessionDates: [...existingSessionDates]
+          .filter((d) => dateKeys.includes(d))
+          .sort(),
+        ...common,
+      });
+    }
+
+    if (plan.totalSets === 0) {
+      throw new ApiError(400, 'Nothing to import: no valid, non-duplicate set found.');
+    }
+
+    // One transaction per import: a failure anywhere rolls back every row.
+    // A multi-year export creates hundreds of sessions in sequential writes,
+    // so the 5 s Prisma default timeout would abort exactly the imports this
+    // feature exists for.
+    const result = await db.$transaction(
+      async (tx) => executeStrongImport(tx, userId, plan, 'Hevy'),
+      { timeout: 60_000, maxWait: 5_000 },
+    );
+
+    return NextResponse.json({
+      mode: 'confirm',
+      createdSessions: result.createdSessions,
+      createdSets: result.createdSets,
+      createdExercises: result.createdExercises,
+      ...common,
+    });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/components/settings/import-section.tsx
+++ b/components/settings/import-section.tsx
@@ -44,18 +44,54 @@ interface Preview {
   errors: LineError[];
 }
 
-// Strong CSV import (issue #100): pick the export file, dry-run preview
-// (counts + per-line errors, nothing written), then explicitly confirm.
+type ImportFormat = 'STRONG' | 'HEVY';
+
+// Copy and endpoint per supported source app. Strong keeps its unit toggle
+// (its export follows the app's unit setting); Hevy always exports kg, so the
+// toggle is hidden for it.
+const FORMAT_META: Record<
+  ImportFormat,
+  { label: string; endpoint: string; exportHint: string; hasUnitToggle: boolean }
+> = {
+  STRONG: {
+    label: 'Strong',
+    endpoint: '/api/import/strong',
+    exportHint: 'export it as CSV (Settings, then Export data)',
+    hasUnitToggle: true,
+  },
+  HEVY: {
+    label: 'Hevy',
+    endpoint: '/api/import/hevy',
+    exportHint: 'export it as CSV (Settings, then Export & Import Data)',
+    hasUnitToggle: false,
+  },
+};
+
+// CSV import from another tracker (issues #100/#113): pick the source app and
+// the export file, dry-run preview (counts + per-line errors, nothing
+// written), then explicitly confirm.
 export function ImportSection() {
   const fileRef = useRef<HTMLInputElement>(null);
+  const [format, setFormat] = useState<ImportFormat>('STRONG');
   const [unit, setUnit] = useState<'KG' | 'LB'>('KG');
   const [fileName, setFileName] = useState<string | null>(null);
   const [csvText, setCsvText] = useState<string | null>(null);
   const [preview, setPreview] = useState<Preview | null>(null);
   const [busy, setBusy] = useState(false);
 
+  const meta = FORMAT_META[format];
+
   function pickFile() {
     fileRef.current?.click();
+  }
+
+  function switchFormat(next: ImportFormat) {
+    if (busy) return;
+    setFormat(next);
+    // A pending preview was produced by the other parser; drop it.
+    setCsvText(null);
+    setFileName(null);
+    setPreview(null);
   }
 
   async function onFilePicked(e: React.ChangeEvent<HTMLInputElement>) {
@@ -74,10 +110,14 @@ export function ImportSection() {
   }
 
   async function callApi(csv: string, mode: 'preview' | 'confirm') {
-    const res = await fetch('/api/import/strong', {
+    const res = await fetch(meta.endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ csv, unit, mode }),
+      // The Hevy route has no unit field (kg always); sending it would be
+      // rejected by Zod only if unknown keys were stripped - keep it clean.
+      body: JSON.stringify(
+        meta.hasUnitToggle ? { csv, unit, mode } : { csv, mode },
+      ),
     });
     const json = (await res.json().catch(() => null)) as
       | (Preview & {
@@ -137,26 +177,43 @@ export function ImportSection() {
   return (
     <Card>
       <CardHeader className="pb-3">
-        <h2 className="text-base font-semibold">Import from Strong</h2>
+        <h2 className="text-base font-semibold">Import from {meta.label}</h2>
         <p className="text-xs text-muted-foreground">
-          Bring your training history from the Strong app: export it as CSV
-          (Settings, then Export data), preview it here, then confirm.
+          Bring your training history from the {meta.label} app:{' '}
+          {meta.exportHint}, preview it here, then confirm.
         </p>
       </CardHeader>
       <CardContent className="flex flex-col gap-3">
         <div className="flex items-end gap-2">
           <div className="space-y-1">
-            <Label htmlFor="strong-unit">Strong weight unit</Label>
-            <Select value={unit} onValueChange={(v) => setUnit(v as 'KG' | 'LB')}>
-              <SelectTrigger id="strong-unit" className="h-9 w-28">
+            <Label htmlFor="import-format">Source app</Label>
+            <Select
+              value={format}
+              onValueChange={(v) => switchFormat(v as ImportFormat)}
+            >
+              <SelectTrigger id="import-format" className="h-9 w-28">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="KG">kg</SelectItem>
-                <SelectItem value="LB">lb</SelectItem>
+                <SelectItem value="STRONG">Strong</SelectItem>
+                <SelectItem value="HEVY">Hevy</SelectItem>
               </SelectContent>
             </Select>
           </div>
+          {meta.hasUnitToggle && (
+            <div className="space-y-1">
+              <Label htmlFor="strong-unit">Strong weight unit</Label>
+              <Select value={unit} onValueChange={(v) => setUnit(v as 'KG' | 'LB')}>
+                <SelectTrigger id="strong-unit" className="h-9 w-28">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="KG">kg</SelectItem>
+                  <SelectItem value="LB">lb</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          )}
           <Button
             variant="outline"
             onClick={pickFile}
@@ -168,7 +225,7 @@ export function ImportSection() {
             ) : (
               <FileUp className="size-4" />
             )}
-            <span className="ml-2">Choose a Strong CSV file</span>
+            <span className="ml-2">Choose a {meta.label} CSV file</span>
           </Button>
         </div>
         <input

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -6,7 +6,62 @@ by the charter in [`07-autonomy.md`](07-autonomy.md).
 
 ---
 
-## 2026-06-10 (evening) - Maintainer run: shipped #99, #101, #100 (fourth ideate batch)
+## 2026-06-11 - Maintainer run: shipped #112, #111, #113 (fifth ideate batch)
+
+**Context.** Maintainer tick over the fifth ideate batch, strictly serialized (lesson L7:
+the next issue's branch is cut only after the prior PR is MERGED). All three issues
+trust-gated (author `JulienAu`). All three are complex features under the 2026-06-10
+directive: each ran `verify.sh --full` locally before its PR and shipped tests at every
+touched layer (unit + integration + E2E). Merge budget 3; used 3.
+
+**Shipped.**
+- **#112 -> PR #115 (merged): one-tap deload week.** Additive nullable `User.deloadUntil`
+  migration (validated on :5434: `migrate deploy` + clean `migrate diff`; rollback baseline
+  `autonomy-baseline-2026-06-11` tagged on main before the merge). POST/DELETE
+  `/api/deload` (strict-empty-object Zod body so no client-chosen duration; operates only
+  on the caller's own row). New `'planned-deload'` suggestion reason: 10% step-down using
+  the existing `READINESS_DELOAD_FRACTION`, precedence over a programmed increment and a
+  readiness hold, never stacking with a readiness deload (one reduction, pinned by unit
+  tests). Banner start/end buttons, session-runner badge + explainer, coach payload
+  `fatigue.deloadActive` (additive; output contract untouched). One local gate red: an
+  existing exact-shape payload test needed the additive field - acknowledged and updated
+  with an extra active/expired case.
+- **#111 -> PR #116 (merged): ask the coach mid-session.** "Ask the coach" button in the
+  session runner -> `/chat?sessionId=...`. Chat payload gains the additive, compact,
+  ownership-checked `currentSession` section (`buildCurrentSessionContext` returns null
+  for a foreign/unknown id - the chat silently degrades). Prompt addition is input-side
+  ONLY; every structured output contract is unchanged and the existing contract tests
+  passed unmodified. Demo provider serves a canned in-session answer keyed on the quoted
+  `"currentSession"` payload marker, and the Playwright web server now runs
+  `LLM_PROVIDER=demo`, so the no-key flow is E2E-covered end to end (the canned answer
+  streaming back proves the live context reached the provider). One local gate red: the
+  suite's 6th parallel UI signup tripped the 5/min register rate limit - the new spec now
+  registers via the API in its own X-Forwarded-For bucket (test-side fix; the limit itself
+  is untouched).
+- **#113 -> PR #117 (this PR): Hevy CSV import.** Second import format behind the same
+  untrusted-input bar as #105: shared caps + RFC4180 reader extracted verbatim to
+  `lib/import/csv.ts` (Strong parser tests pass unmodified), new `hevy-csv.ts` parser
+  (set_type warmup/dropset mapping, both documented timestamp formats, lbs header variant,
+  0-based set_index hardened against silent defaults), planner/executor generalized with
+  optional flags/times that keep the Strong path byte-identical (pinned by a regression
+  test), mirrored `/api/import/hevy` route (streamed body cap, shared rate-limit budget,
+  dry-run preview, transactional confirm, duplicate skip), settings source-app selector
+  (unit toggle stays Strong-only).
+
+**Challenged.** No subagent-spawning tool exists in this environment, so the charter's
+independence requirement could not be met in-run: each PR got an inline multi-lens review
+pass by the author (correctness + does-it-actually-work; + security for #113) on top of the
+green full gate, and per the charter all three merges are flagged for an independent
+POST-MERGE review by the orchestrator as the next action. Findings worth recording from the
+inline passes: the deload step-down on negative (assisted) loads reduces assistance (a
+pre-existing semantic of the readiness deload, not a regression - candidate for a future
+issue), and an active deload cannot be ended early from the progress page when the user has
+no recent training data (bounded: it self-expires).
+
+**Deferred to a human / next run.**
+- Independent post-merge review of #115, #116, #117 (charter "Subagent challenge protocol"
+  backstop, lesson L8).
+- Possible product issue: deload semantics for assisted (negative-load) exercises.
 
 **Context.** Maintainer tick over the fourth ideate batch, strictly serialized (lesson L7:
 next issue only after the prior PR is MERGED). All three issues trust-gated (author

--- a/lib/import/csv.ts
+++ b/lib/import/csv.ts
@@ -1,0 +1,102 @@
+// ============================================================
+// Shared CSV import plumbing (issues #100/#113) - pure, no DB
+// ============================================================
+// The low-level reader and the hard caps shared by every CSV import format
+// (Strong, Hevy). The file content is UNTRUSTED user data: no eval, hard size
+// and row caps, single-pass reading with no regex backtracking.
+
+// Hard caps on the untrusted input, shared by all import formats.
+export const IMPORT_CSV_MAX_BYTES = 5 * 1024 * 1024; // 5 MB of text
+export const IMPORT_CSV_MAX_ROWS = 50000; // data rows, header excluded
+
+// One malformed line, reported instead of failing the whole file.
+export interface CsvLineError {
+  // 1-based line number in the file (header is line 1).
+  line: number;
+  reason: string;
+}
+
+// ------------------------------------------------------------
+// Minimal RFC4180-style CSV reader (quoted fields, "" escapes, quoted
+// newlines, CRLF). Returns one string[] per record plus the 1-based line
+// number the record starts on. No regex backtracking, single pass.
+// ------------------------------------------------------------
+export function readCsvRecords(text: string): Array<{ line: number; fields: string[] }> {
+  const records: Array<{ line: number; fields: string[] }> = [];
+  let fields: string[] = [];
+  let field = '';
+  let inQuotes = false;
+  let line = 1;
+  let recordStartLine = 1;
+  let recordHasContent = false;
+
+  const pushField = () => {
+    fields.push(field);
+    field = '';
+  };
+  const pushRecord = () => {
+    pushField();
+    // Skip records that are entirely empty (blank lines).
+    if (recordHasContent || fields.length > 1 || (fields[0] ?? '') !== '') {
+      records.push({ line: recordStartLine, fields });
+    }
+    fields = [];
+    recordHasContent = false;
+    recordStartLine = line;
+  };
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]!;
+    if (inQuotes) {
+      if (ch === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        if (ch === '\n') line++;
+        field += ch;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inQuotes = true;
+      recordHasContent = true;
+    } else if (ch === ',') {
+      pushField();
+      recordHasContent = true;
+    } else if (ch === '\n') {
+      line++;
+      pushRecord();
+    } else if (ch === '\r') {
+      // Swallow; the following \n (if any) ends the record.
+      if (text[i + 1] !== '\n') {
+        line++;
+        pushRecord();
+      }
+    } else {
+      field += ch;
+      recordHasContent = true;
+    }
+  }
+  // Final record without a trailing newline.
+  if (recordHasContent || field !== '' || fields.length > 0) pushRecord();
+  return records;
+}
+
+// Normalize a header cell for matching: lowercase, trimmed, collapsed spaces.
+export function headerKey(cell: string): string {
+  return cell.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+// Lenient numeric cell reader: empty/absent reads as 0, garbage as NaN (so
+// Zod rejects it downstream with a per-line error).
+export function asNumber(cell: string | undefined): number {
+  if (cell === undefined) return 0;
+  const trimmed = cell.trim();
+  if (trimmed === '') return 0;
+  const n = Number(trimmed);
+  return Number.isFinite(n) ? n : NaN;
+}

--- a/lib/import/hevy-csv.test.ts
+++ b/lib/import/hevy-csv.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect } from 'vitest';
+import {
+  HEVY_CSV_MAX_BYTES,
+  HEVY_CSV_MAX_ROWS,
+  parseHevyCsv,
+  parseHevyTimestamp,
+} from './hevy-csv';
+
+const HEADER =
+  'title,start_time,end_time,description,exercise_title,superset_id,exercise_notes,set_index,set_type,weight_kg,reps,distance_km,duration_seconds,rpe';
+
+function csv(...lines: string[]) {
+  return [HEADER, ...lines].join('\n');
+}
+
+// One data line with sensible defaults, field-overridable.
+function line(over: Partial<Record<string, string>> = {}) {
+  const f = {
+    title: 'Push Day',
+    start_time: '2026-05-02 09:13:00',
+    end_time: '2026-05-02 10:05:00',
+    description: '',
+    exercise_title: 'Bench Press (Barbell)',
+    superset_id: '',
+    exercise_notes: '',
+    set_index: '0',
+    set_type: 'normal',
+    weight_kg: '80',
+    reps: '8',
+    distance_km: '',
+    duration_seconds: '',
+    rpe: '',
+    ...over,
+  };
+  return [
+    f.title, f.start_time, f.end_time, f.description, f.exercise_title,
+    f.superset_id, f.exercise_notes, f.set_index, f.set_type, f.weight_kg,
+    f.reps, f.distance_km, f.duration_seconds, f.rpe,
+  ].join(',');
+}
+
+describe('parseHevyTimestamp', () => {
+  it('parses the newer ISO-like format with and without seconds', () => {
+    expect(parseHevyTimestamp('2026-05-02 09:13:00')).toEqual({
+      dateKey: '2026-05-02',
+      iso: '2026-05-02T09:13:00.000Z',
+    });
+    expect(parseHevyTimestamp('2026-05-02 09:13')?.iso).toBe('2026-05-02T09:13:00.000Z');
+  });
+
+  it('parses the older "07 Jan 2024, 17:15" format', () => {
+    expect(parseHevyTimestamp('07 Jan 2024, 17:15')).toEqual({
+      dateKey: '2024-01-07',
+      iso: '2024-01-07T17:15:00.000Z',
+    });
+  });
+
+  it('rejects garbage and impossible dates/times', () => {
+    expect(parseHevyTimestamp('not-a-date')).toBeNull();
+    expect(parseHevyTimestamp('2026-13-40 09:00:00')).toBeNull();
+    expect(parseHevyTimestamp('2026-05-02 25:00:00')).toBeNull();
+    expect(parseHevyTimestamp('07 Foo 2024, 17:15')).toBeNull();
+    expect(parseHevyTimestamp('')).toBeNull();
+  });
+});
+
+describe('parseHevyCsv happy path', () => {
+  it('parses working sets into normalized rows with real times', () => {
+    const res = parseHevyCsv(csv(line({ set_index: '0' }), line({ set_index: '1', reps: '7' })));
+    expect(res.ok).toBe(true);
+    expect(res.errors).toEqual([]);
+    expect(res.rows).toEqual([
+      {
+        dateKey: '2026-05-02',
+        workoutName: 'Push Day',
+        exerciseName: 'Bench Press (Barbell)',
+        setOrder: 1,
+        weightKg: 80,
+        reps: 8,
+        isWarmup: false,
+        isDropSet: false,
+        startedAtIso: '2026-05-02T09:13:00.000Z',
+        finishedAtIso: '2026-05-02T10:05:00.000Z',
+      },
+      {
+        dateKey: '2026-05-02',
+        workoutName: 'Push Day',
+        exerciseName: 'Bench Press (Barbell)',
+        setOrder: 2,
+        weightKg: 80,
+        reps: 7,
+        isWarmup: false,
+        isDropSet: false,
+        startedAtIso: '2026-05-02T09:13:00.000Z',
+        finishedAtIso: '2026-05-02T10:05:00.000Z',
+      },
+    ]);
+  });
+
+  it('maps set_type warmup and dropset onto the set flags', () => {
+    const res = parseHevyCsv(
+      csv(
+        line({ set_type: 'warmup', weight_kg: '40' }),
+        line({ set_index: '1', set_type: 'dropset', weight_kg: '60' }),
+        line({ set_index: '2', set_type: 'failure' }),
+      ),
+    );
+    expect(res.rows.map((r) => [r.isWarmup, r.isDropSet])).toEqual([
+      [true, false],
+      [false, true],
+      [false, false],
+    ]);
+  });
+
+  it('handles quoted fields with commas and escaped quotes', () => {
+    const res = parseHevyCsv(
+      csv(line({ title: '"Push, heavy"', exercise_title: '"Press ""Smith"" machine"' })),
+    );
+    expect(res.rows[0]?.workoutName).toBe('Push, heavy');
+    expect(res.rows[0]?.exerciseName).toBe('Press "Smith" machine');
+  });
+
+  it('tolerates extra columns and a different column order', () => {
+    const res = parseHevyCsv(
+      [
+        'exercise_title,reps,weight_kg,set_index,start_time,title,custom_col',
+        'Row,10,70,0,2026-05-03 18:00:00,Pull,x',
+      ].join('\n'),
+    );
+    expect(res.ok).toBe(true);
+    expect(res.rows[0]).toMatchObject({
+      exerciseName: 'Row',
+      weightKg: 70,
+      setOrder: 1,
+      finishedAtIso: null,
+    });
+  });
+
+  it('accepts an empty weight as 0 (bodyweight movement)', () => {
+    const res = parseHevyCsv(csv(line({ weight_kg: '', exercise_title: 'Pull-ups' })));
+    expect(res.rows[0]?.weightKg).toBe(0);
+  });
+
+  it('converts the weight_lbs header variant to kg', () => {
+    const res = parseHevyCsv(
+      [
+        'title,start_time,exercise_title,set_index,weight_lbs,reps',
+        'Push,2026-05-02 09:00:00,Bench,0,225,5',
+      ].join('\n'),
+    );
+    expect(res.ok).toBe(true);
+    expect(res.rows[0]?.weightKg).toBeCloseTo(102.06, 2);
+  });
+
+  it('accepts the older timestamp format end to end', () => {
+    const res = parseHevyCsv(
+      csv(line({ start_time: '"07 Jan 2024, 17:15"', end_time: '"07 Jan 2024, 18:02"' })),
+    );
+    expect(res.rows[0]).toMatchObject({
+      dateKey: '2024-01-07',
+      startedAtIso: '2024-01-07T17:15:00.000Z',
+      finishedAtIso: '2024-01-07T18:02:00.000Z',
+    });
+  });
+});
+
+describe('parseHevyCsv malformed input', () => {
+  it('rejects an unrecognized header as fatal', () => {
+    const res = parseHevyCsv('foo,bar\n1,2');
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toMatch(/unrecognized format/i);
+    expect(res.rows).toEqual([]);
+  });
+
+  it('rejects an empty file as fatal', () => {
+    expect(parseHevyCsv('').ok).toBe(false);
+  });
+
+  it('collects per-line errors with line numbers instead of throwing', () => {
+    const res = parseHevyCsv(
+      csv(
+        line({ start_time: 'not-a-date' }), // line 2: bad start time
+        line({ set_index: 'one' }), // line 3: bad set index
+        line({ set_index: '1' }), // line 4: fine
+        line({ set_index: '' }), // line 5: missing set index must not default
+        line({ weight_kg: '9999' }), // line 6: weight above cap
+        line({ exercise_title: '' }), // line 7: empty exercise
+      ),
+    );
+    expect(res.ok).toBe(true);
+    expect(res.rows).toHaveLength(1);
+    expect(res.errors.map((e) => e.line)).toEqual([2, 3, 5, 6, 7]);
+  });
+
+  it('degrades a malformed end_time to null instead of failing the row', () => {
+    const res = parseHevyCsv(csv(line({ end_time: 'garbage' })));
+    expect(res.errors).toEqual([]);
+    expect(res.rows[0]?.finishedAtIso).toBeNull();
+  });
+
+  it('skips cardio rows (duration or distance, no reps) with a count', () => {
+    const res = parseHevyCsv(
+      csv(
+        line({ exercise_title: 'Running', reps: '', distance_km: '5', duration_seconds: '1800', weight_kg: '' }),
+        line({ exercise_title: 'Plank', reps: '', duration_seconds: '60', weight_kg: '' }),
+        line({ set_index: '1' }),
+      ),
+    );
+    expect(res.cardioSkipped).toBe(2);
+    expect(res.rows).toHaveLength(1);
+    expect(res.errors).toEqual([]);
+  });
+
+  it('reports a 0-rep row with no duration as an error, not cardio', () => {
+    const res = parseHevyCsv(csv(line({ reps: '0' })));
+    expect(res.cardioSkipped).toBe(0);
+    expect(res.errors).toHaveLength(1);
+  });
+});
+
+describe('parseHevyCsv caps (untrusted input)', () => {
+  it('rejects a file above the size cap', () => {
+    const big = 'a'.repeat(HEVY_CSV_MAX_BYTES + 1);
+    const res = parseHevyCsv(big);
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toMatch(/too large/i);
+  });
+
+  it('rejects a file above the row cap', () => {
+    const lines = new Array(HEVY_CSV_MAX_ROWS + 1).fill('x');
+    const res = parseHevyCsv(csv(...lines));
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toMatch(/too many rows/i);
+  });
+
+  it('never evaluates content: a formula-looking cell is just an inert string', () => {
+    const res = parseHevyCsv(csv(line({ exercise_title: '=cmd|calc' })));
+    expect(res.rows[0]?.exerciseName).toBe('=cmd|calc');
+  });
+});

--- a/lib/import/hevy-csv.ts
+++ b/lib/import/hevy-csv.ts
@@ -1,0 +1,269 @@
+import { z } from 'zod';
+import { lbToKg, roundWeight } from '@/lib/units';
+import {
+  asNumber,
+  headerKey,
+  IMPORT_CSV_MAX_BYTES,
+  IMPORT_CSV_MAX_ROWS,
+  readCsvRecords,
+  type CsvLineError,
+} from '@/lib/import/csv';
+import type { NormalizedImportRow } from '@/lib/import/strong-import';
+
+// ============================================================
+// Hevy app CSV export parser (issue #113) - pure, no DB
+// ============================================================
+// Mirrors lib/import/strong-csv.ts for Hevy's one-row-per-set export. The
+// file content is UNTRUSTED user data: no eval, the same hard size and row
+// caps, and every value Zod-validated before it leaves this module. Bad lines
+// become per-line errors; only an unrecognized header or a blown cap is fatal.
+//
+// Hevy improvements over Strong's export that we honor:
+// - start_time / end_time are real wall-clock times -> real session times
+//   (Strong only gets the honest noon-UTC default).
+// - set_type distinguishes warmup and dropset rows -> isWarmup / isDropSet.
+
+export const HEVY_CSV_MAX_BYTES = IMPORT_CSV_MAX_BYTES;
+export const HEVY_CSV_MAX_ROWS = IMPORT_CSV_MAX_ROWS;
+
+// One normalized row: the shared NormalizedImportRow with the Hevy extras
+// always present.
+export interface HevyCsvRow extends NormalizedImportRow {
+  isWarmup: boolean;
+  isDropSet: boolean;
+  startedAtIso: string | null;
+  finishedAtIso: string | null;
+}
+
+export interface HevyCsvParseResult {
+  // False when the file as a whole is unusable (bad header, cap exceeded).
+  ok: boolean;
+  fatalError: string | null;
+  rows: HevyCsvRow[];
+  errors: CsvLineError[];
+  // Duration/distance-only rows (cardio) skipped with a counted notice.
+  cardioSkipped: number;
+}
+
+// Bounds mirror lib/schemas/set.ts (and the Strong parser) so imported sets
+// satisfy the same contract as manually logged ones.
+const rowSchema = z.object({
+  dateKey: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  workoutName: z.string().trim().min(1).max(200),
+  exerciseName: z.string().trim().min(1).max(120),
+  setOrder: z.coerce.number().int().min(1).max(50),
+  weightKg: z.coerce.number().min(0).max(500),
+  reps: z.coerce.number().int().min(1).max(100),
+});
+
+interface HeaderMap {
+  title: number;
+  startTime: number;
+  endTime: number | null;
+  exerciseTitle: number;
+  setIndex: number;
+  setType: number | null;
+  weight: number;
+  // True when the weight column is the lbs variant and must be converted.
+  weightIsLbs: boolean;
+  reps: number;
+  distance: number | null;
+  duration: number | null;
+}
+
+// Recognize Hevy's export header (snake_case columns; extra columns are fine,
+// order does not matter; the documented lbs/miles variants are tolerated).
+function mapHeader(cells: string[]): HeaderMap | null {
+  const keys = cells.map(headerKey);
+  const find = (...names: string[]) => {
+    for (const name of names) {
+      const idx = keys.indexOf(name);
+      if (idx !== -1) return idx;
+    }
+    return -1;
+  };
+
+  const title = find('title');
+  const startTime = find('start_time');
+  const exerciseTitle = find('exercise_title');
+  const setIndex = find('set_index');
+  let weightIsLbs = false;
+  let weight = find('weight_kg');
+  if (weight === -1) {
+    weight = find('weight_lbs', 'weight_lb');
+    if (weight !== -1) weightIsLbs = true;
+  }
+  const reps = find('reps');
+
+  if (
+    title === -1 ||
+    startTime === -1 ||
+    exerciseTitle === -1 ||
+    setIndex === -1 ||
+    weight === -1 ||
+    reps === -1
+  ) {
+    return null;
+  }
+  const endTime = find('end_time');
+  const setType = find('set_type');
+  const distance = find('distance_km', 'distance_miles');
+  const duration = find('duration_seconds');
+  return {
+    title,
+    startTime,
+    endTime: endTime === -1 ? null : endTime,
+    exerciseTitle,
+    setIndex,
+    setType: setType === -1 ? null : setType,
+    weight,
+    weightIsLbs,
+    reps,
+    distance: distance === -1 ? null : distance,
+    duration: duration === -1 ? null : duration,
+  };
+}
+
+const MONTHS: Record<string, number> = {
+  jan: 1, feb: 2, mar: 3, apr: 4, may: 5, jun: 6,
+  jul: 7, aug: 8, sep: 9, oct: 10, nov: 11, dec: 12,
+};
+
+// Parses Hevy's two documented timestamp formats into a UTC instant:
+//   - '07 Jan 2024, 17:15'    (older exports)
+//   - '2024-01-07 17:15:00'   (newer exports; seconds optional)
+// Hevy exports local wall-clock times with no zone; we read them as UTC -
+// the same honest convention as Strong's noon-UTC default, but with the real
+// time of day preserved. Returns null when the cell is not a real date.
+export function parseHevyTimestamp(
+  cell: string,
+): { dateKey: string; iso: string } | null {
+  const trimmed = cell.trim();
+  let y: number, mo: number, d: number, h: number, mi: number, s: number;
+
+  let m = /^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2})(?::(\d{2}))?$/.exec(trimmed);
+  if (m) {
+    [y, mo, d, h, mi, s] = [
+      Number(m[1]), Number(m[2]), Number(m[3]),
+      Number(m[4]), Number(m[5]), Number(m[6] ?? 0),
+    ];
+  } else {
+    m = /^(\d{1,2}) ([A-Za-z]{3}) (\d{4}),? (\d{1,2}):(\d{2})$/.exec(trimmed);
+    if (!m) return null;
+    const month = MONTHS[m[2]!.toLowerCase()];
+    if (!month) return null;
+    [y, mo, d, h, mi, s] = [Number(m[3]), month, Number(m[1]), Number(m[4]), Number(m[5]), 0];
+  }
+
+  if (h > 23 || mi > 59 || s > 59) return null;
+  const date = new Date(Date.UTC(y, mo - 1, d, h, mi, s));
+  if (
+    date.getUTCFullYear() !== y ||
+    date.getUTCMonth() !== mo - 1 ||
+    date.getUTCDate() !== d
+  ) {
+    return null;
+  }
+  return { dateKey: date.toISOString().slice(0, 10), iso: date.toISOString() };
+}
+
+// Parse a Hevy CSV export. Hevy stores weight in kg (weight_kg); the lbs
+// header variant is converted. There is no user-facing unit toggle.
+export function parseHevyCsv(text: string): HevyCsvParseResult {
+  const fail = (fatalError: string): HevyCsvParseResult => ({
+    ok: false,
+    fatalError,
+    rows: [],
+    errors: [],
+    cardioSkipped: 0,
+  });
+
+  if (text.length > HEVY_CSV_MAX_BYTES) {
+    return fail('File too large: the limit is 5 MB.');
+  }
+
+  const records = readCsvRecords(text);
+  const header = records[0];
+  if (!header) return fail('Empty file.');
+  const map = mapHeader(header.fields);
+  if (!map) {
+    return fail(
+      'Unrecognized format: expected a Hevy CSV export with the columns ' +
+        'title, start_time, exercise_title, set_index, weight_kg, reps.',
+    );
+  }
+
+  const dataRecords = records.slice(1);
+  if (dataRecords.length > HEVY_CSV_MAX_ROWS) {
+    return fail(
+      `Too many rows: ${dataRecords.length} (the limit is ${HEVY_CSV_MAX_ROWS}). Split the export and import in parts.`,
+    );
+  }
+
+  const rows: HevyCsvRow[] = [];
+  const errors: CsvLineError[] = [];
+  let cardioSkipped = 0;
+
+  for (const record of dataRecords) {
+    const get = (idx: number | null) =>
+      idx === null ? undefined : record.fields[idx];
+
+    const start = parseHevyTimestamp(get(map.startTime) ?? '');
+    if (!start) {
+      errors.push({ line: record.line, reason: 'Invalid or missing start_time.' });
+      continue;
+    }
+    // end_time is optional; a malformed one degrades to "no end time".
+    const end = parseHevyTimestamp(get(map.endTime) ?? '');
+
+    const reps = asNumber(get(map.reps));
+    const weightRaw = asNumber(get(map.weight));
+    const distance = asNumber(get(map.distance));
+    const duration = asNumber(get(map.duration));
+
+    // Cardio / duration-only rows (no reps, but distance or time): skipped
+    // with a counted notice rather than reported as errors.
+    if (!(reps >= 1) && (distance > 0 || duration > 0)) {
+      cardioSkipped++;
+      continue;
+    }
+
+    const weightKg = map.weightIsLbs ? roundWeight(lbToKg(weightRaw), 2) : weightRaw;
+    const setType = headerKey(get(map.setType) ?? '');
+
+    // Hevy's set_index is 0-based; setNumber/setOrder are 1-based. A missing
+    // index must NOT default to 0 (it would collide with real first sets and
+    // be silently dropped as a duplicate), so it fails the row instead.
+    const setIndexCell = get(map.setIndex);
+    const setIndex =
+      setIndexCell === undefined || setIndexCell.trim() === ''
+        ? NaN
+        : asNumber(setIndexCell);
+
+    const parsed = rowSchema.safeParse({
+      dateKey: start.dateKey,
+      workoutName: get(map.title) ?? '',
+      exerciseName: get(map.exerciseTitle) ?? '',
+      setOrder: setIndex + 1,
+      weightKg,
+      reps,
+    });
+    if (!parsed.success) {
+      const issue = parsed.error.issues[0];
+      errors.push({
+        line: record.line,
+        reason: issue ? `${issue.path.join('.')}: ${issue.message}` : 'Invalid row.',
+      });
+      continue;
+    }
+    rows.push({
+      ...parsed.data,
+      isWarmup: setType === 'warmup',
+      isDropSet: setType === 'dropset',
+      startedAtIso: start.iso,
+      finishedAtIso: end?.iso ?? null,
+    });
+  }
+
+  return { ok: true, fatalError: null, rows, errors, cardioSkipped };
+}

--- a/lib/import/hevy-import.test.ts
+++ b/lib/import/hevy-import.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { buildStrongImportPlan, type NormalizedImportRow } from './strong-import';
+
+// Issue #113: the shared planner carries the Hevy extras (set flags, real
+// times) through to the planned sessions. The Strong behavior is pinned by
+// strong-import.test.ts, untouched.
+
+function row(over: Partial<NormalizedImportRow> = {}): NormalizedImportRow {
+  return {
+    dateKey: '2026-05-02',
+    workoutName: 'Push',
+    exerciseName: 'Bench',
+    setOrder: 1,
+    weightKg: 80,
+    reps: 8,
+    isWarmup: false,
+    isDropSet: false,
+    startedAtIso: '2026-05-02T09:13:00.000Z',
+    finishedAtIso: '2026-05-02T10:05:00.000Z',
+    ...over,
+  };
+}
+
+describe('buildStrongImportPlan with normalized Hevy rows', () => {
+  it('keeps the warmup/dropset flags on the planned sets', () => {
+    const plan = buildStrongImportPlan(
+      [
+        row({ isWarmup: true, weightKg: 40 }),
+        row({ setOrder: 2 }),
+        row({ setOrder: 3, isDropSet: true, weightKg: 60 }),
+      ],
+      [],
+      new Set(),
+    );
+    expect(plan.sessions[0]?.sets.map((s) => [s.isWarmup, s.isDropSet])).toEqual([
+      [true, false],
+      [false, false],
+      [false, true],
+    ]);
+  });
+
+  it('takes the earliest start and the latest end across the session rows', () => {
+    const plan = buildStrongImportPlan(
+      [
+        row({
+          setOrder: 1,
+          startedAtIso: '2026-05-02T09:20:00.000Z',
+          finishedAtIso: '2026-05-02T10:05:00.000Z',
+        }),
+        row({
+          setOrder: 2,
+          startedAtIso: '2026-05-02T09:13:00.000Z',
+          finishedAtIso: '2026-05-02T10:30:00.000Z',
+        }),
+      ],
+      [],
+      new Set(),
+    );
+    expect(plan.sessions[0]?.startedAtIso).toBe('2026-05-02T09:13:00.000Z');
+    expect(plan.sessions[0]?.finishedAtIso).toBe('2026-05-02T10:30:00.000Z');
+  });
+
+  it('leaves the times unset for rows without them (Strong rows)', () => {
+    const plan = buildStrongImportPlan(
+      [row({ startedAtIso: undefined, finishedAtIso: undefined })],
+      [],
+      new Set(),
+    );
+    expect(plan.sessions[0]?.startedAtIso).toBeUndefined();
+    expect(plan.sessions[0]?.finishedAtIso).toBeUndefined();
+  });
+
+  it('a warmup and a working set with identical numbers stay distinct (set order keys them)', () => {
+    const plan = buildStrongImportPlan(
+      [row({ setOrder: 1, isWarmup: true, weightKg: 60, reps: 8 }), row({ setOrder: 2, weightKg: 60, reps: 8 })],
+      [],
+      new Set(),
+    );
+    expect(plan.totalSets).toBe(2);
+    expect(plan.duplicateCount).toBe(0);
+  });
+});

--- a/lib/import/strong-csv.ts
+++ b/lib/import/strong-csv.ts
@@ -1,6 +1,13 @@
 import { z } from 'zod';
 import type { WeightUnit } from '@prisma/client';
 import { lbToKg, roundWeight } from '@/lib/units';
+import {
+  asNumber,
+  headerKey,
+  IMPORT_CSV_MAX_BYTES,
+  IMPORT_CSV_MAX_ROWS,
+  readCsvRecords,
+} from '@/lib/import/csv';
 
 // ============================================================
 // Strong app CSV export parser (issue #100) - pure, no DB
@@ -11,9 +18,9 @@ import { lbToKg, roundWeight } from '@/lib/units';
 // instead of failing the whole file; only an unrecognized header or a blown
 // cap is fatal.
 
-// Hard caps on the untrusted input.
-export const STRONG_CSV_MAX_BYTES = 5 * 1024 * 1024; // 5 MB of text
-export const STRONG_CSV_MAX_ROWS = 50000; // data rows, header excluded
+// Hard caps on the untrusted input (shared across import formats).
+export const STRONG_CSV_MAX_BYTES = IMPORT_CSV_MAX_BYTES;
+export const STRONG_CSV_MAX_ROWS = IMPORT_CSV_MAX_ROWS;
 
 // One normalized working-set row. Weight is in kg, like everything stored.
 export interface StrongCsvRow {
@@ -52,81 +59,6 @@ const rowSchema = z.object({
   weightKg: z.coerce.number().min(0).max(500),
   reps: z.coerce.number().int().min(1).max(100),
 });
-
-// ------------------------------------------------------------
-// Minimal RFC4180-style CSV reader (quoted fields, "" escapes, quoted
-// newlines, CRLF). Returns one string[] per record plus the 1-based line
-// number the record starts on. No regex backtracking, single pass.
-// ------------------------------------------------------------
-function readCsvRecords(text: string): Array<{ line: number; fields: string[] }> {
-  const records: Array<{ line: number; fields: string[] }> = [];
-  let fields: string[] = [];
-  let field = '';
-  let inQuotes = false;
-  let line = 1;
-  let recordStartLine = 1;
-  let recordHasContent = false;
-
-  const pushField = () => {
-    fields.push(field);
-    field = '';
-  };
-  const pushRecord = () => {
-    pushField();
-    // Skip records that are entirely empty (blank lines).
-    if (recordHasContent || fields.length > 1 || (fields[0] ?? '') !== '') {
-      records.push({ line: recordStartLine, fields });
-    }
-    fields = [];
-    recordHasContent = false;
-    recordStartLine = line;
-  };
-
-  for (let i = 0; i < text.length; i++) {
-    const ch = text[i]!;
-    if (inQuotes) {
-      if (ch === '"') {
-        if (text[i + 1] === '"') {
-          field += '"';
-          i++;
-        } else {
-          inQuotes = false;
-        }
-      } else {
-        if (ch === '\n') line++;
-        field += ch;
-      }
-      continue;
-    }
-    if (ch === '"') {
-      inQuotes = true;
-      recordHasContent = true;
-    } else if (ch === ',') {
-      pushField();
-      recordHasContent = true;
-    } else if (ch === '\n') {
-      line++;
-      pushRecord();
-    } else if (ch === '\r') {
-      // Swallow; the following \n (if any) ends the record.
-      if (text[i + 1] !== '\n') {
-        line++;
-        pushRecord();
-      }
-    } else {
-      field += ch;
-      recordHasContent = true;
-    }
-  }
-  // Final record without a trailing newline.
-  if (recordHasContent || field !== '' || fields.length > 0) pushRecord();
-  return records;
-}
-
-// Normalize a header cell for matching: lowercase, trimmed, collapsed spaces.
-function headerKey(cell: string): string {
-  return cell.trim().toLowerCase().replace(/\s+/g, ' ');
-}
 
 interface HeaderMap {
   date: number;
@@ -209,14 +141,6 @@ function toDateKey(cell: string): string | null {
     return null;
   }
   return `${y}-${mo}-${d}`;
-}
-
-function asNumber(cell: string | undefined): number {
-  if (cell === undefined) return 0;
-  const trimmed = cell.trim();
-  if (trimmed === '') return 0;
-  const n = Number(trimmed);
-  return Number.isFinite(n) ? n : NaN;
 }
 
 // Parse a Strong CSV export. `unit` is the unit the Strong app was set to

--- a/lib/import/strong-import.ts
+++ b/lib/import/strong-import.ts
@@ -1,26 +1,50 @@
 import type { Prisma, PrismaClient } from '@prisma/client';
-import type { StrongCsvRow } from '@/lib/import/strong-csv';
 
 // ============================================================
-// Strong import planning + execution (issue #100)
+// CSV import planning + execution (issues #100/#113)
 // ============================================================
 // buildStrongImportPlan is pure: it groups parsed rows into sessions, matches
 // exercises case-insensitively against the user's catalog, and skips exact
 // duplicates. executeStrongImport performs the writes through the transaction
 // client it is given, so the route can wrap one import in one transaction and
-// a failure rolls everything back.
+// a failure rolls everything back. Both are shared by every import format
+// (Strong, Hevy) through the normalized row type below; the historical names
+// are kept so the Strong call sites stay untouched.
+
+// The format-neutral row every CSV parser normalizes to. StrongCsvRow is the
+// base shape; richer exports (Hevy) also carry set flags and real times.
+export interface NormalizedImportRow {
+  dateKey: string; // YYYY-MM-DD
+  workoutName: string;
+  exerciseName: string;
+  setOrder: number;
+  weightKg: number;
+  reps: number;
+  // Optional extras (issue #113). Absent for Strong rows.
+  isWarmup?: boolean;
+  isDropSet?: boolean;
+  // Real session times as ISO strings, when the source export has them.
+  startedAtIso?: string | null;
+  finishedAtIso?: string | null;
+}
 
 export interface PlannedSet {
   exerciseName: string;
   setOrder: number;
   weightKg: number;
   reps: number;
+  isWarmup?: boolean;
+  isDropSet?: boolean;
 }
 
 export interface PlannedSession {
   dateKey: string; // YYYY-MM-DD
   workoutName: string;
   sets: PlannedSet[];
+  // Earliest/latest real times seen across the session's rows (issue #113);
+  // undefined/null falls back to the honest noon-UTC default.
+  startedAtIso?: string | null;
+  finishedAtIso?: string | null;
 }
 
 export interface StrongImportPlan {
@@ -46,7 +70,7 @@ export function setDuplicateKey(
 }
 
 export function buildStrongImportPlan(
-  rows: StrongCsvRow[],
+  rows: NormalizedImportRow[],
   existingExerciseNames: string[],
   existingSetKeys: ReadonlySet<string>,
 ): StrongImportPlan {
@@ -87,8 +111,22 @@ export function buildStrongImportPlan(
       setOrder: row.setOrder,
       weightKg: row.weightKg,
       reps: row.reps,
+      ...(row.isWarmup !== undefined && { isWarmup: row.isWarmup }),
+      ...(row.isDropSet !== undefined && { isDropSet: row.isDropSet }),
     });
     totalSets++;
+
+    // Track the earliest start / latest end across the session's rows.
+    if (row.startedAtIso) {
+      if (!session.startedAtIso || row.startedAtIso < session.startedAtIso) {
+        session.startedAtIso = row.startedAtIso;
+      }
+    }
+    if (row.finishedAtIso) {
+      if (!session.finishedAtIso || row.finishedAtIso > session.finishedAtIso) {
+        session.finishedAtIso = row.finishedAtIso;
+      }
+    }
   }
 
   const sessions = [...sessionsByKey.values()].sort((a, b) =>
@@ -124,11 +162,14 @@ export interface StrongImportResult {
 type Db = PrismaClient | Prisma.TransactionClient;
 
 // Performs the writes for a plan through the given client. Call it inside
-// db.$transaction so a mid-import failure rolls back every row.
+// db.$transaction so a mid-import failure rolls back every row. `sourceLabel`
+// names the originating app in the created notes (default keeps the Strong
+// call sites byte-identical).
 export async function executeStrongImport(
   tx: Db,
   userId: string,
   plan: StrongImportPlan,
+  sourceLabel = 'Strong',
 ): Promise<StrongImportResult> {
   // Resolve the user's exercises case-insensitively, creating the missing
   // ones (OTHER / ISOLATION; the user can re-categorize later).
@@ -148,7 +189,7 @@ export async function executeStrongImport(
         name,
         muscleGroup: 'OTHER',
         category: 'ISOLATION',
-        notes: 'Imported from Strong. Adjust the muscle group and category.',
+        notes: `Imported from ${sourceLabel}. Adjust the muscle group and category.`,
       },
     });
     idByLower.set(lower, created.id);
@@ -159,13 +200,23 @@ export async function executeStrongImport(
   let createdSets = 0;
   for (const session of plan.sessions) {
     if (session.sets.length === 0) continue;
-    const startedAt = sessionDateFromKey(session.dateKey);
+    // Real export times win (issue #113); otherwise the honest noon default.
+    const startedAt = session.startedAtIso
+      ? new Date(session.startedAtIso)
+      : sessionDateFromKey(session.dateKey);
+    // A garbled export can claim an end before the start; never trust it
+    // below the start time.
+    const finishedAtRaw = session.finishedAtIso ? new Date(session.finishedAtIso) : null;
+    const finishedAt =
+      finishedAtRaw && finishedAtRaw.getTime() >= startedAt.getTime()
+        ? finishedAtRaw
+        : startedAt;
     const created = await tx.session.create({
       data: {
         userId,
         startedAt,
-        finishedAt: startedAt,
-        notes: `Imported from Strong - ${session.workoutName}`,
+        finishedAt,
+        notes: `Imported from ${sourceLabel} - ${session.workoutName}`,
       },
     });
     createdSessions++;
@@ -184,6 +235,8 @@ export async function executeStrongImport(
           setNumber: s.setOrder,
           weight: s.weightKg,
           reps: s.reps,
+          isWarmup: s.isWarmup ?? false,
+          isDropSet: s.isDropSet ?? false,
           completedAt: startedAt,
         };
       }),

--- a/lib/schemas/import.ts
+++ b/lib/schemas/import.ts
@@ -13,3 +13,13 @@ export const strongImportInputSchema = z.object({
 });
 
 export type StrongImportInput = z.infer<typeof strongImportInputSchema>;
+
+// Hevy CSV import request (issue #113). Same cap and modes; no unit field -
+// Hevy exports weight in kg (the lbs header variant is converted by the
+// parser, not chosen by the user).
+export const hevyImportInputSchema = z.object({
+  csv: z.string().min(1).max(STRONG_CSV_MAX_BYTES, 'File too large: the limit is 5 MB.'),
+  mode: z.enum(['preview', 'confirm']),
+});
+
+export type HevyImportInput = z.infer<typeof hevyImportInputSchema>;

--- a/tests/e2e/hevy-import.spec.ts
+++ b/tests/e2e/hevy-import.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+
+// Hevy CSV import (issue #113): switch the settings import section to Hevy,
+// upload an export, check the dry-run preview, confirm, and find the imported
+// session in the history. Mirrors import.spec.ts (Strong), which is untouched.
+
+// One warmup + two working sets + one broken line. The history page counts
+// working sets only, so it shows "2 sets" after the confirm.
+const HEVY_CSV = [
+  'title,start_time,end_time,exercise_title,set_index,set_type,weight_kg,reps,distance_km,duration_seconds',
+  'Push Day,2026-05-02 09:13:00,2026-05-02 10:05:00,Bench Press,0,warmup,40,8,,',
+  'Push Day,2026-05-02 09:13:00,2026-05-02 10:05:00,Bench Press,1,normal,80,8,,',
+  'Push Day,2026-05-02 09:13:00,2026-05-02 10:05:00,Bench Press,2,normal,80,7,,',
+  'Push Day,not-a-date,2026-05-02 10:05:00,Bench Press,3,normal,80,6,,',
+].join('\n');
+
+test('a lifter can preview and confirm a Hevy CSV import', async ({ page }) => {
+  // Sign up through the API (fresh user; the cookie lands in the context). A
+  // unique X-Forwarded-For keeps this spec in its own register rate-limit
+  // bucket - the suite's parallel UI signups use up the 5/min per-IP budget.
+  const registerRes = await page.request.post('/api/auth/register', {
+    headers: { 'x-forwarded-for': '10.111.0.2' },
+    data: {
+      displayName: 'Hevy E2E',
+      email: `e2e-hevy-${Date.now()}@test.dev`,
+      password: 'supersecret',
+    },
+  });
+  expect(registerRes.ok()).toBeTruthy();
+
+  await page.goto('/settings');
+  await expect(page.getByText('Import from Strong')).toBeVisible();
+
+  // Switch the source app to Hevy: the unit toggle (Strong-only) disappears.
+  await page.getByLabel('Source app').click();
+  await page.getByRole('option', { name: 'Hevy' }).click();
+  await expect(page.getByText('Import from Hevy')).toBeVisible();
+  await expect(page.getByText('Strong weight unit')).not.toBeVisible();
+
+  // Upload the file: the dry-run preview appears, nothing imported yet.
+  await page
+    .locator('input[type="file"][accept=".csv,text/csv"]')
+    .setInputFiles({
+      name: 'hevy.csv',
+      mimeType: 'text/csv',
+      buffer: Buffer.from(HEVY_CSV, 'utf-8'),
+    });
+
+  const preview = page.getByTestId('import-preview');
+  await expect(preview).toBeVisible();
+  await expect(preview).toContainText('1 session, 3 sets to import');
+  await expect(preview).toContainText('1 new exercise will be created: Bench Press');
+  await expect(preview).toContainText('Line 5');
+
+  // Confirm and find the imported session in the history with its real time.
+  await page.getByRole('button', { name: /confirm import/i }).click();
+  await expect(page.getByTestId('import-preview')).not.toBeVisible();
+
+  await page.goto('/history');
+  await expect(page.getByText('May 02, 2026')).toBeVisible();
+  await expect(page.getByText('2 sets')).toBeVisible();
+});

--- a/tests/integration/hevy-import-route.test.ts
+++ b/tests/integration/hevy-import-route.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { db } from '@/lib/db';
+import { getCurrentUserId } from '@/lib/auth';
+
+vi.mock('@/lib/auth', () => ({ getCurrentUserId: vi.fn() }));
+const mockUserId = vi.mocked(getCurrentUserId);
+
+import { POST as postImport } from '@/app/api/import/hevy/route';
+
+function actAs(userId: string) {
+  mockUserId.mockResolvedValue(userId);
+}
+
+function importReq(body: unknown): Request {
+  return new Request('http://test.local/api/import/hevy', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+const HEADER =
+  'title,start_time,end_time,exercise_title,set_index,set_type,weight_kg,reps,distance_km,duration_seconds';
+
+const CSV = [
+  HEADER,
+  'Push Day,2026-05-02 09:13:00,2026-05-02 10:05:00,Bench Press,0,warmup,40,8,,',
+  'Push Day,2026-05-02 09:13:00,2026-05-02 10:05:00,Bench Press,1,normal,80,8,,',
+  'Push Day,2026-05-02 09:13:00,2026-05-02 10:05:00,Bench Press,2,dropset,60,10,,',
+  'Pull Day,2026-05-03 18:00:00,2026-05-03 18:45:00,Imported Row,0,normal,70,10,,',
+  'Pull Day,2026-05-03 18:00:00,2026-05-03 18:45:00,Running,0,normal,,,5,1800',
+].join('\n');
+
+async function seedUser(email = 'hevy-importer@test.dev') {
+  return db.user.create({ data: { email, passwordHash: 'x' } });
+}
+
+beforeEach(() => {
+  mockUserId.mockReset();
+});
+
+describe('POST /api/import/hevy (preview)', () => {
+  it('returns counts and per-line info without writing anything', async () => {
+    const user = await seedUser();
+    actAs(user.id);
+
+    const res = await postImport(importReq({ csv: CSV, mode: 'preview' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      mode: 'preview',
+      sessions: 2,
+      sets: 4,
+      newExercises: ['Bench Press', 'Imported Row'],
+      duplicatesSkipped: 0,
+      cardioSkipped: 1,
+      errorCount: 0,
+    });
+
+    expect(await db.session.count()).toBe(0);
+    expect(await db.set.count()).toBe(0);
+    expect(await db.exercise.count()).toBe(0);
+  });
+
+  it('rejects an unrecognized header with a clear message', async () => {
+    const user = await seedUser();
+    actAs(user.id);
+    const res = await postImport(importReq({ csv: 'foo,bar\n1,2', mode: 'preview' }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/unrecognized format/i);
+  });
+
+  it('rejects a Strong-format file with the Hevy message (formats are not interchangeable)', async () => {
+    const user = await seedUser();
+    actAs(user.id);
+    const res = await postImport(
+      importReq({
+        csv: 'Date,Workout Name,Exercise Name,Set Order,Weight,Reps\n2026-05-02,Push,Bench,1,80,8',
+        mode: 'preview',
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/hevy csv export/i);
+  });
+
+  it('requires auth', async () => {
+    mockUserId.mockResolvedValue(null);
+    const res = await postImport(importReq({ csv: CSV, mode: 'preview' }));
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('POST /api/import/hevy (confirm)', () => {
+  it('creates sessions with real start/end times and mapped set flags, transactionally', async () => {
+    const user = await seedUser();
+    actAs(user.id);
+
+    const res = await postImport(importReq({ csv: CSV, mode: 'confirm' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      mode: 'confirm',
+      createdSessions: 2,
+      createdSets: 4,
+      createdExercises: 2,
+      cardioSkipped: 1,
+    });
+
+    const sessions = await db.session.findMany({
+      where: { userId: user.id },
+      orderBy: { startedAt: 'asc' },
+      include: { sets: { orderBy: { setNumber: 'asc' } } },
+    });
+    expect(sessions).toHaveLength(2);
+    // Real export times, not the noon-UTC fallback.
+    expect(sessions[0]?.startedAt.toISOString()).toBe('2026-05-02T09:13:00.000Z');
+    expect(sessions[0]?.finishedAt?.toISOString()).toBe('2026-05-02T10:05:00.000Z');
+    expect(sessions[0]?.notes).toBe('Imported from Hevy - Push Day');
+
+    // set_type mapping persisted: warmup, normal, dropset.
+    expect(sessions[0]?.sets.map((s) => [s.isWarmup, s.isDropSet])).toEqual([
+      [true, false],
+      [false, false],
+      [false, true],
+    ]);
+
+    const created = await db.exercise.findMany({
+      where: { userId: user.id },
+      orderBy: { name: 'asc' },
+    });
+    expect(created.map((e) => e.notes)).toEqual([
+      'Imported from Hevy. Adjust the muscle group and category.',
+      'Imported from Hevy. Adjust the muscle group and category.',
+    ]);
+  });
+
+  it("never matches or touches another user's exercises", async () => {
+    const user = await seedUser();
+    const other = await seedUser('hevy-other@test.dev');
+    await db.exercise.create({
+      data: { userId: other.id, name: 'Bench Press', muscleGroup: 'CHEST', category: 'COMPOUND' },
+    });
+    actAs(user.id);
+
+    await postImport(importReq({ csv: CSV, mode: 'confirm' }));
+    expect(
+      await db.exercise.count({ where: { userId: user.id, name: 'Bench Press' } }),
+    ).toBe(1);
+    expect(await db.set.count({ where: { session: { userId: other.id } } })).toBe(0);
+  });
+
+  it('skips exact duplicates on re-import (idempotence)', async () => {
+    const user = await seedUser();
+    actAs(user.id);
+
+    await postImport(importReq({ csv: CSV, mode: 'confirm' }));
+    const res = await postImport(importReq({ csv: CSV, mode: 'confirm' }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/nothing to import/i);
+
+    expect(await db.session.count({ where: { userId: user.id } })).toBe(2);
+    expect(await db.set.count({ where: { session: { userId: user.id } } })).toBe(4);
+  });
+
+  it('rejects invalid input (Zod) and writes nothing', async () => {
+    const user = await seedUser();
+    actAs(user.id);
+    // 'unit' is a Strong-only field; mode must be preview|confirm.
+    const res = await postImport(importReq({ csv: CSV, mode: 'apply' }));
+    expect(res.status).toBe(400);
+    expect(await db.session.count()).toBe(0);
+  });
+
+  it('leaves the Strong import route behavior intact (shared executor, distinct labels)', async () => {
+    // Guards the refactor: the Strong route still writes its own notes.
+    const user = await seedUser();
+    actAs(user.id);
+    const { POST: postStrong } = await import('@/app/api/import/strong/route');
+    const strongCsv = [
+      'Date,Workout Name,Exercise Name,Set Order,Weight,Reps',
+      '2026-06-01 09:00:00,Push,Bench,1,80,8',
+    ].join('\n');
+    const res = await postStrong(
+      new Request('http://test.local/api/import/strong', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ csv: strongCsv, mode: 'confirm' }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    const session = await db.session.findFirstOrThrow({ where: { userId: user.id } });
+    // Unchanged Strong behavior: noon-UTC fallback and Strong-labelled notes.
+    expect(session.startedAt.toISOString()).toBe('2026-06-01T12:00:00.000Z');
+    expect(session.notes).toBe('Imported from Strong - Push');
+  });
+});


### PR DESCRIPTION
Closes #113.

Second import format on the adoption wedge: Hevy's one-row-per-set CSV export, behind the same hardened pipeline as the Strong import (#100/#105). The Strong path and its tests are untouched.

## What changed

- **Shared plumbing** (`lib/import/csv.ts`): the RFC4180 reader, header normalization, numeric cell reader, and the 5 MB / 50000-row caps moved out of `strong-csv.ts` verbatim; the Strong parser now consumes them and re-exports its historical constant names. Mechanical extraction - all 22 pre-existing import unit tests pass unmodified.
- **Parser** (`lib/import/hevy-csv.ts`): untrusted-input bar identical to Strong - hard caps, no eval, Zod on every value, per-line errors, fatal only on a bad header or blown cap. Hevy specifics: `set_type` warmup/dropset map to `isWarmup`/`isDropSet`, real `start_time`/`end_time` (both documented timestamp formats) become real session times, `weight_lbs` header variant converts to kg, 0-based `set_index` becomes 1-based set order (a missing index fails the row instead of colliding with real first sets), cardio rows skip with a count.
- **Planner/executor**: `NormalizedImportRow` generalizes the row type with optional set flags and times; the planner takes the earliest start / latest end per session; the executor takes an optional source label and never trusts an end time before the start. All additive with defaults - the Strong call sites are byte-identical (pinned by an integration test that runs the Strong route through the shared executor).
- **Route** (`POST /api/import/hevy`): mirrors the untouched Strong route - streamed body cap (1.5x envelope), shared per-user rate-limit budget, dry-run preview, one-transaction confirm, duplicate skip.
- **Settings UI**: Source app selector (Strong / Hevy); the unit toggle stays Strong-only (Hevy always exports kg). Default remains Strong, so the existing component tests and the Strong E2E pass untouched.

## How I tested

`bash scripts/verify.sh --full` passed locally. New tests at every touched layer:

- unit: 23 new parser/planner tests (happy path, set_type mapping, both timestamp formats, lbs variant, malformed lines incl. missing set_index, caps, formula-cell inertness, flag/time passthrough in the planner)
- integration: Hevy route preview/confirm (real times + persisted flags), ownership isolation, duplicate idempotence, Zod rejection, Strong-format file rejected with a Hevy-specific message, and a Strong-route regression guard (noon fallback + Strong-labelled notes unchanged)
- E2E: full Hevy flow - switch the source selector, upload, preview with per-line error, confirm, find the session in history; the Strong import spec is untouched and still green