### PR TITLE
feat: include cardio duration/distance in the CSV history export

### DIFF
--- a/app/api/history/csv/route.ts
+++ b/app/api/history/csv/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { handleApiError, requireApiUserId } from '@/lib/api';
-import { csvEscape } from '@/lib/csv';
+import { csvEscape, HISTORY_CSV_HEADERS } from '@/lib/csv';
 import { effectiveWeight, estimate1RM, setVolume } from '@/lib/stats';
 
 // GET /api/history/csv?programId=...&month=YYYY-MM
@@ -53,30 +53,7 @@ export async function GET(req: Request) {
     ]);
     const bodyweight = user?.bodyweight ?? null;
 
-    const HEADERS = [
-      'session_id',
-      'session_date',
-      'session_started_at',
-      'session_finished_at',
-      'duration_min',
-      'program',
-      'workout',
-      'exercise',
-      'muscle_group',
-      'uses_bodyweight',
-      'set_number',
-      'external_load_kg', // entered value (added weight for bodyweight exercises, total load otherwise)
-      'effective_weight_kg', // = bodyweight + external for bodyweight exercises, otherwise = external
-      'reps',
-      'rir',
-      'is_warmup',
-      'is_drop_set',
-      'volume_kg', // based on effective weight
-      'estimated_1rm_kg', // based on effective weight
-      'set_notes',
-    ];
-
-    const lines: string[] = [HEADERS.join(',')];
+    const lines: string[] = [HISTORY_CSV_HEADERS.join(',')];
 
     for (const s of sessions) {
       const durationMin =
@@ -112,6 +89,9 @@ export async function GET(req: Request) {
           String(setVolume(effSet)),
           set.isWarmup ? '' : estimate1RM(eff, set.reps).toFixed(2),
           set.notes ?? '',
+          // Cardio columns (issue #144): raw storage units, empty on strength sets.
+          set.durationSec != null ? String(set.durationSec) : '',
+          set.distanceM != null ? String(set.distanceM) : '',
         ];
         lines.push(row.map(csvEscape).join(','));
       }

--- a/lib/csv.test.ts
+++ b/lib/csv.test.ts
@@ -1,5 +1,36 @@
 import { describe, it, expect } from 'vitest';
-import { csvEscape } from './csv';
+import { csvEscape, HISTORY_CSV_HEADERS } from './csv';
+
+describe('HISTORY_CSV_HEADERS', () => {
+  it('pins the column order: pre-cardio columns byte-identical, cardio columns trailing', () => {
+    // Downstream scripts key on column positions. Never reorder or insert;
+    // new columns may only be appended after the last entry.
+    expect([...HISTORY_CSV_HEADERS]).toEqual([
+      'session_id',
+      'session_date',
+      'session_started_at',
+      'session_finished_at',
+      'duration_min',
+      'program',
+      'workout',
+      'exercise',
+      'muscle_group',
+      'uses_bodyweight',
+      'set_number',
+      'external_load_kg',
+      'effective_weight_kg',
+      'reps',
+      'rir',
+      'is_warmup',
+      'is_drop_set',
+      'volume_kg',
+      'estimated_1rm_kg',
+      'set_notes',
+      'duration_sec',
+      'distance_m',
+    ]);
+  });
+});
 
 describe('csvEscape', () => {
   it('passes plain values through unchanged', () => {

--- a/lib/csv.ts
+++ b/lib/csv.ts
@@ -9,6 +9,34 @@
 //   with a single-quote prefix, the spreadsheet convention for "literal text".
 const FORMULA_PREFIX = /^[=+\-@\t\r]/;
 
+// Column order of the history export (app/api/history/csv/route.ts).
+// Downstream scripts key on column positions, so the order is a contract:
+// only append new columns at the end (pinned by lib/csv.test.ts).
+export const HISTORY_CSV_HEADERS = [
+  'session_id',
+  'session_date',
+  'session_started_at',
+  'session_finished_at',
+  'duration_min',
+  'program',
+  'workout',
+  'exercise',
+  'muscle_group',
+  'uses_bodyweight',
+  'set_number',
+  'external_load_kg', // entered value (added weight for bodyweight exercises, total load otherwise)
+  'effective_weight_kg', // = bodyweight + external for bodyweight exercises, otherwise = external
+  'reps',
+  'rir',
+  'is_warmup',
+  'is_drop_set',
+  'volume_kg', // based on effective weight
+  'estimated_1rm_kg', // based on effective weight
+  'set_notes',
+  'duration_sec', // cardio sets only (raw seconds); empty on strength sets
+  'distance_m', // cardio sets only (raw meters); empty on strength sets
+] as const;
+
 export function csvEscape(value: string): string {
   const safe = FORMULA_PREFIX.test(value) ? `'${value}` : value;
   if (/[",\n\r]/.test(safe)) {

--- a/tests/integration/history-csv-route.test.ts
+++ b/tests/integration/history-csv-route.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { db } from '@/lib/db';
+import { getCurrentUserId } from '@/lib/auth';
+import { HISTORY_CSV_HEADERS } from '@/lib/csv';
+
+// CSV history export with cardio columns (issue #144): the export must
+// round-trip duration/distance, with the pre-existing column order untouched.
+
+// Auth is read through getCurrentUserId (via requireApiUserId in @/lib/api).
+vi.mock('@/lib/auth', () => ({ getCurrentUserId: vi.fn() }));
+const mockUserId = vi.mocked(getCurrentUserId);
+
+import { GET as getCsv } from '@/app/api/history/csv/route';
+
+function actAs(userId: string) {
+  mockUserId.mockResolvedValue(userId);
+}
+
+async function seedMixedSession() {
+  const user = await db.user.create({
+    data: { email: 'csv-export@test.dev', passwordHash: 'x' },
+  });
+  const running = await db.exercise.create({
+    data: { userId: user.id, name: 'Running', muscleGroup: 'OTHER', category: 'CARDIO' },
+  });
+  const bench = await db.exercise.create({
+    data: { userId: user.id, name: 'Bench', muscleGroup: 'CHEST', category: 'COMPOUND' },
+  });
+  const session = await db.session.create({
+    data: {
+      userId: user.id,
+      startedAt: new Date('2026-06-01T10:00:00Z'),
+      finishedAt: new Date('2026-06-01T11:00:00Z'),
+    },
+  });
+  await db.set.create({
+    data: {
+      sessionId: session.id,
+      exerciseId: bench.id,
+      setNumber: 1,
+      weight: 100,
+      reps: 5,
+    },
+  });
+  await db.set.create({
+    data: {
+      sessionId: session.id,
+      exerciseId: running.id,
+      setNumber: 1,
+      weight: 0,
+      reps: 1,
+      durationSec: 1800,
+      distanceM: 5000,
+    },
+  });
+  return { user, session };
+}
+
+async function exportRows(): Promise<{ header: string[]; rows: string[][] }> {
+  const res = await getCsv(new Request('http://test.local/api/history/csv'));
+  expect(res.status).toBe(200);
+  const body = (await res.text()).replace(/^﻿/, '');
+  // Numeric-only cells in these fixtures: a plain split is safe.
+  const [header, ...rows] = body.split('\n').map((line) => line.split(','));
+  if (!header) throw new Error('empty CSV export');
+  return { header, rows };
+}
+
+beforeEach(() => {
+  mockUserId.mockReset();
+});
+
+describe('GET /api/history/csv - cardio columns (issue #144)', () => {
+  it('appends duration_sec and distance_m, populated only on cardio rows', async () => {
+    const { user } = await seedMixedSession();
+    actAs(user.id);
+
+    const { header, rows } = await exportRows();
+    expect(header).toEqual([...HISTORY_CSV_HEADERS]);
+
+    const durationIdx = header.indexOf('duration_sec');
+    const distanceIdx = header.indexOf('distance_m');
+    expect(durationIdx).toBe(header.length - 2);
+    expect(distanceIdx).toBe(header.length - 1);
+
+    const exerciseIdx = header.indexOf('exercise');
+    const strengthRow = rows.find((r) => r[exerciseIdx] === 'Bench');
+    const cardioRow = rows.find((r) => r[exerciseIdx] === 'Running');
+    expect(strengthRow).toBeDefined();
+    expect(cardioRow).toBeDefined();
+
+    // Cardio row: raw storage units, stored row shape (weight 0 / reps 1).
+    expect(cardioRow![durationIdx]).toBe('1800');
+    expect(cardioRow![distanceIdx]).toBe('5000');
+    expect(cardioRow![header.indexOf('external_load_kg')]).toBe('0');
+    expect(cardioRow![header.indexOf('reps')]).toBe('1');
+
+    // Strength row: cardio columns empty, lifting cells unchanged.
+    expect(strengthRow![durationIdx]).toBe('');
+    expect(strengthRow![distanceIdx]).toBe('');
+    expect(strengthRow![header.indexOf('external_load_kg')]).toBe('100');
+    expect(strengthRow![header.indexOf('reps')]).toBe('5');
+    expect(strengthRow![header.indexOf('volume_kg')]).toBe('500');
+  });
+});


### PR DESCRIPTION
Cardio sets are first-class since #137 but the CSV history export silently dropped duration and distance. This appends two trailing columns - `duration_sec` and `distance_m` - in raw storage units, populated only on cardio rows; every pre-existing column position is unchanged.

- The header list moves to `lib/csv.ts` as `HISTORY_CSV_HEADERS` (Next.js route files may only export handlers), with a unit test pinning the full column order so the positional contract cannot drift.
- New integration test `tests/integration/history-csv-route.test.ts`: exports a mixed strength + cardio session, asserts the two trailing columns are populated only on the cardio row and the lifting cells are untouched (cardio row keeps its stored weight 0 / reps 1 shape per the #137 exclusion contract).
- `csvEscape` still covers every cell.

Closes #144

## How I tested
- `bash scripts/verify.sh` - GREEN-GATE PASSED (prisma generate + lint + typecheck + unit + build)
- `npm run test:integration -- history-csv-route` against the :5434 test Postgres - 1 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)