### PR TITLE
feat: demo-mode production image with rich seeded data, reset on every deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   single field of the set logger to fill the weight, reps, and effort fields
   (RPE maps to the stored RIR). Deterministic parser in the user's display
   unit; the classic fields keep working unchanged.
+- Demo-mode production image: the Dockerfile and prod compose now accept the
+  build-time demo flags (one-click demo login), and a run-once `seed-demo`
+  compose service fills the demo account with the rich deterministic dataset
+  and resets it on every deploy. Normal self-host builds are unchanged.
 - One-tap deload week: the deload recommendation banner can now start a
   7-day planned deload; while active, every suggested load steps down 10%
   (reason "planned deload", shown in the suggestion badge), it never stacks

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,16 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
+# Demo-mode flags are NEXT_PUBLIC_* and therefore baked in at build time.
+# Default off: a normal self-host build is unchanged. The public demo passes
+# these as build args (see docker-compose.prod.yml).
+ARG NEXT_PUBLIC_DEMO_MODE=false
+ARG NEXT_PUBLIC_DEMO_EMAIL=
+ARG NEXT_PUBLIC_DEMO_PASSWORD=
+ENV NEXT_PUBLIC_DEMO_MODE=$NEXT_PUBLIC_DEMO_MODE \
+    NEXT_PUBLIC_DEMO_EMAIL=$NEXT_PUBLIC_DEMO_EMAIL \
+    NEXT_PUBLIC_DEMO_PASSWORD=$NEXT_PUBLIC_DEMO_PASSWORD
+
 # Génération du client Prisma puis build Next.js
 RUN npx prisma generate
 RUN npm run build

--- a/README.md
+++ b/README.md
@@ -236,6 +236,19 @@ docker compose -f docker-compose.prod.yml up -d --build
 docker compose -f docker-compose.prod.yml exec app npx prisma migrate deploy
 ```
 
+### Deploying a public demo instance
+
+Set `NEXT_PUBLIC_DEMO_MODE=true` (plus the throwaway demo credentials) in the
+instance's `.env`, then build with the demo profile and run the one-shot
+seeder. It fills the demo account with a rich deterministic dataset (12 weeks
+of sessions, a bodyweight trend, a goal, readiness check-ins); re-running it
+on every deploy also resets whatever visitors changed.
+
+```bash
+docker compose -f docker-compose.prod.yml --profile demo up -d --build
+docker compose -f docker-compose.prod.yml --profile demo run --rm seed-demo
+```
+
 ## Roadmap
 
 - [x] Single user MVP (logging, progress, weekly AI debrief, program adjustments)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -29,6 +29,12 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        # Demo mode is build-time (NEXT_PUBLIC_*). Defaults keep a normal
+        # self-host build unchanged; the public demo sets these in its .env.
+        NEXT_PUBLIC_DEMO_MODE: ${NEXT_PUBLIC_DEMO_MODE:-false}
+        NEXT_PUBLIC_DEMO_EMAIL: ${NEXT_PUBLIC_DEMO_EMAIL:-}
+        NEXT_PUBLIC_DEMO_PASSWORD: ${NEXT_PUBLIC_DEMO_PASSWORD:-}
     container_name: gymcoach-app
     restart: always
     depends_on:
@@ -55,6 +61,28 @@ services:
       # Bind local uniquement, Nginx fait le reverse proxy en frontal.
       # Port hôte 3010 (3000 est pris par lead-radar sur le VPS partagé).
       - '127.0.0.1:3010:3000'
+
+  # Run-once demo seeder (public demo only): resets the demo account to the
+  # rich deterministic dataset (12 weeks of sessions, bodyweight trend, a
+  # goal, readiness check-ins). Built from the builder stage, which still has
+  # the dev dependencies (tsx) the seed scripts need. Re-running it on every
+  # deploy doubles as the cleanup of whatever visitors did to the demo data.
+  #   docker compose -f docker-compose.prod.yml --profile demo run --rm seed-demo
+  seed-demo:
+    profiles: ['demo']
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: builder
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      USER_EMAIL: ${USER_EMAIL}
+      USER_PASSWORD: ${USER_PASSWORD}
+    command: >
+      sh -c "npx prisma migrate deploy && npm run db:seed && npm run seed:demo"
 
 volumes:
   postgres-data:


### PR DESCRIPTION
Closes #122 (operator request: the public demo is stale and empty).

- Dockerfile: NEXT_PUBLIC_DEMO_MODE/EMAIL/PASSWORD as builder-stage build args (default off - a normal self-host build is unchanged).
- docker-compose.prod.yml: passes the build args from the env; new run-once seed-demo service under the demo profile, built from the builder stage (has tsx), running migrate deploy + db:seed + seed:demo. Re-running on every deploy resets the demo account to the deterministic rich dataset, cleaning visitor pollution by design.
- README: "Deploying a public demo instance" subsection with the two commands; CHANGELOG entry.

## How I tested

- bash scripts/verify.sh - GREEN-GATE PASSED
- Built the image with the demo args and ran it against a throwaway Postgres: the login page serves the one-click demo login (asserted on the rendered HTML).
- Ran the seed-demo command from the builder image against the same DB: migrations applied, then "Demo history: 35 sessions, 986 sets over 12 weeks" + "Demo extras: 12 bodyweight entries, 1 goal, 5 readiness check-ins".

Note: this PR makes the demo deployable and rich; actually redeploying the VPS regularly is #123 (needs operator SSH secrets - human decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)