### PR TITLE
docs: broaden the product vision beyond hypertrophy (training/fitness)

### DIFF
--- a/.claude/skills/ideate/SKILL.md
+++ b/.claude/skills/ideate/SKILL.md
@@ -7,7 +7,7 @@ description: When the backlog is empty, manufacture well-scoped PRODUCT feature 
 
 triage manufactures code-health work (tests, small bugs, deps); `ideate` manufactures
 **product** work when even triage comes up dry, so the loop keeps pushing the product
-toward the goal of being the most complete self-hosted AI hypertrophy/fitness app - not
+toward the goal of being the most complete self-hosted AI training/fitness app - not
 just keeping it tidy. The output is **issues, not code**: crisp, single-PR feature ideas a
 later `implement-issue` run picks up unattended. Read `CLAUDE.md` and
 `docs/loops/07-autonomy.md` first.
@@ -40,7 +40,11 @@ ideas on top of unstarted ones.
 
 ## Where ideas come from (grounded, not random)
 
-1. **The vision.** Aim: the most complete self-hosted AI hypertrophy/fitness app. Ask "what
+1. **The vision.** Aim: the most complete self-hosted AI training/fitness app. The operator
+   broadened the scope (2026-06-11) beyond pure hypertrophy: strength, conditioning/cardio,
+   endurance, mobility, and general fitness are all in scope. Concretely, the CSV importers
+   (`lib/import/strong-csv.ts`, `lib/import/hevy-csv.ts`) currently SKIP cardio rows and
+   nothing in the app tracks duration/distance work - that axis is now fair game. Ask "what
    would a serious lifter, a coach, or a leading competitor expect that we do not have yet?"
 2. **The captured research** (Memory: `research-product-direction.md`) and its wedge - AI
    that advises *within* the user's program, explains why, and respects data ownership.
@@ -50,7 +54,7 @@ ideas on top of unstarted ones.
    uses it next).
 4. **The README roadmap** - unchecked items.
 5. **Optional bounded web check** (<= ~6 searches) for what users want / what is missing in
-   AI hypertrophy apps lately - only if it beats the memory. No heavy fan-out.
+   AI training/fitness apps lately - only if it beats the memory. No heavy fan-out.
 
 ## What a good idea-issue looks like
 

--- a/docs/loops/08-ideation-loop.md
+++ b/docs/loops/08-ideation-loop.md
@@ -4,7 +4,7 @@
 But a repo that only tidies itself plateaus. The ideation loop is the head *above* triage:
 when even triage comes up dry, it manufactures **product** work - well-scoped feature ideas
 - so the Issue -> PR loop never starves for *direction*, and the product keeps moving
-toward the goal of being the most complete self-hosted AI hypertrophy/fitness app.
+toward the goal of being the most complete self-hosted AI training/fitness app.
 
 It is the cheap, recurring cousin of the one-off deep-research workflow we ran once to seed
 the roadmap (captured in Memory `research-product-direction.md`). That workflow spent ~100

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -6,6 +6,25 @@ by the charter in [`07-autonomy.md`](07-autonomy.md).
 
 ---
 
+## 2026-06-11 - Operator decision: product vision broadened beyond hypertrophy
+
+**Context.** The operator decided (2026-06-11) that the product opens beyond pure
+hypertrophy. The aim becomes: **the most complete self-hosted AI training/fitness app** -
+strength, conditioning/cardio, endurance, mobility, and general fitness are all in scope.
+
+**Decided / shipped.** Updated the two spots that carried the old wording:
+`.claude/skills/ideate/SKILL.md` (three occurrences; the "The vision" item now records the
+broadening and the concrete opening: the Strong/Hevy CSV importers currently SKIP cardio
+rows and nothing tracks duration/distance work - that axis is now fair game) and
+`docs/loops/08-ideation-loop.md` (one occurrence). Docs-only PR, no code change.
+
+**Challenged.** Docs-only; merged on green CI per the charter (no independent review
+needed for wording-only changes).
+
+**Deferred to human.** Nothing.
+
+---
+
 ## 2026-06-11 - Fifth batch: roadmap's last AI item shipped; first zero-defect reviews; model routing live
 
 **Context.** Fifth ideate batch (#111 ask-the-coach mid-session, #112 one-tap deload,


### PR DESCRIPTION
## Context

Operator decision (2026-06-11): the product opens beyond pure hypertrophy. The aim becomes **the most complete self-hosted AI training/fitness app** - strength, conditioning/cardio, endurance, mobility, and general fitness are all in scope.

## Changes

- `.claude/skills/ideate/SKILL.md`: three occurrences of the old "hypertrophy/fitness app" / "AI hypertrophy apps" wording updated; the "The vision" item now records the broadening decision and the concrete opening (the Strong/Hevy CSV importers currently SKIP cardio rows and nothing tracks duration/distance work - that axis is now fair game).
- `docs/loops/08-ideation-loop.md`: one occurrence updated.
- `docs/loops/autonomy-log.md`: newest-first entry recording the decision.

Docs-only; `bash scripts/verify.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)