### PR TITLE
feat: conditioning card on the progress page (weekly cardio minutes/distance)

### DIFF
--- a/app/(app)/progress/page.tsx
+++ b/app/(app)/progress/page.tsx
@@ -11,6 +11,7 @@ import {
   isStalled,
   isoWeekKey,
   trainingConsistency,
+  weeklyConditioning,
   weeklySetsByMuscleGroup,
   weeklyVolumeByMuscleGroup,
   WEEKLY_SETS_MEV,
@@ -26,6 +27,7 @@ import { ProgressDashboard } from '@/components/progress/progress-dashboard';
 import { ConsistencyCard } from '@/components/progress/consistency-card';
 import { DeloadBanner } from '@/components/progress/deload-banner';
 import { BodyweightCard } from '@/components/progress/bodyweight-card';
+import { ConditioningCard } from '@/components/progress/conditioning-card';
 
 interface SearchParams {
   exerciseId?: string;
@@ -157,6 +159,8 @@ export default async function ProgressPage({
       reps: true,
       isWarmup: true,
       durationSec: true,
+      distanceM: true,
+      sessionId: true,
       exercise: { select: { muscleGroup: true, usesBodyweight: true } },
       session: { select: { startedAt: true } },
     },
@@ -295,6 +299,30 @@ export default async function ProgressPage({
     select: { id: true, weightKg: true, measuredAt: true },
   });
 
+  // Conditioning card (issue #135, display-only): weekly cardio minutes /
+  // distance / sessions over the last 8 weeks, derived from the cardio sets
+  // already fetched for the window. The card stays hidden until the user has
+  // logged at least one cardio set EVER (not just in the window), so a brand
+  // new axis never shows an empty chart unprompted.
+  const hasCardioSets =
+    (await db.set.count({
+      where: { durationSec: { not: null }, session: { userId: auth.userId } },
+    })) > 0;
+  const conditioningWeeks = hasCardioSets
+    ? weeklyConditioning(
+        weeklySetsRaw
+          .filter((s) => s.durationSec != null)
+          .map((s) => ({
+            durationSec: s.durationSec,
+            distanceM: s.distanceM,
+            isWarmup: s.isWarmup,
+            sessionId: s.sessionId,
+            sessionStartedAt: s.session.startedAt,
+          })),
+        { windowWeeks: 8 },
+      )
+    : null;
+
   const deload = recommendDeload({
     stalledExerciseNames: recap
       .filter((r) => r.stalled)
@@ -323,6 +351,18 @@ export default async function ProgressPage({
           }))}
           unit={unit}
         />
+
+        {conditioningWeeks && (
+          <ConditioningCard
+            weeks={conditioningWeeks.map((w) => ({
+              weekKey: w.weekKey,
+              weekStartIso: w.weekStart.toISOString(),
+              minutes: w.minutes,
+              distanceKm: w.distanceKm,
+              sessions: w.sessions,
+            }))}
+          />
+        )}
 
         {exercisesWithSets.length === 0 ? (
           <EmptyState

--- a/components/progress/conditioning-card.test.tsx
+++ b/components/progress/conditioning-card.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ConditioningCard, type ConditioningWeekView } from './conditioning-card';
+
+// The chart itself renders inside Recharts' ResponsiveContainer (zero-sized
+// in jsdom), so these tests assert the card chrome and the textual summary -
+// the aggregation math is covered by lib/stats.test.ts (weeklyConditioning).
+
+function week(over: Partial<ConditioningWeekView> = {}): ConditioningWeekView {
+  return {
+    weekKey: '2026-W24',
+    weekStartIso: '2026-06-08T00:00:00.000Z',
+    minutes: 0,
+    distanceKm: 0,
+    sessions: 0,
+    ...over,
+  };
+}
+
+describe('ConditioningCard', () => {
+  it('renders the title and the 150 min/week guideline copy', () => {
+    render(<ConditioningCard weeks={[week()]} />);
+    expect(screen.getByText('Conditioning')).toBeInTheDocument();
+    expect(screen.getByText(/150 min\/week guideline/)).toBeInTheDocument();
+  });
+
+  it('summarizes the current week and the window totals', () => {
+    const weeks = [
+      week({ weekKey: '2026-W23', weekStartIso: '2026-06-01T00:00:00.000Z', minutes: 90, distanceKm: 10, sessions: 2 }),
+      week({ minutes: 45, distanceKm: 5.5, sessions: 1 }),
+    ];
+    render(<ConditioningCard weeks={weeks} />);
+    expect(
+      screen.getByText(/This week: 45 min · 5.5 km · 1 session · 2-week total: 135 min, 15.5 km./),
+    ).toBeInTheDocument();
+  });
+
+  it('omits distance copy when the window has no distance data', () => {
+    render(<ConditioningCard weeks={[week({ minutes: 30, sessions: 1 })]} />);
+    expect(screen.getByText(/This week: 30 min · 1 session · 1-week total: 30 min./)).toBeInTheDocument();
+  });
+});

--- a/components/progress/conditioning-card.tsx
+++ b/components/progress/conditioning-card.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { HeartPulse } from 'lucide-react';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { WEEKLY_CONDITIONING_TARGET_MIN } from '@/lib/stats';
+
+// One weekly conditioning point, serialized at the Server Component boundary.
+export interface ConditioningWeekView {
+  weekKey: string; // YYYY-Www
+  weekStartIso: string; // Monday 00:00 UTC
+  minutes: number;
+  distanceKm: number;
+  sessions: number;
+}
+
+interface Props {
+  // Zero-filled window, oldest first (lib/stats weeklyConditioning).
+  weeks: ConditioningWeekView[];
+}
+
+function weekLabel(iso: string): string {
+  return new Intl.DateTimeFormat('en-US', { day: '2-digit', month: '2-digit' }).format(
+    new Date(iso),
+  );
+}
+
+// Conditioning card (issue #135, display-only): weekly cardio minutes as bars
+// against the WHO 150 min/week reference line, with distance and session
+// count as secondary labels. The parent hides the card entirely while the
+// user has never logged a cardio set.
+export function ConditioningCard({ weeks }: Props) {
+  const chartData = weeks.map((w) => ({
+    ...w,
+    label: weekLabel(w.weekStartIso),
+  }));
+  const current = weeks[weeks.length - 1];
+  const totalMinutes = weeks.reduce((acc, w) => acc + w.minutes, 0);
+  const totalKm = +weeks.reduce((acc, w) => acc + w.distanceKm, 0).toFixed(2);
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center gap-2">
+          <HeartPulse className="size-4 text-primary" />
+          <h2 className="text-base font-semibold">Conditioning</h2>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Weekly cardio minutes vs the {WEEKLY_CONDITIONING_TARGET_MIN} min/week guideline
+          (moderate activity). Distance and sessions in the tooltip.
+        </p>
+      </CardHeader>
+      <CardContent>
+        <div className="h-56 w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={chartData} margin={{ top: 5, right: 10, bottom: 0, left: -10 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+              <XAxis dataKey="label" tick={{ fontSize: 11 }} />
+              <YAxis tick={{ fontSize: 11 }} allowDecimals={false} />
+              <Tooltip
+                contentStyle={{
+                  background: 'hsl(var(--popover))',
+                  border: '1px solid hsl(var(--border))',
+                  borderRadius: 6,
+                  fontSize: 12,
+                }}
+                formatter={(value, name) => {
+                  if (name === 'minutes') return [`${value ?? 0} min`, 'Duration'];
+                  return [value ?? '', name];
+                }}
+                labelFormatter={(label, payload) => {
+                  const p = payload?.[0]?.payload as ConditioningWeekView | undefined;
+                  if (!p) return label;
+                  const extras = [
+                    p.distanceKm > 0 ? `${p.distanceKm} km` : null,
+                    `${p.sessions} session${p.sessions === 1 ? '' : 's'}`,
+                  ]
+                    .filter(Boolean)
+                    .join(' · ');
+                  return `Week of ${label} · ${extras}`;
+                }}
+              />
+              <ReferenceLine
+                y={WEEKLY_CONDITIONING_TARGET_MIN}
+                stroke="hsl(var(--primary))"
+                strokeDasharray="4 4"
+                label={{
+                  value: `${WEEKLY_CONDITIONING_TARGET_MIN} min`,
+                  position: 'insideTopRight',
+                  fontSize: 11,
+                  fill: 'hsl(var(--primary))',
+                }}
+              />
+              <Bar dataKey="minutes" fill="#10b981" name="minutes" />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+        <p className="mt-2 text-xs text-muted-foreground">
+          This week: {current?.minutes ?? 0} min
+          {current && current.distanceKm > 0 ? ` · ${current.distanceKm} km` : ''}
+          {current ? ` · ${current.sessions} session${current.sessions === 1 ? '' : 's'}` : ''}
+          {' · '}
+          {weeks.length}-week total: {totalMinutes} min
+          {totalKm > 0 ? `, ${totalKm} km` : ''}.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -6,6 +6,48 @@ by the charter in [`07-autonomy.md`](07-autonomy.md).
 
 ---
 
+## 2026-06-11 - Conditioning/cardio foundation batch shipped (#133, #134, #135)
+
+**Context.** Maintainer tick executing the conditioning batch ideated on 2026-06-11, in
+strict dependency order (each PR merged before the next branch was cut). All three issues
+authored by JulienAu (trust-gated, collaborator-verified 204).
+
+**Decided / shipped.**
+- PR #137 (Closes #133): first-class cardio sets. Additive migration
+  (`Set.durationSec`, `Set.distanceM`, `ExerciseCategory.CARDIO`) validated on the test
+  DB (migrate deploy + clean migrate diff); rollback baseline
+  `autonomy-baseline-2026-06-11b` tagged on main before merge. Cardio sets store
+  reps = 1 / weight = 0 (normalized server-side), Zod bounds 1..86400 s / 0..1000 km,
+  cross-field rule (duration/distance only on CARDIO exercises, duration required) in
+  the API route. Session logger swaps weight/reps for mm:ss + km inputs; sets list,
+  summary and history render `12:30 · 2.5 km`. Offline queue/sync/hydration carry the
+  fields. Tonnage/e1RM/PR/progress/MEV-MRV math skips cardio sets explicitly; CARDIO
+  excluded from the lifting selector. Catalog gains 4 cardio movements. Tests at every
+  layer (unit, integration incl. pinned strength path, new E2E). One local full-gate red
+  on the way: the new E2E spec's UI signup pushed the suite over the register limiter's
+  5/min budget - fixed with the established per-spec X-Forwarded-For bucket pattern, not
+  by touching the limiter.
+- PR #138 (Closes #134): the Strong/Hevy importers map cardio rows onto the new fields.
+  Qualifying condition is exactly the old skip branch; usable-duration rows import
+  (meters/miles conversion per export unit), the rest keep the counted skip notice.
+  Cardio-only new exercises are created CARDIO/OTHER. Dup keys byte-identical for
+  strength, extended for cardio so distinct runs do not collapse. #105/#106/#108
+  hardening untouched and re-pinned (strength-row shapes, dup-key format, caps).
+- PR #139 (Closes #135): conditioning card on the progress page - pure
+  `weeklyConditioning` derivation (8 zero-filled ISO weeks: minutes, km, sessions),
+  Recharts bar chart with the WHO 150 min/week reference line, hidden until the first
+  cardio set ever; strength charts untouched.
+
+**Challenged.** Nested run, no independent subagent spawnable: per the charter's
+backstop, all three PRs merged on green full CI (local `verify.sh --full` plus the
+5-check CI including docker-smoke) and are flagged for post-merge independent review as
+the orchestrator's next action - multi-lens (correctness + does-it-work) for #133,
+security lens for #134 (untrusted file input), correctness for #135.
+
+**Deferred.** Pace/speed analytics, conditioning in the AI coach payload, per-exercise
+cardio drill-down, CSV history export of duration/distance - future slices, not filed
+yet to respect anti-flood.
+
 ## 2026-06-11 - Docker smoke test in CI (#129) + first conditioning-axis ideate batch
 
 **Context.** Maintainer tick after the vision broadening (#130/#131). One trusted open

--- a/lib/stats.test.ts
+++ b/lib/stats.test.ts
@@ -14,6 +14,7 @@ import {
   STALL_TOLERANCE,
   totalVolume,
   trainingConsistency,
+  weeklyConditioning,
   weeklySetsByMuscleGroup,
   weeklyVolumeByMuscleGroup,
   WEEKLY_SETS_MEV,
@@ -505,5 +506,76 @@ describe('cardio set exclusion', () => {
     expect(counts).toHaveLength(1);
     expect(counts[0]!.byMuscleGroup).toEqual({ CHEST: 1 });
     expect(counts[0]!.total).toBe(1);
+  });
+});
+
+describe('weeklyConditioning (issue #135)', () => {
+  const NOW = new Date('2026-06-11T10:00:00Z'); // Thursday, ISO week 2026-W24
+  const run = (over: Record<string, unknown> = {}) => ({
+    durationSec: 1800,
+    distanceM: 5000,
+    isWarmup: false,
+    sessionId: 's1',
+    sessionStartedAt: new Date('2026-06-09T07:00:00Z'), // same ISO week as NOW
+    ...over,
+  });
+
+  it('returns a zero-filled window ending at the current week', () => {
+    const points = weeklyConditioning([], { windowWeeks: 8, now: NOW });
+    expect(points).toHaveLength(8);
+    expect(points[7]!.weekKey).toBe(isoWeekKey(NOW));
+    expect(points.every((p) => p.minutes === 0 && p.distanceKm === 0 && p.sessions === 0)).toBe(
+      true,
+    );
+    // Oldest first, consecutive weeks.
+    expect(points[0]!.weekStart.getTime()).toBeLessThan(points[7]!.weekStart.getTime());
+  });
+
+  it('aggregates minutes, distance and distinct sessions per ISO week', () => {
+    const points = weeklyConditioning(
+      [
+        run(),
+        run({ sessionId: 's1', durationSec: 600, distanceM: null }), // same session
+        run({ sessionId: 's2', durationSec: 900, distanceM: 2500 }),
+      ],
+      { windowWeeks: 4, now: NOW },
+    );
+    const current = points[3]!;
+    expect(current.minutes).toBe(Math.round((1800 + 600 + 900) / 60));
+    expect(current.distanceKm).toBe(7.5);
+    expect(current.sessions).toBe(2);
+  });
+
+  it('handles duration-only sets (distance stays 0)', () => {
+    const points = weeklyConditioning([run({ distanceM: null })], {
+      windowWeeks: 1,
+      now: NOW,
+    });
+    expect(points[0]!.minutes).toBe(30);
+    expect(points[0]!.distanceKm).toBe(0);
+  });
+
+  it('buckets sets into their own ISO weeks and ignores non-cardio or warmup sets', () => {
+    const points = weeklyConditioning(
+      [
+        run(),
+        run({ sessionId: 's0', sessionStartedAt: new Date('2026-06-01T07:00:00Z') }), // prior week
+        run({ isWarmup: true, sessionId: 's3' }), // warmup: ignored
+        run({ durationSec: null, sessionId: 's4' }), // not cardio: ignored
+      ],
+      { windowWeeks: 2, now: NOW },
+    );
+    expect(points[0]!.minutes).toBe(30);
+    expect(points[0]!.sessions).toBe(1);
+    expect(points[1]!.minutes).toBe(30);
+    expect(points[1]!.sessions).toBe(1);
+  });
+
+  it('drops cardio sets older than the window', () => {
+    const points = weeklyConditioning(
+      [run({ sessionStartedAt: new Date('2026-01-05T07:00:00Z') })],
+      { windowWeeks: 4, now: NOW },
+    );
+    expect(points.every((p) => p.minutes === 0)).toBe(true);
   });
 });

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -325,6 +325,78 @@ export function weeklySetsByMuscleGroup(
 }
 
 // ============================================================
+// Conditioning (weekly cardio minutes / distance / sessions)
+// ============================================================
+
+// WHO guideline for moderate aerobic activity, rendered as a display-only
+// reference line on the conditioning card (issue #135).
+export const WEEKLY_CONDITIONING_TARGET_MIN = 150;
+
+export interface ConditioningWeekPoint {
+  weekKey: string; // YYYY-Www
+  weekStart: Date; // Monday 00:00 UTC
+  minutes: number; // total cardio duration, rounded to whole minutes
+  distanceKm: number; // total distance, km with 2 decimals (0 when none)
+  sessions: number; // distinct sessions containing >= 1 cardio set
+}
+
+// Pure weekly aggregation of cardio sets (issue #135, display-only). Returns
+// exactly `windowWeeks` ISO weeks ending at the week of `now` (zero-filled,
+// oldest first) so the chart timeline has no gaps. Input: non-warmup cardio
+// sets (durationSec != null) with their session id and start date; non-cardio
+// sets are ignored defensively.
+export function weeklyConditioning(
+  sets: {
+    durationSec?: number | null;
+    distanceM?: number | null;
+    isWarmup: boolean;
+    sessionId: string;
+    sessionStartedAt: Date;
+  }[],
+  options: { windowWeeks?: number; now?: Date } = {},
+): ConditioningWeekPoint[] {
+  const windowWeeks = options.windowWeeks ?? 8;
+  const now = options.now ?? new Date();
+
+  interface Bucket {
+    seconds: number;
+    meters: number;
+    sessionIds: globalThis.Set<string>;
+  }
+  const byWeek = new Map<string, Bucket>();
+  for (const s of sets) {
+    if (s.isWarmup || !isCardioSet(s)) continue;
+    const key = isoWeekKey(s.sessionStartedAt);
+    let bucket = byWeek.get(key);
+    if (!bucket) {
+      bucket = { seconds: 0, meters: 0, sessionIds: new globalThis.Set<string>() };
+      byWeek.set(key, bucket);
+    }
+    bucket.seconds += s.durationSec ?? 0;
+    bucket.meters += s.distanceM ?? 0;
+    bucket.sessionIds.add(s.sessionId);
+  }
+
+  // Zero-filled window: the current ISO week and the (windowWeeks - 1) before.
+  const currentWeekStart = isoWeekStart(now);
+  const points: ConditioningWeekPoint[] = [];
+  for (let i = windowWeeks - 1; i >= 0; i--) {
+    const weekStart = new Date(currentWeekStart);
+    weekStart.setUTCDate(weekStart.getUTCDate() - i * 7);
+    const weekKey = isoWeekKey(weekStart);
+    const bucket = byWeek.get(weekKey);
+    points.push({
+      weekKey,
+      weekStart,
+      minutes: bucket ? Math.round(bucket.seconds / 60) : 0,
+      distanceKm: bucket ? +(bucket.meters / 1000).toFixed(2) : 0,
+      sessions: bucket ? bucket.sessionIds.size : 0,
+    });
+  }
+  return points;
+}
+
+// ============================================================
 // Training consistency (per-week trained days + current streak)
 // ============================================================
 


### PR DESCRIPTION
Closes #135

The read-only slice that makes the new conditioning axis visible: a "Conditioning" card on the progress page showing weekly cardio minutes against the WHO 150 min/week guideline.

## What changed

- **Pure derivation** (`lib/stats.ts`): `weeklyConditioning(sets, { windowWeeks, now })` buckets non-warmup cardio sets (durationSec != null) into a zero-filled window of ISO weeks ending at the current week (default 8), returning per week: total minutes, total distance (km, 2 decimals), and the count of distinct sessions. Non-cardio and warmup sets are ignored defensively. New constant `WEEKLY_CONDITIONING_TARGET_MIN = 150`.
- **Card** (`components/progress/conditioning-card.tsx`): Recharts bar chart of weekly minutes in the same style as the per-muscle volume chart, with a dashed `ReferenceLine` at 150 min/week, distance/session details in the tooltip, and a textual this-week + window-total summary line.
- **Progress page**: the card renders right after the bodyweight card - outside the strength-only branch, so a cardio-only user sees it too - and only when the user has logged at least one cardio set ever (a cheap `Set.count` on `durationSec != null`). The card data is derived from the already-fetched 12-week window query (extended to select `distanceM` and `sessionId`); no new tables, no writes.
- **Strength charts untouched**: the lifting selector, e1RM/volume charts, MEV/MRV landmarks and recap are unchanged (their inputs and the per-muscle chart data are byte-identical; the window query only gained two selected columns).

## Tests

- Unit: `weeklyConditioning` (zero-filled window, ISO bucketing, distinct-session counting, duration-only vs duration+distance, warmup/non-cardio exclusion, out-of-window drops) and the card's summary rendering.
- `bash scripts/verify.sh --full` green locally (unit + integration + E2E).

Also rides in this PR: the autonomy-log entry for this run (docs/loops/autonomy-log.md), per the journal convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
