### PR TITLE
fix: copy bcrypt prebuilds into the standalone Docker image (auth 500)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,13 @@ COPY --from=builder --chown=nextjs:nodejs /app/node_modules/.prisma ./node_modul
 COPY --from=builder --chown=nextjs:nodejs /app/node_modules/@prisma ./node_modules/@prisma
 COPY --from=builder --chown=nextjs:nodejs /app/node_modules/prisma ./node_modules/prisma
 
+# bcrypt 6 resolves its native binding from prebuilds/ via node-gyp-build at
+# runtime; the Next standalone tracer misses those .node files, which 500s
+# every auth route in the image (issue #127). Copy the full module from the
+# builder, where the binding is known-good.
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules/bcrypt ./node_modules/bcrypt
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules/node-gyp-build ./node_modules/node-gyp-build
+
 USER nextjs
 EXPOSE 3000
 ENV PORT=3000


### PR DESCRIPTION
Closes #127. Found live on the public demo (reported as "the demo has no data" - in fact login 500ed).

bcrypt@6 loads its native binding from prebuilds/ via node-gyp-build at runtime; the Next standalone tracer misses those .node files, so the production image had no working auth while the builder stage (full node_modules - used by the seeder) was fine. CI never sees this because nothing runs inside the image.

Fix: the runner stage copies node_modules/bcrypt (and node-gyp-build) from the builder, mirroring the existing Prisma copy pattern.

## How I tested

- docker build of the fixed image + seeded throwaway Postgres: POST /api/auth/login -> 200 (was 500 with the previous image, reproduced on the live demo)
- bash scripts/verify.sh - GREEN-GATE PASSED

Follow-up filed: a CI smoke test that builds the image and probes login, so image-only regressions are caught pre-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)