### PR TITLE
chore: stop documenting negative assisted loads the validation clamps out

### DIFF
--- a/lib/exercise-catalog.ts
+++ b/lib/exercise-catalog.ts
@@ -116,7 +116,7 @@ export const EXERCISE_CATALOG: CatalogExercise[] = [
     category: ExerciseCategory.COMPOUND,
     defaultRestSec: 75,
     usesBodyweight: true,
-    notes: 'Vertical torso for triceps focus. On an assisted machine, enter the assistance weight as negative.',
+    notes: 'Vertical torso for triceps focus. On an assisted machine, log the machine assistance setting as the added load.',
   },
   {
     name: 'Triceps pushdown (rope)',

--- a/lib/progression.ts
+++ b/lib/progression.ts
@@ -55,6 +55,10 @@ export const SORENESS_DELOAD_AT_OR_ABOVE = 5;
 // 10% is a light, evidence-informed deload that protects a fatigued muscle
 // without throwing away the training block.
 export const READINESS_DELOAD_FRACTION = 0.1;
+// The step-down math above relies on weights being >= 0 (the Zod input
+// schemas and both CSV importers clamp them): reducing a negative load by a
+// fraction would shrink assistance and make the set HARDER, not easier
+// (issue #118).
 
 // A recent readiness check-in, shaped for pure progression logic. The caller
 // resolves recency by passing `ageHours` (how old the check-in is), keeping this

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,8 +15,8 @@ model User {
   email        String     @unique
   passwordHash String
   // Bodyweight in kg, used to compute the effective tonnage on bodyweight
-  // exercises (Set.weight = added load, can be negative for assistance
-  // machines). Null = not filled in yet, so no bodyweight bonus is applied
+  // exercises (Set.weight = added load, always >= 0; the input schemas clamp
+  // it). Null = not filled in yet, so no bodyweight bonus is applied
   // (backward-safe).
   bodyweight   Float?
   // Optional profile, used to tailor the AI coach output to the user.
@@ -101,7 +101,8 @@ model Exercise {
   notes            String?
   // For bodyweight exercises (pull-ups, dips, push-ups...): the effective
   // tonnage includes User.bodyweight. Set.weight remains the added load (0 by
-  // default, negative for an assistance machine).
+  // default, always >= 0 - the input schemas clamp it; negative loads for
+  // assistance machines are deliberately not supported, see issue #118).
   usesBodyweight   Boolean           @default(false)
   createdAt        DateTime          @default(now())
   programExercises ProgramExercise[]


### PR DESCRIPTION
Closes #118 (option A from the issue, surfaced by the #115 post-merge review).

Schema comments and the assisted-dips catalog note no longer promise negative-load support that lib/schemas/set.ts, the backup restore, and both CSV importers all clamp out; lib/progression.ts now states the >= 0 invariant its step-down math relies on. Docs/comments only - no behavior change.

## How I tested

- bash scripts/verify.sh - GREEN-GATE PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)