### PR TITLE
feat: import cardio rows from Strong/Hevy CSV instead of skipping them

### DIFF
--- a/app/api/import/hevy/route.ts
+++ b/app/api/import/hevy/route.ts
@@ -65,6 +65,8 @@ export async function POST(req: Request) {
               setNumber: true,
               weight: true,
               reps: true,
+              durationSec: true,
+              distanceM: true,
               exercise: { select: { name: true } },
             },
           },
@@ -75,7 +77,15 @@ export async function POST(req: Request) {
         existingSessionDates.add(dateKey);
         for (const set of session.sets) {
           existingSetKeys.add(
-            setDuplicateKey(dateKey, set.exercise.name, set.setNumber, set.weight, set.reps),
+            setDuplicateKey(
+              dateKey,
+              set.exercise.name,
+              set.setNumber,
+              set.weight,
+              set.reps,
+              set.durationSec,
+              set.distanceM,
+            ),
           );
         }
       }
@@ -93,6 +103,9 @@ export async function POST(req: Request) {
 
     const common = {
       duplicatesSkipped: plan.duplicateCount,
+      // Cardio sets among the planned sets (issue #134); cardioSkipped now
+      // only counts rows that cannot be represented (no usable duration).
+      cardioSets: plan.cardioSetCount,
       cardioSkipped: parsed.cardioSkipped,
       errorCount: parsed.errors.length,
       errors: parsed.errors.slice(0, MAX_REPORTED_ERRORS),

--- a/app/api/import/strong/route.ts
+++ b/app/api/import/strong/route.ts
@@ -63,6 +63,8 @@ export async function POST(req: Request) {
               setNumber: true,
               weight: true,
               reps: true,
+              durationSec: true,
+              distanceM: true,
               exercise: { select: { name: true } },
             },
           },
@@ -73,7 +75,15 @@ export async function POST(req: Request) {
         existingSessionDates.add(dateKey);
         for (const set of session.sets) {
           existingSetKeys.add(
-            setDuplicateKey(dateKey, set.exercise.name, set.setNumber, set.weight, set.reps),
+            setDuplicateKey(
+              dateKey,
+              set.exercise.name,
+              set.setNumber,
+              set.weight,
+              set.reps,
+              set.durationSec,
+              set.distanceM,
+            ),
           );
         }
       }
@@ -91,6 +101,9 @@ export async function POST(req: Request) {
 
     const common = {
       duplicatesSkipped: plan.duplicateCount,
+      // Cardio sets among the planned sets (issue #134); cardioSkipped now
+      // only counts rows that cannot be represented (no usable duration).
+      cardioSets: plan.cardioSetCount,
       cardioSkipped: parsed.cardioSkipped,
       errorCount: parsed.errors.length,
       errors: parsed.errors.slice(0, MAX_REPORTED_ERRORS),

--- a/components/settings/import-section.test.tsx
+++ b/components/settings/import-section.test.tsx
@@ -15,6 +15,7 @@ const PREVIEW = {
   newExercises: ['Bench Press'],
   existingSessionDates: [],
   duplicatesSkipped: 0,
+  cardioSets: 1,
   cardioSkipped: 1,
   errorCount: 1,
   errors: [{ line: 4, reason: 'Invalid or missing date.' }],
@@ -60,7 +61,8 @@ describe('ImportSection', () => {
 
     expect(screen.getByText(/2 sessions, 3 sets to import/)).toBeInTheDocument();
     expect(screen.getByText(/1 new exercise will be created/)).toBeInTheDocument();
-    expect(screen.getByText(/1 cardio row/)).toBeInTheDocument();
+    expect(screen.getByText(/1 cardio set \(duration\/distance\) included/)).toBeInTheDocument();
+    expect(screen.getByText(/1 cardio row without a usable duration/)).toBeInTheDocument();
     expect(screen.getByText(/line 4: invalid or missing date/i)).toBeInTheDocument();
   });
 

--- a/components/settings/import-section.tsx
+++ b/components/settings/import-section.tsx
@@ -39,6 +39,9 @@ interface Preview {
   newExercises: string[];
   existingSessionDates: string[];
   duplicatesSkipped: number;
+  // Cardio sets to import (issue #134) vs rows that still cannot be
+  // represented (no usable duration) and are skipped with a notice.
+  cardioSets: number;
   cardioSkipped: number;
   errorCount: number;
   errors: LineError[];
@@ -256,8 +259,18 @@ export function ImportSection() {
               {preview.duplicatesSkipped > 0 && (
                 <li>{preview.duplicatesSkipped} exact duplicates will be skipped</li>
               )}
+              {preview.cardioSets > 0 && (
+                <li>
+                  {preview.cardioSets} cardio set{preview.cardioSets === 1 ? '' : 's'}{' '}
+                  (duration/distance) included
+                </li>
+              )}
               {preview.cardioSkipped > 0 && (
-                <li>{preview.cardioSkipped} cardio rows (no reps) will be skipped</li>
+                <li>
+                  {preview.cardioSkipped} cardio row
+                  {preview.cardioSkipped === 1 ? '' : 's'} without a usable duration will
+                  be skipped
+                </li>
               )}
               {preview.existingSessionDates.length > 0 && (
                 <li className="text-amber-700 dark:text-amber-400">

--- a/lib/cardio.ts
+++ b/lib/cardio.ts
@@ -12,6 +12,9 @@
 export const MAX_DURATION_SEC = 86400;
 export const MAX_DISTANCE_M = 1000000;
 
+// Statute mile in meters, for imports from imperial-unit exports.
+export const MILES_TO_METERS = 1609.34;
+
 // True when a set-like record is a cardio set.
 export function isCardioSet(set: { durationSec?: number | null }): boolean {
   return set.durationSec != null;

--- a/lib/import/hevy-csv.test.ts
+++ b/lib/import/hevy-csv.test.ts
@@ -198,7 +198,9 @@ describe('parseHevyCsv malformed input', () => {
     expect(res.rows[0]?.finishedAtIso).toBeNull();
   });
 
-  it('skips cardio rows (duration or distance, no reps) with a count', () => {
+  // Cardio rows are imported as duration/distance sets since issue #134
+  // (they were skipped with a count before).
+  it('maps cardio rows (duration, optional distance) onto cardio sets', () => {
     const res = parseHevyCsv(
       csv(
         line({ exercise_title: 'Running', reps: '', distance_km: '5', duration_seconds: '1800', weight_kg: '' }),
@@ -206,9 +208,63 @@ describe('parseHevyCsv malformed input', () => {
         line({ set_index: '1' }),
       ),
     );
-    expect(res.cardioSkipped).toBe(2);
-    expect(res.rows).toHaveLength(1);
+    expect(res.cardioSkipped).toBe(0);
     expect(res.errors).toEqual([]);
+    expect(res.rows).toHaveLength(3);
+    // distance_km converted to meters; cardio convention weight 0 / reps 1.
+    expect(res.rows[0]).toMatchObject({
+      exerciseName: 'Running',
+      setOrder: 1,
+      weightKg: 0,
+      reps: 1,
+      durationSec: 1800,
+      distanceM: 5000,
+      isWarmup: false,
+      isDropSet: false,
+      startedAtIso: '2026-05-02T09:13:00.000Z',
+    });
+    expect(res.rows[1]).toMatchObject({
+      exerciseName: 'Plank',
+      durationSec: 60,
+      distanceM: null,
+    });
+    // The strength row is untouched (no cardio keys at all).
+    expect(res.rows[2]).not.toHaveProperty('durationSec');
+    expect(res.rows[2]).toMatchObject({ weightKg: 80, reps: 8, setOrder: 2 });
+  });
+
+  it('converts cardio distance from the distance_miles header variant', () => {
+    const header =
+      'title,start_time,exercise_title,set_index,set_type,weight_kg,reps,distance_miles,duration_seconds';
+    const res = parseHevyCsv(
+      [header, 'Run Day,2026-05-02 09:13:00,Running,0,normal,,,3,1800'].join('\n'),
+    );
+    expect(res.errors).toEqual([]);
+    expect(res.rows[0]).toMatchObject({
+      durationSec: 1800,
+      distanceM: +(3 * 1609.34).toFixed(2),
+    });
+  });
+
+  it('still skips unrepresentable cardio rows with a count (no usable duration)', () => {
+    const res = parseHevyCsv(
+      csv(
+        line({ exercise_title: 'Rowing', reps: '', distance_km: '5', duration_seconds: '', weight_kg: '' }),
+        line({ exercise_title: 'Running', reps: '', duration_seconds: '90000', weight_kg: '' }),
+      ),
+    );
+    expect(res.cardioSkipped).toBe(2);
+    expect(res.rows).toHaveLength(0);
+    expect(res.errors).toEqual([]);
+  });
+
+  it('reports a cardio row with a missing set_index as a line error', () => {
+    const res = parseHevyCsv(
+      csv(line({ exercise_title: 'Running', reps: '', duration_seconds: '1800', weight_kg: '', set_index: '' })),
+    );
+    expect(res.cardioSkipped).toBe(0);
+    expect(res.rows).toHaveLength(0);
+    expect(res.errors).toHaveLength(1);
   });
 
   it('reports a 0-rep row with no duration as an error, not cardio', () => {

--- a/lib/import/hevy-csv.ts
+++ b/lib/import/hevy-csv.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { MAX_DISTANCE_M, MAX_DURATION_SEC, MILES_TO_METERS } from '@/lib/cardio';
 import { lbToKg, roundWeight } from '@/lib/units';
 import {
   asNumber,
@@ -41,7 +42,9 @@ export interface HevyCsvParseResult {
   fatalError: string | null;
   rows: HevyCsvRow[];
   errors: CsvLineError[];
-  // Duration/distance-only rows (cardio) skipped with a counted notice.
+  // Cardio rows that still cannot be represented (issue #134: zero/negative
+  // or out-of-bounds duration), skipped with a counted notice. Representable
+  // cardio rows are imported as duration/distance sets since #133.
   cardioSkipped: number;
 }
 
@@ -56,6 +59,17 @@ const rowSchema = z.object({
   reps: z.coerce.number().int().min(1).max(100),
 });
 
+// Cardio rows (issue #134): same identity fields, plus the #133 set bounds
+// on duration/distance. weight/reps are forced to the cardio convention.
+const cardioRowSchema = z.object({
+  dateKey: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  workoutName: z.string().trim().min(1).max(200),
+  exerciseName: z.string().trim().min(1).max(120),
+  setOrder: z.coerce.number().int().min(1).max(50),
+  durationSec: z.number().int().min(1).max(MAX_DURATION_SEC),
+  distanceM: z.number().min(0).max(MAX_DISTANCE_M).nullable(),
+});
+
 interface HeaderMap {
   title: number;
   startTime: number;
@@ -68,6 +82,8 @@ interface HeaderMap {
   weightIsLbs: boolean;
   reps: number;
   distance: number | null;
+  // True when the distance column is the miles variant (issue #134).
+  distanceIsMiles: boolean;
   duration: number | null;
 }
 
@@ -107,7 +123,12 @@ function mapHeader(cells: string[]): HeaderMap | null {
   }
   const endTime = find('end_time');
   const setType = find('set_type');
-  const distance = find('distance_km', 'distance_miles');
+  let distanceIsMiles = false;
+  let distance = find('distance_km');
+  if (distance === -1) {
+    distance = find('distance_miles');
+    if (distance !== -1) distanceIsMiles = true;
+  }
   const duration = find('duration_seconds');
   return {
     title,
@@ -120,6 +141,7 @@ function mapHeader(cells: string[]): HeaderMap | null {
     weightIsLbs,
     reps,
     distance: distance === -1 ? null : distance,
+    distanceIsMiles,
     duration: duration === -1 ? null : duration,
   };
 }
@@ -221,10 +243,58 @@ export function parseHevyCsv(text: string): HevyCsvParseResult {
     const distance = asNumber(get(map.distance));
     const duration = asNumber(get(map.duration));
 
-    // Cardio / duration-only rows (no reps, but distance or time): skipped
-    // with a counted notice rather than reported as errors.
+    // Cardio / duration-only rows (no reps, but distance or time) become
+    // duration/distance sets (issue #134). The qualifying condition is
+    // exactly the pre-#134 skip branch; only what happens to the row changed.
     if (!(reps >= 1) && (distance > 0 || duration > 0)) {
-      cardioSkipped++;
+      // A representable cardio set needs a duration (the #133 model); a
+      // distance-only or out-of-bounds row stays a counted skip notice.
+      if (!(duration >= 1) || duration > MAX_DURATION_SEC) {
+        cardioSkipped++;
+        continue;
+      }
+      // distance_km in km, distance_miles in miles; stored in meters.
+      const distanceM =
+        distance > 0
+          ? +(distance * (map.distanceIsMiles ? MILES_TO_METERS : 1000)).toFixed(2)
+          : null;
+      if (distanceM !== null && distanceM > MAX_DISTANCE_M) {
+        cardioSkipped++;
+        continue;
+      }
+      // Same set_index handling as strength rows: 0-based, a missing index
+      // fails the row instead of colliding with real first sets.
+      const cardioSetIndexCell = get(map.setIndex);
+      const cardioSetIndex =
+        cardioSetIndexCell === undefined || cardioSetIndexCell.trim() === ''
+          ? NaN
+          : asNumber(cardioSetIndexCell);
+      const cardioParsed = cardioRowSchema.safeParse({
+        dateKey: start.dateKey,
+        workoutName: get(map.title) ?? '',
+        exerciseName: get(map.exerciseTitle) ?? '',
+        setOrder: cardioSetIndex + 1,
+        durationSec: Math.round(duration),
+        distanceM,
+      });
+      if (!cardioParsed.success) {
+        const issue = cardioParsed.error.issues[0];
+        errors.push({
+          line: record.line,
+          reason: issue ? `${issue.path.join('.')}: ${issue.message}` : 'Invalid row.',
+        });
+        continue;
+      }
+      const cardioSetType = headerKey(get(map.setType) ?? '');
+      rows.push({
+        ...cardioParsed.data,
+        weightKg: 0,
+        reps: 1,
+        isWarmup: cardioSetType === 'warmup',
+        isDropSet: cardioSetType === 'dropset',
+        startedAtIso: start.iso,
+        finishedAtIso: end?.iso ?? null,
+      });
       continue;
     }
 

--- a/lib/import/strong-csv.test.ts
+++ b/lib/import/strong-csv.test.ts
@@ -124,7 +124,9 @@ describe('parseStrongCsv malformed input', () => {
     expect(res.errors.map((e) => e.line)).toEqual([2, 3, 5, 6, 7]);
   });
 
-  it('skips cardio rows (duration or distance, no reps) with a count', () => {
+  // Cardio rows are imported as duration/distance sets since issue #134
+  // (they were skipped with a count before).
+  it('maps cardio rows (duration, optional distance) onto cardio sets', () => {
     const res = parseStrongCsv(
       csv(
         '2026-05-02,Cardio,Running,1,0,0,5000,1800',
@@ -132,9 +134,68 @@ describe('parseStrongCsv malformed input', () => {
         '2026-05-02,Push,Bench,1,80,8,0,0',
       ),
     );
-    expect(res.cardioSkipped).toBe(2);
-    expect(res.rows).toHaveLength(1);
+    expect(res.cardioSkipped).toBe(0);
     expect(res.errors).toEqual([]);
+    expect(res.rows).toHaveLength(3);
+    // Metric export: Distance is in meters.
+    expect(res.rows[0]).toEqual({
+      dateKey: '2026-05-02',
+      workoutName: 'Cardio',
+      exerciseName: 'Running',
+      setOrder: 1,
+      weightKg: 0,
+      reps: 1,
+      durationSec: 1800,
+      distanceM: 5000,
+    });
+    // Duration-only cardio: distance stays null.
+    expect(res.rows[1]).toMatchObject({
+      exerciseName: 'Plank',
+      durationSec: 60,
+      distanceM: null,
+    });
+    // The strength row is untouched (no cardio keys at all).
+    expect(res.rows[2]).toEqual({
+      dateKey: '2026-05-02',
+      workoutName: 'Push',
+      exerciseName: 'Bench',
+      setOrder: 1,
+      weightKg: 80,
+      reps: 8,
+    });
+  });
+
+  it('converts cardio distance from miles when the export unit is LB', () => {
+    const res = parseStrongCsv(csv('2026-05-02,Cardio,Running,1,0,0,3,1800'), 'LB');
+    expect(res.rows[0]).toMatchObject({
+      durationSec: 1800,
+      distanceM: +(3 * 1609.34).toFixed(2),
+    });
+  });
+
+  it('still skips unrepresentable cardio rows with a count (no usable duration)', () => {
+    const res = parseStrongCsv(
+      csv(
+        '2026-05-02,Cardio,Rowing,1,0,0,5000,0', // distance-only, no duration
+        '2026-05-02,Cardio,Running,1,0,0,0,90000', // duration above the 24h cap
+      ),
+    );
+    expect(res.cardioSkipped).toBe(2);
+    expect(res.rows).toHaveLength(0);
+    expect(res.errors).toEqual([]);
+  });
+
+  it('skips a cardio row whose converted distance exceeds the 1000 km cap', () => {
+    const res = parseStrongCsv(csv('2026-05-02,Cardio,Cycling,1,0,0,2000000,3600'));
+    expect(res.cardioSkipped).toBe(1);
+    expect(res.rows).toHaveLength(0);
+  });
+
+  it('reports a cardio row with a bad set order as a line error', () => {
+    const res = parseStrongCsv(csv('2026-05-02,Cardio,Running,zero,0,0,0,1800'));
+    expect(res.cardioSkipped).toBe(0);
+    expect(res.rows).toHaveLength(0);
+    expect(res.errors).toHaveLength(1);
   });
 
   it('reports a 0-rep row with no duration as an error, not cardio', () => {

--- a/lib/import/strong-csv.ts
+++ b/lib/import/strong-csv.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { WeightUnit } from '@prisma/client';
+import { MAX_DISTANCE_M, MAX_DURATION_SEC, MILES_TO_METERS } from '@/lib/cardio';
 import { lbToKg, roundWeight } from '@/lib/units';
 import {
   asNumber,
@@ -31,6 +32,10 @@ export interface StrongCsvRow {
   setOrder: number;
   weightKg: number;
   reps: number;
+  // Cardio rows (issue #134): duration in seconds, optional distance in
+  // meters (the #133 set model). Absent on strength rows.
+  durationSec?: number;
+  distanceM?: number | null;
 }
 
 export interface StrongCsvLineError {
@@ -45,7 +50,9 @@ export interface StrongCsvParseResult {
   fatalError: string | null;
   rows: StrongCsvRow[];
   errors: StrongCsvLineError[];
-  // Duration/distance-only rows (cardio) skipped with a counted notice.
+  // Cardio rows that still cannot be represented (issue #134: zero/negative
+  // or out-of-bounds duration), skipped with a counted notice. Representable
+  // cardio rows are imported as duration/distance sets since #133.
   cardioSkipped: number;
 }
 
@@ -58,6 +65,17 @@ const rowSchema = z.object({
   setOrder: z.coerce.number().int().min(1).max(50),
   weightKg: z.coerce.number().min(0).max(500),
   reps: z.coerce.number().int().min(1).max(100),
+});
+
+// Cardio rows (issue #134): same identity fields, plus the #133 set bounds
+// on duration/distance. weight/reps are forced to the cardio convention.
+const cardioRowSchema = z.object({
+  dateKey: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  workoutName: z.string().trim().min(1).max(200),
+  exerciseName: z.string().trim().min(1).max(120),
+  setOrder: z.coerce.number().int().min(1).max(50),
+  durationSec: z.number().int().min(1).max(MAX_DURATION_SEC),
+  distanceM: z.number().min(0).max(MAX_DISTANCE_M).nullable(),
 });
 
 interface HeaderMap {
@@ -199,10 +217,43 @@ export function parseStrongCsv(
     const distance = asNumber(get(map.distance));
     const seconds = asNumber(get(map.seconds));
 
-    // Cardio / duration-only rows (no reps, but distance or time): skipped
-    // with a counted notice rather than reported as errors.
+    // Cardio / duration-only rows (no reps, but distance or time) become
+    // duration/distance sets (issue #134). The qualifying condition is
+    // exactly the pre-#134 skip branch; only what happens to the row changed.
+    // Strong's Distance follows the export's unit setting: meters when the
+    // app is metric (kg), miles when imperial (lbs).
     if (!(reps >= 1) && (distance > 0 || seconds > 0)) {
-      cardioSkipped++;
+      // A representable cardio set needs a duration (the #133 model); a
+      // distance-only or out-of-bounds row stays a counted skip notice.
+      if (!(seconds >= 1) || seconds > MAX_DURATION_SEC) {
+        cardioSkipped++;
+        continue;
+      }
+      const distanceM =
+        distance > 0
+          ? +(effectiveUnit === 'LB' ? distance * MILES_TO_METERS : distance).toFixed(2)
+          : null;
+      if (distanceM !== null && distanceM > MAX_DISTANCE_M) {
+        cardioSkipped++;
+        continue;
+      }
+      const cardioParsed = cardioRowSchema.safeParse({
+        dateKey,
+        workoutName: get(map.workoutName) ?? '',
+        exerciseName: get(map.exerciseName) ?? '',
+        setOrder: get(map.setOrder),
+        durationSec: Math.round(seconds),
+        distanceM,
+      });
+      if (!cardioParsed.success) {
+        const issue = cardioParsed.error.issues[0];
+        errors.push({
+          line: record.line,
+          reason: issue ? `${issue.path.join('.')}: ${issue.message}` : 'Invalid row.',
+        });
+        continue;
+      }
+      rows.push({ ...cardioParsed.data, weightKg: 0, reps: 1 });
       continue;
     }
 

--- a/lib/import/strong-import.test.ts
+++ b/lib/import/strong-import.test.ts
@@ -92,3 +92,73 @@ describe('sessionDateFromKey', () => {
     );
   });
 });
+
+// Cardio rows in the plan (issue #134).
+describe('buildStrongImportPlan - cardio sets', () => {
+  const cardioRow = (over: Partial<StrongCsvRow> = {}): StrongCsvRow =>
+    row({
+      exerciseName: 'Running',
+      weightKg: 0,
+      reps: 1,
+      durationSec: 1800,
+      distanceM: 5000,
+      ...over,
+    });
+
+  it('carries duration/distance onto planned sets and counts them', () => {
+    const plan = buildStrongImportPlan([cardioRow(), row({ setOrder: 2 })], [], new Set());
+    expect(plan.totalSets).toBe(2);
+    expect(plan.cardioSetCount).toBe(1);
+    const sets = plan.sessions[0]!.sets;
+    const cardio = sets.find((s) => s.exerciseName === 'Running')!;
+    expect(cardio.durationSec).toBe(1800);
+    expect(cardio.distanceM).toBe(5000);
+    const strength = sets.find((s) => s.exerciseName === 'Bench')!;
+    expect(strength).not.toHaveProperty('durationSec');
+  });
+
+  it('flags a new exercise as cardio only when every row of it is cardio', () => {
+    const plan = buildStrongImportPlan(
+      [
+        cardioRow(),
+        cardioRow({ exerciseName: 'Rowing', setOrder: 2, distanceM: null }),
+        // Mixed: one cardio row and one strength row for the same name.
+        cardioRow({ exerciseName: 'Mixed Thing', setOrder: 3 }),
+        row({ exerciseName: 'Mixed Thing', setOrder: 4 }),
+      ],
+      [],
+      new Set(),
+    );
+    expect(plan.newExerciseNames).toEqual(['Mixed Thing', 'Rowing', 'Running']);
+    expect(plan.newCardioExerciseNames).toEqual(['Rowing', 'Running']);
+  });
+
+  it('does not collapse two different cardio efforts at the same set order as duplicates', () => {
+    const plan = buildStrongImportPlan(
+      [
+        cardioRow({ workoutName: 'AM Run' }),
+        cardioRow({ workoutName: 'PM Run', durationSec: 2400, distanceM: 7000 }),
+      ],
+      [],
+      new Set(),
+    );
+    expect(plan.duplicateCount).toBe(0);
+    expect(plan.totalSets).toBe(2);
+  });
+
+  it('still skips an exact cardio duplicate (same duration and distance)', () => {
+    const key = setDuplicateKey('2026-05-02', 'Running', 1, 0, 1, 1800, 5000);
+    const plan = buildStrongImportPlan([cardioRow()], [], new Set([key]));
+    expect(plan.duplicateCount).toBe(1);
+    expect(plan.totalSets).toBe(0);
+  });
+
+  it('keeps strength duplicate keys byte-identical to the pre-cardio format', () => {
+    expect(setDuplicateKey('2026-05-02', 'Bench', 1, 80, 8)).toBe(
+      '2026-05-02|bench|1|80|8',
+    );
+    expect(setDuplicateKey('2026-05-02', 'Bench', 1, 80, 8, null, null)).toBe(
+      '2026-05-02|bench|1|80|8',
+    );
+  });
+});

--- a/lib/import/strong-import.ts
+++ b/lib/import/strong-import.ts
@@ -23,6 +23,11 @@ export interface NormalizedImportRow {
   // Optional extras (issue #113). Absent for Strong rows.
   isWarmup?: boolean;
   isDropSet?: boolean;
+  // Cardio rows (issue #134): duration in seconds and optional distance in
+  // meters, per the #133 set model (such rows carry weightKg 0 / reps 1).
+  // Absent/null on strength rows - their path is unchanged.
+  durationSec?: number | null;
+  distanceM?: number | null;
   // Real session times as ISO strings, when the source export has them.
   startedAtIso?: string | null;
   finishedAtIso?: string | null;
@@ -35,6 +40,8 @@ export interface PlannedSet {
   reps: number;
   isWarmup?: boolean;
   isDropSet?: boolean;
+  durationSec?: number | null;
+  distanceM?: number | null;
 }
 
 export interface PlannedSession {
@@ -52,21 +59,33 @@ export interface StrongImportPlan {
   // New exercise names to create (original casing of first occurrence),
   // sorted.
   newExerciseNames: string[];
+  // Subset of newExerciseNames whose every imported row is cardio (issue
+  // #134): created as CARDIO / OTHER instead of ISOLATION / OTHER.
+  newCardioExerciseNames: string[];
   totalSets: number;
+  // Cardio sets among totalSets (durationSec present), for the summary.
+  cardioSetCount: number;
   // Exact duplicates (same day, exercise, set order, weight, reps as an
   // existing set or an earlier row of this file), skipped.
   duplicateCount: number;
 }
 
-// Key for exact-duplicate detection.
+// Key for exact-duplicate detection. Strength keys are byte-identical to the
+// pre-#134 format; cardio sets (durationSec != null) append their
+// duration/distance so two different runs logged with the same set order on
+// the same day are not collapsed (they all share weight 0 / reps 1).
 export function setDuplicateKey(
   dateKey: string,
   exerciseName: string,
   setOrder: number,
   weightKg: number,
   reps: number,
+  durationSec?: number | null,
+  distanceM?: number | null,
 ): string {
-  return `${dateKey}|${exerciseName.trim().toLowerCase()}|${setOrder}|${weightKg}|${reps}`;
+  const base = `${dateKey}|${exerciseName.trim().toLowerCase()}|${setOrder}|${weightKg}|${reps}`;
+  if (durationSec == null) return base;
+  return `${base}|d${durationSec}|${distanceM ?? 0}`;
 }
 
 export function buildStrongImportPlan(
@@ -76,18 +95,24 @@ export function buildStrongImportPlan(
 ): StrongImportPlan {
   const known = new Set(existingExerciseNames.map((n) => n.trim().toLowerCase()));
   const newByLower = new Map<string, string>();
+  // For each NEW exercise name: true while every one of its rows is cardio.
+  const newAllCardioByLower = new Map<string, boolean>();
   const sessionsByKey = new Map<string, PlannedSession>();
   const seenKeys = new Set<string>(existingSetKeys);
   let totalSets = 0;
+  let cardioSetCount = 0;
   let duplicateCount = 0;
 
   for (const row of rows) {
+    const isCardio = row.durationSec != null;
     const dupKey = setDuplicateKey(
       row.dateKey,
       row.exerciseName,
       row.setOrder,
       row.weightKg,
       row.reps,
+      row.durationSec,
+      row.distanceM,
     );
     if (seenKeys.has(dupKey)) {
       duplicateCount++;
@@ -98,6 +123,10 @@ export function buildStrongImportPlan(
     const lower = row.exerciseName.trim().toLowerCase();
     if (!known.has(lower) && !newByLower.has(lower)) {
       newByLower.set(lower, row.exerciseName.trim());
+      newAllCardioByLower.set(lower, isCardio);
+    } else if (newAllCardioByLower.has(lower) && !isCardio) {
+      // Mixed strength + cardio rows: keep the conservative strength default.
+      newAllCardioByLower.set(lower, false);
     }
 
     const sessionKey = `${row.dateKey}|${row.workoutName}`;
@@ -113,8 +142,10 @@ export function buildStrongImportPlan(
       reps: row.reps,
       ...(row.isWarmup !== undefined && { isWarmup: row.isWarmup }),
       ...(row.isDropSet !== undefined && { isDropSet: row.isDropSet }),
+      ...(isCardio && { durationSec: row.durationSec, distanceM: row.distanceM ?? null }),
     });
     totalSets++;
+    if (isCardio) cardioSetCount++;
 
     // Track the earliest start / latest end across the session's rows.
     if (row.startedAtIso) {
@@ -142,7 +173,12 @@ export function buildStrongImportPlan(
   return {
     sessions,
     newExerciseNames: [...newByLower.values()].sort((a, b) => a.localeCompare(b)),
+    newCardioExerciseNames: [...newByLower.entries()]
+      .filter(([lower]) => newAllCardioByLower.get(lower))
+      .map(([, name]) => name)
+      .sort((a, b) => a.localeCompare(b)),
     totalSets,
+    cardioSetCount,
     duplicateCount,
   };
 }
@@ -179,17 +215,25 @@ export async function executeStrongImport(
   });
   const idByLower = new Map(existing.map((e) => [e.name.trim().toLowerCase(), e.id]));
 
+  // Exercises whose imported rows are all cardio are created as CARDIO
+  // (issue #134); everything else keeps the conservative ISOLATION default.
+  const cardioLowers = new Set(
+    plan.newCardioExerciseNames.map((n) => n.trim().toLowerCase()),
+  );
   let createdExercises = 0;
   for (const name of plan.newExerciseNames) {
     const lower = name.trim().toLowerCase();
     if (idByLower.has(lower)) continue;
+    const isCardio = cardioLowers.has(lower);
     const created = await tx.exercise.create({
       data: {
         userId,
         name,
         muscleGroup: 'OTHER',
-        category: 'ISOLATION',
-        notes: `Imported from ${sourceLabel}. Adjust the muscle group and category.`,
+        category: isCardio ? 'CARDIO' : 'ISOLATION',
+        notes: isCardio
+          ? `Imported from ${sourceLabel}.`
+          : `Imported from ${sourceLabel}. Adjust the muscle group and category.`,
       },
     });
     idByLower.set(lower, created.id);
@@ -237,6 +281,8 @@ export async function executeStrongImport(
           reps: s.reps,
           isWarmup: s.isWarmup ?? false,
           isDropSet: s.isDropSet ?? false,
+          durationSec: s.durationSec ?? null,
+          distanceM: s.distanceM ?? null,
           completedAt: startedAt,
         };
       }),

--- a/tests/integration/hevy-import-route.test.ts
+++ b/tests/integration/hevy-import-route.test.ts
@@ -50,10 +50,12 @@ describe('POST /api/import/hevy (preview)', () => {
     expect(body).toMatchObject({
       mode: 'preview',
       sessions: 2,
-      sets: 4,
-      newExercises: ['Bench Press', 'Imported Row'],
+      sets: 5,
+      newExercises: ['Bench Press', 'Imported Row', 'Running'],
       duplicatesSkipped: 0,
-      cardioSkipped: 1,
+      // The Running row is imported as a cardio set since #134.
+      cardioSets: 1,
+      cardioSkipped: 0,
       errorCount: 0,
     });
 
@@ -101,9 +103,10 @@ describe('POST /api/import/hevy (confirm)', () => {
     expect(body).toMatchObject({
       mode: 'confirm',
       createdSessions: 2,
-      createdSets: 4,
-      createdExercises: 2,
-      cardioSkipped: 1,
+      createdSets: 5,
+      createdExercises: 3,
+      cardioSets: 1,
+      cardioSkipped: 0,
     });
 
     const sessions = await db.session.findMany({
@@ -131,7 +134,20 @@ describe('POST /api/import/hevy (confirm)', () => {
     expect(created.map((e) => e.notes)).toEqual([
       'Imported from Hevy. Adjust the muscle group and category.',
       'Imported from Hevy. Adjust the muscle group and category.',
+      'Imported from Hevy.',
     ]);
+    // Cardio-only imported exercises are created as CARDIO (issue #134), and
+    // their sets carry the #133 model: km converted to meters, weight 0, reps 1.
+    expect(created.map((e) => e.category)).toEqual(['ISOLATION', 'ISOLATION', 'CARDIO']);
+    const cardioSet = await db.set.findFirst({
+      where: { exercise: { name: 'Running' } },
+    });
+    expect(cardioSet).toMatchObject({
+      durationSec: 1800,
+      distanceM: 5000,
+      weight: 0,
+      reps: 1,
+    });
   });
 
   it("never matches or touches another user's exercises", async () => {
@@ -159,7 +175,7 @@ describe('POST /api/import/hevy (confirm)', () => {
     expect((await res.json()).error).toMatch(/nothing to import/i);
 
     expect(await db.session.count({ where: { userId: user.id } })).toBe(2);
-    expect(await db.set.count({ where: { session: { userId: user.id } } })).toBe(4);
+    expect(await db.set.count({ where: { session: { userId: user.id } } })).toBe(5);
   });
 
   it('rejects invalid input (Zod) and writes nothing', async () => {

--- a/tests/integration/import-route.test.ts
+++ b/tests/integration/import-route.test.ts
@@ -50,10 +50,12 @@ describe('POST /api/import/strong (preview)', () => {
     expect(body).toMatchObject({
       mode: 'preview',
       sessions: 2,
-      sets: 3,
-      newExercises: ['Bench Press', 'Imported Row'],
+      sets: 4,
+      newExercises: ['Bench Press', 'Imported Row', 'Running'],
       duplicatesSkipped: 0,
-      cardioSkipped: 1,
+      // The Running row is imported as a cardio set since #134.
+      cardioSets: 1,
+      cardioSkipped: 0,
       errorCount: 0,
     });
 
@@ -103,9 +105,10 @@ describe('POST /api/import/strong (confirm)', () => {
     expect(body).toMatchObject({
       mode: 'confirm',
       createdSessions: 2,
-      createdSets: 3,
-      createdExercises: 2,
-      cardioSkipped: 1,
+      createdSets: 4,
+      createdExercises: 3,
+      cardioSets: 1,
+      cardioSkipped: 0,
     });
 
     const sessions = await db.session.findMany({
@@ -120,9 +123,29 @@ describe('POST /api/import/strong (confirm)', () => {
     expect(sessions[0]?.notes).toBe('Imported from Strong - Push Day');
     expect(sessions[0]?.sets).toHaveLength(2);
 
-    const created = await db.exercise.findMany({ where: { userId: user.id } });
-    expect(created.map((e) => e.muscleGroup)).toEqual(['OTHER', 'OTHER']);
-    expect(created.map((e) => e.category)).toEqual(['ISOLATION', 'ISOLATION']);
+    const created = await db.exercise.findMany({
+      where: { userId: user.id },
+      orderBy: { name: 'asc' },
+    });
+    expect(created.map((e) => e.muscleGroup)).toEqual(['OTHER', 'OTHER', 'OTHER']);
+    // Cardio-only imported exercises are created as CARDIO (issue #134).
+    expect(created.map((e) => e.category)).toEqual(['ISOLATION', 'ISOLATION', 'CARDIO']);
+
+    // The cardio set carries the #133 model: duration/distance, weight 0, reps 1.
+    const cardioSet = await db.set.findFirst({
+      where: { exercise: { name: 'Running' } },
+    });
+    expect(cardioSet).toMatchObject({
+      durationSec: 1800,
+      distanceM: 5000,
+      weight: 0,
+      reps: 1,
+    });
+    // Strength sets keep NULL cardio columns (pinned).
+    const benchSet = await db.set.findFirst({
+      where: { exercise: { name: 'Bench Press' } },
+    });
+    expect(benchSet).toMatchObject({ durationSec: null, distanceM: null });
   });
 
   it('matches existing exercises case-insensitively instead of duplicating them', async () => {
@@ -135,7 +158,7 @@ describe('POST /api/import/strong (confirm)', () => {
     const body = await (
       await postImport(importReq({ csv: CSV, mode: 'confirm' }))
     ).json();
-    expect(body.createdExercises).toBe(1); // only "Imported Row"
+    expect(body.createdExercises).toBe(2); // "Imported Row" and "Running"
 
     const benchSets = await db.set.count({ where: { exerciseId: bench.id } });
     expect(benchSets).toBe(2);
@@ -168,7 +191,7 @@ describe('POST /api/import/strong (confirm)', () => {
     expect((await res.json()).error).toMatch(/nothing to import/i);
 
     expect(await db.session.count({ where: { userId: user.id } })).toBe(2);
-    expect(await db.set.count({ where: { session: { userId: user.id } } })).toBe(3);
+    expect(await db.set.count({ where: { session: { userId: user.id } } })).toBe(4);
   });
 
   it('rejects invalid input (Zod) and writes nothing', async () => {


### PR DESCRIPTION
Closes #134

The Strong and Hevy CSV importers now map cardio rows onto the first-class cardio set fields from #133 instead of skipping them.

## What changed

- **Both parsers** (`lib/import/strong-csv.ts`, `lib/import/hevy-csv.ts`): the row-qualifying condition is exactly the pre-#134 skip branch (no reps, but duration or distance). A qualifying row becomes a cardio set when its duration is usable (1..86400 s); distance is converted to meters and bounded (0..1000000 m). Rows without a usable duration (distance-only, zero/negative, or out-of-bounds) keep the counted `cardioSkipped` notice. Cardio rows are Zod-validated with the same bounds as `lib/schemas/set.ts`.
- **Unit conversion**: Strong `Distance` follows the export's unit setting - meters when metric (kg), miles x 1609.34 when imperial (lbs). Hevy `distance_km` x 1000; the `distance_miles` header variant x 1609.34 (the header map now records which variant matched).
- **Plan/executor** (`lib/import/strong-import.ts`, shared by both routes): planned sets carry `durationSec`/`distanceM`; a NEW exercise whose imported rows are all cardio is created as `CARDIO` / `OTHER` (mixed names keep the conservative `ISOLATION` default). Duplicate keys stay byte-identical for strength sets and append duration/distance for cardio sets, so two different runs at the same set order are not collapsed; the routes feed existing DB cardio sets into the key set the same way.
- **Summary**: the API responses and the preview UI now report "N cardio sets (duration/distance) included" next to the remaining skip notice; `cardioSkipped` only counts unrepresentable rows.

## Hardening posture (#105/#106/#108 bar)

- Importer input remains untrusted: the byte/row caps, streamed body cap, rate budget, transaction timeout and formula-injection-free CSV reader are untouched; cardio values pass through the same Zod bounds as manually logged sets.
- Strength-row paths are pinned: parser happy-path tests assert strength rows deep-equal their pre-#134 shape (no cardio keys), the strength duplicate-key format is asserted byte-identical, and all existing strength import tests (incl. set_type flags, real times, cross-user isolation, rollback) pass unchanged. The existing E2E import flows (strength-only fixtures) stay green.
- Tests whose counts intentionally changed are exactly the cardio-row expectations this issue redefines (skip -> import); no assertion was weakened.

## Gate

- `bash scripts/verify.sh --full` green locally (unit + integration + E2E).
- New tests: cardio mapping and bounds on both parsers (incl. miles conversion and the `distance_miles` header), plan-level cardio counting/dup keys/CARDIO exercise creation, and integration coverage of mixed strength + cardio imports on both routes with persisted set values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
