### PR TITLE
fix: exclude cardio sets from the coach payload's strength signals

### DIFF
--- a/lib/coach.ts
+++ b/lib/coach.ts
@@ -9,6 +9,7 @@ import {
   totalVolume,
 } from '@/lib/stats';
 import { READINESS_RECENCY_HOURS } from '@/lib/progression';
+import { isCardioSet } from '@/lib/cardio';
 import { goalProgress } from '@/lib/goals';
 import {
   DELOAD_READINESS_LOOKBACK,
@@ -402,6 +403,11 @@ async function weekSummary(
         }
       >();
       for (const set of s.sets) {
+        // Cardio sets are excluded from the strength summary: they would
+        // surface as phantom 0-volume lifts and inflate workingSetCount, the
+        // training-load signal the coach reads (issue #140). A deliberate
+        // conditioning payload section is a separate, future slice.
+        if (isCardioSet(set)) continue;
         const key = set.exerciseId;
         let entry = setsByExo.get(key);
         if (!entry) {
@@ -450,7 +456,7 @@ async function weekSummary(
         durationMin,
         notes: s.notes,
         totalVolume: sessionTotalVolume,
-        workingSetCount: s.sets.filter((set) => !set.isWarmup).length,
+        workingSetCount: s.sets.filter((set) => !set.isWarmup && !isCardioSet(set)).length,
         exercises,
       };
     }),

--- a/tests/integration/core.test.ts
+++ b/tests/integration/core.test.ts
@@ -188,6 +188,46 @@ describe('buildCoachPayload isolation', () => {
   });
 });
 
+describe('buildCoachPayload cardio exclusion (issue #140)', () => {
+  it('keeps cardio sets out of the week summary and workingSetCount', async () => {
+    const user = await makeUser('cardio-coach@test.dev');
+    const bench = await db.exercise.create({
+      data: { userId: user.id, name: 'Bench', muscleGroup: 'CHEST', category: 'COMPOUND' },
+    });
+    const run = await db.exercise.create({
+      data: { userId: user.id, name: 'Running', muscleGroup: 'OTHER', category: 'CARDIO' },
+    });
+
+    const session = await db.session.create({ data: { userId: user.id } });
+    await db.set.create({
+      data: { sessionId: session.id, exerciseId: bench.id, setNumber: 1, weight: 80, reps: 8 },
+    });
+    await db.set.create({
+      data: { sessionId: session.id, exerciseId: bench.id, setNumber: 2, weight: 40, reps: 10, isWarmup: true },
+    });
+    await db.set.create({
+      data: {
+        sessionId: session.id,
+        exerciseId: run.id,
+        setNumber: 1,
+        weight: 0,
+        reps: 1,
+        durationSec: 1800,
+        distanceM: 5000,
+      },
+    });
+
+    const payload = await buildCoachPayload(user.id);
+    const week = payload.weekCurrent.sessions.find((s) => s.sessionId === session.id);
+    expect(week).toBeDefined();
+    // Only the strength working set counts; the cardio set is not a lift.
+    expect(week?.workingSetCount).toBe(1);
+    const exerciseNames = week?.exercises.map((e) => e.exerciseName) ?? [];
+    expect(exerciseNames).toContain('Bench');
+    expect(exerciseNames).not.toContain('Running');
+  });
+});
+
 describe('buildCoachPayload readiness (issue #38)', () => {
   it('surfaces the latest recent readiness check-in into the payload', async () => {
     const user = await makeUser('readiness@test.dev');


### PR DESCRIPTION
Closes #140 (the one REAL finding across the three independent post-merge reviews of the cardio batch #137/#138/#139).

weekSummary in lib/coach.ts filtered on isWarmup only: cardio sets counted as working sets and CARDIO exercises appeared in the per-exercise list as phantom lifts with bestE1RM 0 / volume 0. The summaries now skip isCardioSet rows (both the per-exercise map and workingSetCount), mirroring the exclusions recentProgress and fetchFatigueSummary already had. Feeding conditioning to the coach deliberately, as its own payload section, stays a future ideate item.

## How I tested

- bash scripts/verify.sh --full - GREEN-GATE PASSED
- New integration test pins the exclusion: a session with 1 strength working set + 1 warmup + 1 cardio set yields workingSetCount 1 and no CARDIO exercise in the week summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)