### PR TITLE
docs: drop "hypertrophy" from the product descriptor, keep "training tracker"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — working agreement for agents on GymCoach
 
-GymCoach is an open source, self-hosted hypertrophy training tracker with a
+GymCoach is an open source, self-hosted training tracker with a
 built-in AI coach. This file tells any Claude Code agent (interactive or inside
 a loop) how to work in this repo so it does not have to re-derive conventions.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GymCoach
 
-Open source, self hosted hypertrophy training tracker with a built in AI coach. Log your sessions, track your progress, and get evidence based weekly debriefs and program suggestions from the LLM of your choice (Anthropic Claude or any OpenRouter model).
+Open source, self hosted training tracker with a built in AI coach. Log your sessions, track your progress, and get evidence based weekly debriefs and program suggestions from the LLM of your choice (Anthropic Claude or any OpenRouter model).
 
 [![CI](https://github.com/Julien-Au/gymcoach/actions/workflows/ci.yml/badge.svg)](https://github.com/Julien-Au/gymcoach/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gymcoach",
   "version": "0.1.0",
   "private": true,
-  "description": "Open source, self hosted hypertrophy training tracker with a built in AI coach",
+  "description": "Open source, self hosted training tracker with a built in AI coach",
   "license": "MIT",
   "scripts": {
     "dev": "next dev -p 3030",


### PR DESCRIPTION
Operator request 2026-06-11: the product anchor reads "open source, self hosted training tracker with a built in AI coach" - README tagline, CLAUDE.md project line, package.json description. Functional occurrences (training-goal labels, the MEV/MRV explainer, form placeholders) are deliberately untouched. The GitHub repo About description already had no "hypertrophy".

bash scripts/verify.sh - GREEN-GATE PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)