### PR TITLE
docs: graduate two loop-engineering checks into triage (gate spot-check, permissions re-audit)

### DIFF
--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -41,6 +41,16 @@ later `implement-issue` run can pick up unattended.
    (only file if concrete and locatable).
 5. **Dependency hygiene** - `npm outdated` for clearly safe minor/patch bumps, or a
    flagged advisory from `npm audit`. One issue per coherent group, not per package.
+6. **Gate spot-check ("gates rot")** - periodically (roughly monthly, or when no other
+   source yields work): pick 1-2 recently merged fix/feature PRs, revert the core change
+   locally (never push), and confirm the tests that approved the PR actually FAIL. A test
+   that still passes with the fix reverted is a rotten gate - file an issue naming the
+   test and the uncovered failure mode. Record the spot-check (date + PRs checked) in
+   `docs/loops/autonomy-log.md` even when everything fails correctly.
+7. **Permissions re-audit** - roughly every 30 days, re-read `.claude/settings.json` /
+   `.claude/settings.local.json` allow/deny lists against what the loop actually needs
+   now. Scope creep (a permission added "temporarily" and never removed) becomes an
+   issue; the deny list (curl/wget, force-push, hard reset) must still be intact.
 
 Prefer the source that yields the most concrete, lowest-ambiguity item. A good triage
 issue names the file(s) and the acceptance check.

--- a/.claude/skills/write-up/SKILL.md
+++ b/.claude/skills/write-up/SKILL.md
@@ -82,6 +82,13 @@ commit on an existing docs branch.
 - Docs only - no product code, no merges (let `ship-pr` merge it).
 - Do not document unmerged work as shipped (it belongs in the PR, not `main`'s story).
 
+## One metric per batch
+
+Each batch write-up records, in the autonomy-log entry, the cheap acceptance metric:
+PRs merged vs PRs abandoned/reverted this batch (the accepted-change rate), and the
+approximate token spend of the implementing tick when known. Cost per accepted change -
+not tokens spent - is the number that says whether the loop is winning.
+
 ## What success looks like
 
 The CHANGELOG and the `docs/loops/` playbook always reflect what actually shipped, so the

--- a/docs/loops/lessons.md
+++ b/docs/loops/lessons.md
@@ -105,3 +105,17 @@ Format per entry: trigger/evidence, the lesson (actionable), and **Status** = `g
   multiple "lenses" - independence, not effort, is what catches the defect.
 - **Status:** graduated -> charter (`07-autonomy.md`, "Subagent challenge protocol"): the
   no-reviewer-available case is now an explicit rule with the post-merge backstop.
+
+### L9 - Gates rot, permissions creep: schedule the meta-checks
+- **Trigger:** an external loop-engineering writeup (2026-06-11) listed two failure modes
+  our system had no answer for: a test that approved a fix can silently stop catching the
+  regression it was written for ("gates rot" - we had never reverted a fix to confirm its
+  test fails), and permission scope creep in an unattended loop's settings.
+- **Lesson:** the loop's own controls need periodic verification, not just existence. A
+  gate is only as good as the last time someone proved it can fail; a permission list is
+  only as tight as its last re-read.
+- **Status:** graduated -> `triage` skill (sources 6 and 7: monthly gate spot-check with
+  revert-the-fix verification, ~30-day permissions re-audit), and the write-up skill now
+  records the accepted-change rate per batch. External validation noted: the rest of the
+  writeup's recommendations (maker/checker split, state files, objective gates, hard
+  stops, regrounding spec) were already implemented here.


### PR DESCRIPTION
Reviewed an external loop-engineering roadmap against our loop system: most recommendations (maker/checker split, state files, objective gates, hard stops, regrounding) are already implemented here; two were genuinely missing and are graduated per the lessons rule:

- triage source 6: monthly gate spot-check - revert a merged fix locally and prove its tests FAIL (gates rot otherwise)
- triage source 7: ~30-day permissions re-audit of .claude/settings allow/deny lists
- write-up: records the accepted-change rate per batch (cost per accepted change is the metric)
- lessons.md L9 records the graduation

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)