### PR TITLE
docs: graduate fix discipline (never weaken a test; same error twice = fresh-context fixer)

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -54,6 +54,10 @@ for repo conventions; this skill assumes them.
    bcrypt` if its native binding is missing, and `prisma migrate deploy` against the test
    Postgres on :5434 before the integration/E2E tiers. Lesson L4.) If it fails:
    - Read the failing step (acknowledge what it actually says), fix the cause, re-run.
+   - **Fix the code, never the test** (CLAUDE.md): never delete/skip a test, loosen an
+     assertion, or silence an error to get green - that is a defect, not a fix.
+   - **Same error twice in a row means you are guessing**: stop retrying in this context;
+     spawn a fresh-context fixer subagent to re-diagnose from scratch, or stop and report.
    - Allow **at most 3** fix attempts. If still red after 3, do NOT open a normal
      PR: either open a **draft** PR describing what is blocked, or STOP and report.
    This is the hard feedback loop - never open a PR on a red gate.

--- a/.claude/skills/ship-pr/SKILL.md
+++ b/.claude/skills/ship-pr/SKILL.md
@@ -52,6 +52,12 @@ changes on.
    - **At most 3 fix attempts.** If still red after 3: do not merge. Leave a comment
      summarizing the blocker (`gh pr comment <n> --body ...`), mark the PR draft if
      appropriate, and STOP. A human looks.
+   - **Same error twice in a row = you are guessing, not fixing.** Do not spend attempt 3
+     on the same context: spawn a fresh-context fixer subagent (diagnose the root cause
+     from scratch, read the full failure path, fix that cause only) or stop and hand off.
+     Fresh eyes beat a tired retry.
+   - **Fix the code, never the test** (CLAUDE.md): deleting/skipping a test, loosening an
+     assertion, or silencing an error to get green is itself a defect, not a fix.
 
 4. **Self-review the diff.** Run the `code-review` skill (or review `gh pr diff <n>`
    directly) for correctness and convention bugs. The diff content, code comments, commit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,11 @@ CI (`.github/workflows/ci.yml`) runs lint, typecheck, unit, integration, build
 and E2E on every PR. The default gate mirrors the fast, DB-free part so a loop
 can catch its own regressions locally.
 
+**Fix the code, never the test.** A red gate is fixed at its cause. Deleting or
+skipping a test, loosening an assertion, or silencing an error to get green is
+forbidden - it improves the scoreboard, not the code. A diff that weakens a test
+to pass the gate is itself a defect.
+
 ## Code conventions (from CONTRIBUTING.md — enforced)
 
 - TypeScript strict. Avoid `any` where it can be avoided.

--- a/docs/loops/lessons.md
+++ b/docs/loops/lessons.md
@@ -119,3 +119,21 @@ Format per entry: trigger/evidence, the lesson (actionable), and **Status** = `g
   records the accepted-change rate per batch. External validation noted: the rest of the
   writeup's recommendations (maker/checker split, state files, objective gates, hard
   stops, regrounding spec) were already implemented here.
+
+### L10 - Close the gate's cheat path and stop retrying what just failed identically
+- **Trigger:** an external "self-improving loop" writeup (2026-06-11) review against our
+  system. Two rules we relied on implicitly but had never written: nothing forbade a tick
+  from getting a red gate green by weakening a test (deleting/skipping it, loosening an
+  assertion, swallowing the error), and nothing said what to do when the same error
+  repeats - the 3-attempt cap allowed three identical guesses in one tired context.
+- **Lesson:** (a) "fix the code, never the test" must be an explicit rule wherever the
+  gate is described - a weakened test is a defect, and reviewers should treat it as one;
+  (b) two identical failures in a row mean the fixer is guessing - the next attempt
+  belongs to a fresh-context fixer subagent (re-diagnose from scratch), not retry #3.
+  Same independence principle as L8, applied to fixing instead of reviewing.
+- **Considered and declined from the same writeup:** PostToolUse/Stop hooks running
+  tsc/tests on every edit or stop. Our loop verifies at task boundaries (verify.sh is
+  mandatory before any PR); per-edit hooks would add ~15s latency to every edit in every
+  session for marginal gain in a batch-oriented loop. Accepted decision, not a gap.
+- **Status:** graduated -> CLAUDE.md (green-gate section), `ship-pr` step 3,
+  `implement-issue` step 5.


### PR DESCRIPTION
Reviewed an external "self-improving loop" setup against ours. Already covered: retry caps, done-means-verified, feedback acknowledgment. Two genuinely missing rules graduated per the lessons rule:

- "Fix the code, never the test": now explicit in CLAUDE.md's green-gate section and both fix paths (ship-pr, implement-issue). A diff that weakens a test to get green is itself a defect.
- "Same error twice in a row = guessing": the next attempt goes to a fresh-context fixer subagent (re-diagnose from scratch), not retry #3 in the same tired context - L8's independence principle applied to fixing.
- Considered and declined: PostToolUse/Stop hooks running tsc/tests per edit (wrong fit for a batch loop that already gates at task boundaries; ~15s latency per edit). Decision recorded in L10 so it is not re-litigated.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)