### PR TITLE
docs: write up the fifth batch (zero-defect reviews, model routing live)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   single field of the set logger to fill the weight, reps, and effort fields
   (RPE maps to the stored RIR). Deterministic parser in the user's display
   unit; the classic fields keep working unchanged.
+- One-tap deload week: the deload recommendation banner can now start a
+  7-day planned deload; while active, every suggested load steps down 10%
+  (reason "planned deload", shown in the suggestion badge), it never stacks
+  with a readiness step-down, a session badge shows the state, and the AI
+  coach is told a deload is underway. Ends automatically or in one tap.
+- Ask the coach mid-session: a button in the session runner opens the
+  streaming chat with the live workout attached (sets logged so far, program
+  targets, today's readiness check-in) so advice is immediate and grounded;
+  the chat stays free-form and all structured output contracts are unchanged.
+- Import from Hevy: the CSV import now accepts Hevy exports too (real session
+  times, warmup and drop-set markers), behind the same hardened pipeline as
+  the Strong format - shared size/row caps, streamed body limit, shared rate
+  limit, dry-run preview, transactional confirm with duplicate skipping.
 - Bodyweight tracking: log dated bodyweight entries from a trend card on the
   progress page (12-week chart, quick add in your display unit, deletable
   entries). The newest entry keeps the profile's current bodyweight in sync

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ more about *how a repo can maintain itself* than about the gym app, start there.
   MEV/MRV landmark bands, a training-consistency calendar, and personal-record
   badges in session and on the post-session summary
 - Stalled-lift detection plus a deload-week recommendation derived from your
-  stalls and readiness trend
+  stalls and readiness trend - and a one-tap planned deload week that lightens
+  every suggested load by 10% until it expires
 - Per-exercise target goals (weight x reps) with a progress bar and an
   achieved badge
 - Bodyweight tracking with a trend chart - and bodyweight-aware tonnage for
@@ -69,11 +70,13 @@ more about *how a repo can maintain itself* than about the gym app, start there.
   runnable as written and editable like any program
 - AI coach: weekly debrief and assisted program adjustments, aware of your
   goals and fatigue signals
-- Conversational AI coach: streaming chat grounded in your training data
+- Conversational AI coach: streaming chat grounded in your training data -
+  including mid-session, with the live workout (sets so far, targets, today's
+  readiness) attached in one tap
 - AI program generation from a natural-language goal, editable before saving
 - Pluggable LLM provider: Anthropic SDK or any OpenRouter model
-- Import your training history from a Strong CSV export (dry-run preview,
-  duplicate-safe); export everything back out as CSV anytime
+- Import your training history from a Strong or Hevy CSV export (dry-run
+  preview, duplicate-safe); export everything back out as CSV anytime
 - Train in kilograms or pounds, a per-user preference (data is always stored in kg)
 - Installable PWA with offline session logging
 
@@ -243,7 +246,9 @@ docker compose -f docker-compose.prod.yml exec app npx prisma migrate deploy
 - [x] Test pyramid (unit, integration, E2E) and CI
 - [x] Shorthand set logging (`100x8@9`) - the deterministic slice of
       natural-language logging
-- [ ] In-session AI suggestions and free-text set logging
+- [x] In-session AI suggestions (ask the coach mid-workout with the live
+      session attached)
+- [ ] Free-text (AI-parsed) set logging
 
 ## Contributing
 

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -6,6 +6,34 @@ by the charter in [`07-autonomy.md`](07-autonomy.md).
 
 ---
 
+## 2026-06-11 - Fifth batch: roadmap's last AI item shipped; first zero-defect reviews; model routing live
+
+**Context.** Fifth ideate batch (#111 ask-the-coach mid-session, #112 one-tap deload,
+#113 Hevy import) filed and logged (#114), implemented by a Fable background tick (PRs
+#115/#116/#117, all merged on green full CI, budget 3/3, rollback baseline tagged before
+the migration). First cycle under the operator's model-routing directive: Fable for the
+implementing tick, Opus 4.8 for the three independent post-merge reviews.
+
+**Decided / shipped.**
+- All three post-merge reviews came back CLEAN - the first batch with zero REAL defects
+  since the L8 backstop exists. Notable verifications: deload precedence on every branch
+  incl. no-stacking; double ownership gate on the chat sessionId; shared import rate
+  bucket and a byte-identical Strong path.
+- The tick's flagged product concern (deload step-down on negative assisted loads) was
+  requalified by the reviewer as a pre-existing, currently unreachable doc-vs-validation
+  contradiction; filed as #118 with a default option-A (docs) resolution.
+- Write-up: CHANGELOG, README features + roadmap (in-session AI suggestions checked;
+  free-text AI set logging is the remaining open item), backlog, this entry. Media
+  unchanged per the rule (no captured page changed; clips at 1 batch of lag).
+
+**Challenged.** Three independent Opus reviews in parallel; all CLEAN. The quality
+signal survived the model split - the cheaper review lane still verified empirically
+(ran tests, checked diffs byte-level) rather than rubber-stamping.
+
+**Deferred to human.** Nothing. #118 awaits a normal loop pick-up (option A specced).
+
+---
+
 ## 2026-06-11 - Maintainer run: shipped #112, #111, #113 (fifth ideate batch)
 
 **Context.** Maintainer tick over the fifth ideate batch, strictly serialized (lesson L7:

--- a/docs/loops/ideas-backlog.md
+++ b/docs/loops/ideas-backlog.md
@@ -27,6 +27,6 @@ research and the product wedge). See `docs/loops/08-ideation-loop.md` for how th
 - shipped - import training history from a Strong app CSV export (issue #100, 2026-06-10, PR #105 + hardening #108) - re-evaluated rejection; security review found and fixed body-cap bypass, transaction timeout, CSV formula injection
 - shipped - give the AI coach the user's goals and fatigue signals (issue #101, 2026-06-10, PR #104) - payload + prompt input-side only; post-merge review verdict CLEAN
 - deferred - supersets/circuits (2026-06-10) - now allowed by the directive (nullable group column is additive) but the session-runner UX surface is too heavy for one tight PR; revisit as its own batch with a UX-first slice
-- proposed - ask the coach mid-session with live session context (issue #111, 2026-06-11) - the AI half of the last roadmap item; chat payload gains currentSession, output contract unchanged
-- proposed - start a deload week in one tap from the recommendation (issue #112, 2026-06-11) - additive User.deloadUntil + 'planned-deload' suggestion reason, no-stacking precedence
-- proposed - import training history from a Hevy CSV export (issue #113, 2026-06-11) - second format on the hardened import pipeline; real session times, set_type mapping
+- shipped - ask the coach mid-session with live session context (issue #111, 2026-06-11, PR #116) - post-merge review CLEAN (double ownership gate, contracts byte-identical)
+- shipped - start a deload week in one tap from the recommendation (issue #112, 2026-06-11, PR #115) - post-merge review CLEAN; latent negative-weight doc contradiction filed as #118
+- shipped - import training history from a Hevy CSV export (issue #113, 2026-06-11, PR #117) - security review CLEAN (shared caps/rate budget verified, Strong path byte-identical)

--- a/docs/loops/review-digest.md
+++ b/docs/loops/review-digest.md
@@ -146,3 +146,34 @@ showing the current product; demo seed extended with bodyweight/goal/readiness d
 > The L8 backstop is now proven twice: independent post-merge review found one REAL defect
 > in #95 and four across #103/#105. Author self-review keeps missing what independent eyes
 > catch in one pass.
+
+---
+
+## 2026-06-11 - fifth batch (#115/#116/#117): three CLEAN verdicts, first zero-defect batch
+
+Merged: #114 (ideate log), #115 (one-tap deload week - migration + progression + API),
+#116 (ask the coach mid-session - live session context in the chat payload), #117 (Hevy
+CSV import on the hardened pipeline). All three were flagged for post-merge independent
+review (L8) and all three came back CLEAN - the first batch with zero REAL defects. Also
+the first batch under the model-routing directive (Fable implements, Opus reviews).
+
+**Read first, in order:**
+
+1. **#115 - the deload precedence rule.** `gh pr diff 115`. suggestNextWeight now has a
+   planned-deload branch that pre-empts progression AND readiness adjustments (one 10%
+   step-down, never stacked). This changes what weight the app tells you to lift - the
+   reviewer verified every branch, but it is core training behavior, worth your eyes.
+2. **#116 - what the chat can see now.** `gh pr diff 116`. A sessionId query param attaches
+   your live workout to the chat payload; two independent ownership gates (page + API),
+   foreign ids degrade to null. The structured contracts are byte-identical.
+3. **#117 - the import surface doubled.** `gh pr diff 117`. New Hevy parser + shared
+   executor refactor; the Strong path is pinned byte-identical by a regression test and
+   the rate-limit bucket is genuinely shared across both routes.
+
+**Skim:** #114 and this write-up. **Follow-up filed:** #118 (latent doc-vs-validation
+contradiction on negative assisted loads - unreachable today, option-A doc fix specced).
+
+> Screenshots note: none of the four captured pages (home/progress/generator/catalog)
+> visibly changed in this batch (the new surfaces live in the session runner, the chat,
+> and settings), and the GIFs were re-recorded yesterday - so per the media rule (refresh
+> on visible change; clips max ~3 batches lag) the media stands as-is at 1 batch of lag.


### PR DESCRIPTION
Content-loop tail for the fifth batch (#115 one-tap deload, #116 ask the coach mid-session, #117 Hevy import).

- CHANGELOG: the three features, claims checked against the merged diffs.
- README: features list extended (deload action, mid-session chat, Hevy import); roadmap - "In-session AI suggestions" checked, "Free-text (AI-parsed) set logging" stays open as the honest remainder.
- All three post-merge independent reviews (run on Opus per the new model-routing directive) returned CLEAN - the first zero-defect batch; verdicts recorded in the backlog, digest, and journal. Follow-up #118 filed for the latent negative-weight doc contradiction the reviews surfaced.
- Demo media intentionally untouched: none of the four captured pages visibly changed (the new surfaces live in the session runner, chat, and settings) and the GIFs are one batch old - within the media rule's staleness cap.

bash scripts/verify.sh - GREEN-GATE PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)