### PR TITLE
feat: dedicated conditioning section in the AI coach payload

### DIFF
--- a/lib/coach.ts
+++ b/lib/coach.ts
@@ -7,6 +7,8 @@ import {
   isStalled,
   isoWeekStart,
   totalVolume,
+  weeklyConditioning,
+  WEEKLY_CONDITIONING_TARGET_MIN,
 } from '@/lib/stats';
 import { READINESS_RECENCY_HOURS } from '@/lib/progression';
 import { isCardioSet } from '@/lib/cardio';
@@ -57,6 +59,13 @@ export interface CoachPayload {
   // isStalled over the progress page's 12-week window, plus the program-level
   // deload recommendation from lib/deload.ts with its human-readable reasons.
   fatigue: FatigueSummary;
+  // Weekly conditioning aggregates (issue #145). Cardio is deliberately
+  // excluded from the strength signals above (issue #140), so this dedicated
+  // section keeps the coach aware of it: current and previous ISO week via
+  // the same lib/stats.ts weeklyConditioning derivation the progress page
+  // uses. Input signal only; the output contract (the <adjustments> block)
+  // is unchanged.
+  conditioning: ConditioningSummary;
   // The workout the user is in RIGHT NOW (issue #111), attached only when the
   // chat is opened from the session runner with a session the user owns.
   // Additive and input-side only; the output contract is unchanged.
@@ -78,6 +87,25 @@ export interface CoachPayload {
       estimated1RM: number;
     }>;
   }>;
+}
+
+interface ConditioningWeek {
+  // Total cardio duration, whole minutes.
+  minutes: number;
+  // Total cardio distance, km with 2 decimals (0 when none logged).
+  km: number;
+  // Distinct sessions containing at least one cardio set.
+  sessions: number;
+}
+
+interface ConditioningSummary {
+  // Always present: a zero-cardio user reads as zeros, never null.
+  weekCurrent: ConditioningWeek;
+  // Null when the previous ISO week had no cardio session (mirrors the
+  // strength summary's weekPrevious semantics).
+  weekPrevious: ConditioningWeek | null;
+  // The weekly guideline the progress page tracks (150 min/week).
+  weeklyTargetMin: number;
 }
 
 interface GoalSummary {
@@ -257,6 +285,7 @@ export async function buildCoachPayload(userId: string): Promise<CoachPayload> {
         reps: true,
         isWarmup: true,
         durationSec: true,
+        distanceM: true,
         sessionId: true,
         exerciseId: true,
         exercise: {
@@ -271,6 +300,37 @@ export async function buildCoachPayload(userId: string): Promise<CoachPayload> {
       },
     }),
   ]);
+
+  // Conditioning aggregates (issue #145): the shared weeklyConditioning
+  // derivation over the already-fetched recent sets, windowed to the previous
+  // and current ISO weeks (oldest first, zero-filled).
+  const conditioningWeeks = weeklyConditioning(
+    recentSets.map((s) => ({
+      durationSec: s.durationSec,
+      distanceM: s.distanceM,
+      isWarmup: s.isWarmup,
+      sessionId: s.sessionId,
+      sessionStartedAt: s.session.startedAt,
+    })),
+    { windowWeeks: 2, now },
+  );
+  const [conditioningPrev, conditioningCurrent] = conditioningWeeks;
+  const conditioning: ConditioningSummary = {
+    weekCurrent: {
+      minutes: conditioningCurrent?.minutes ?? 0,
+      km: conditioningCurrent?.distanceKm ?? 0,
+      sessions: conditioningCurrent?.sessions ?? 0,
+    },
+    weekPrevious:
+      conditioningPrev && conditioningPrev.sessions > 0
+        ? {
+            minutes: conditioningPrev.minutes,
+            km: conditioningPrev.distanceKm,
+            sessions: conditioningPrev.sessions,
+          }
+        : null,
+    weeklyTargetMin: WEEKLY_CONDITIONING_TARGET_MIN,
+  };
 
   // Current load per exercise = workingWeight of the last session.
   const currentLoadByExercise = new Map<string, number>();
@@ -353,6 +413,7 @@ export async function buildCoachPayload(userId: string): Promise<CoachPayload> {
       // deloadUntil reads as inactive.
       deloadActive: isDeloadActive(user?.deloadUntil ?? null, now),
     },
+    conditioning,
     recentProgress: recentProgress.sort((a, b) =>
       a.exerciseName.localeCompare(b.exerciseName),
     ),

--- a/lib/llm/demo.test.ts
+++ b/lib/llm/demo.test.ts
@@ -68,4 +68,22 @@ describe('demo provider', () => {
     });
     expect(normal.text.toLowerCase()).toContain('volume');
   });
+
+  // Issue #145: the canned debrief exercises the conditioning payload section
+  // so the no-key flow demonstrates the coach reading cardio volume.
+  it('references the conditioning numbers in the canned debrief', async () => {
+    process.env.LLM_PROVIDER = 'demo';
+    const p = getLlmProvider();
+
+    const debrief = await p.complete({
+      system: 'You produce a debrief and an <adjustments> block.',
+      messages: [{ role: 'user', content: 'x' }],
+    });
+    expect(debrief.text).toMatch(/\*\*Conditioning\*\*/);
+    expect(debrief.text).toMatch(/150 weekly target minutes/i);
+    expect(debrief.text).toMatch(/cardio sessions/i);
+    // The conditioning section must not displace the output contract: the
+    // <adjustments> block still closes the response.
+    expect(debrief.text.trimEnd().endsWith('</adjustments>')).toBe(true);
+  });
 });

--- a/lib/llm/demo.ts
+++ b/lib/llm/demo.ts
@@ -31,6 +31,9 @@ Solid week: 3 sessions logged, total working volume up about 4% versus last week
 **Fatigue signals**
 - RIR is holding around 2 and no deload is recommended this week, so keep pushing.
 
+**Conditioning**
+- 95 of your 150 weekly target minutes logged (9.6 km across 2 cardio sessions), up from 60 minutes last week. Aerobic volume is climbing but still moderate, so it is not cutting into lifting recovery yet - keep the easy pace.
+
 **Suggestions for next week**
 - Push bench to 72.5 kg for the first working sets - that lines up with your stated goal.
 - Bias a little more side-delt volume.

--- a/lib/prompts/coach-system-prompt.test.ts
+++ b/lib/prompts/coach-system-prompt.test.ts
@@ -53,6 +53,20 @@ describe('coach system prompt positioning', () => {
     expect(COACH_SYSTEM_PROMPT).toMatch(/fatigue\.deloadActive/);
     expect(COACH_SYSTEM_PROMPT).toMatch(/do not\s+recommend starting a deload then/i);
   });
+
+  // Issue #145: conditioning is an INPUT-side signal; the output contract
+  // (the <adjustments> block) stays about the lifting program.
+  it('tells the coach to factor conditioning into recovery, without medical advice', () => {
+    expect(COACH_SYSTEM_PROMPT).toMatch(/conditioning\.weekCurrent/);
+    expect(COACH_SYSTEM_PROMPT).toMatch(/conditioning\.weeklyTargetMin/);
+    expect(COACH_SYSTEM_PROMPT).toMatch(
+      /high-cardio week compounds the fatigue from lifting/i,
+    );
+    expect(COACH_SYSTEM_PROMPT).toMatch(/never give\s+medical advice/i);
+    expect(COACH_SYSTEM_PROMPT).toMatch(
+      /do not propose program\s+adjustments to chase the cardio target/i,
+    );
+  });
 });
 
 describe('program generation prompt positioning', () => {

--- a/lib/prompts/coach-system-prompt.ts
+++ b/lib/prompts/coach-system-prompt.ts
@@ -47,6 +47,20 @@ week (the app is stepping their suggested loads down about 10%): do not
 recommend starting a deload then - support executing the one underway and frame
 suggestions around returning to normal loads when it ends.
 
+The "conditioning" section summarizes the user's cardio training, which is
+deliberately kept out of the strength signals above: conditioning.weekCurrent
+and conditioning.weekPrevious give total minutes, km and cardio session counts
+per ISO week (weekPrevious is null when no cardio was logged that week), and
+conditioning.weeklyTargetMin is the general aerobic activity guideline the app
+tracks (150 minutes per week). Factor conditioning volume into your recovery
+and fatigue reasoning: a high-cardio week compounds the fatigue from lifting,
+so when both lifting volume and conditioning minutes are high, prefer holding
+loads or volume over pushing. Acknowledge progress toward the weekly guideline
+when relevant. Treat it as a general activity guideline only - never give
+medical advice or prescribe cardio as treatment - and do not propose program
+adjustments to chase the cardio target: the <adjustments> block stays about
+the lifting program.
+
 Be concise (max 600 words), actionable, factual. Cite studies when relevant
 (Schoenfeld, Helms, Israetel). Do not make up data that is not in the payload.
 

--- a/tests/integration/core.test.ts
+++ b/tests/integration/core.test.ts
@@ -4,6 +4,7 @@ import { seedExerciseCatalog, EXERCISE_CATALOG } from '@/lib/exercise-catalog';
 import { buildProgramFromGenerated } from '@/lib/program-generation';
 import type { GeneratedProgram } from '@/lib/schemas/program-generation';
 import { buildCoachPayload } from '@/lib/coach';
+import { isoWeekStart } from '@/lib/stats';
 import { programTemplates, getTemplateBySlug } from '@/lib/programs/templates';
 
 async function makeUser(email: string) {
@@ -225,6 +226,101 @@ describe('buildCoachPayload cardio exclusion (issue #140)', () => {
     const exerciseNames = week?.exercises.map((e) => e.exerciseName) ?? [];
     expect(exerciseNames).toContain('Bench');
     expect(exerciseNames).not.toContain('Running');
+  });
+});
+
+describe('buildCoachPayload conditioning (issue #145)', () => {
+  async function makeCardioUser(email: string) {
+    const user = await makeUser(email);
+    const run = await db.exercise.create({
+      data: { userId: user.id, name: 'Running', muscleGroup: 'OTHER', category: 'CARDIO' },
+    });
+    return { user, run };
+  }
+
+  async function cardioSession(
+    userId: string,
+    exerciseId: string,
+    startedAt: Date,
+    sets: Array<{ durationSec: number; distanceM?: number }>,
+  ) {
+    const session = await db.session.create({
+      data: { userId, startedAt, finishedAt: startedAt },
+    });
+    for (const [i, s] of sets.entries()) {
+      await db.set.create({
+        data: {
+          sessionId: session.id,
+          exerciseId,
+          setNumber: i + 1,
+          weight: 0,
+          reps: 1,
+          durationSec: s.durationSec,
+          distanceM: s.distanceM ?? null,
+        },
+      });
+    }
+    return session;
+  }
+
+  it('aggregates current and previous ISO week via the shared derivation', async () => {
+    const { user, run } = await makeCardioUser('conditioning@test.dev');
+    // Deterministic anchors: Monday 00:00 UTC of the current ISO week.
+    const weekStart = isoWeekStart(new Date());
+    const inCurrentWeek = new Date(weekStart.getTime() + 60 * 60 * 1000);
+    const inPreviousWeek = new Date(weekStart.getTime() - 7 * 24 * 60 * 60 * 1000 + 60 * 60 * 1000);
+
+    // Two cardio sessions this week (30 min / 5 km and 10 min), one last week.
+    await cardioSession(user.id, run.id, inCurrentWeek, [
+      { durationSec: 1800, distanceM: 5000 },
+    ]);
+    await cardioSession(user.id, run.id, inCurrentWeek, [{ durationSec: 600 }]);
+    await cardioSession(user.id, run.id, inPreviousWeek, [
+      { durationSec: 3600, distanceM: 10000 },
+    ]);
+
+    const payload = await buildCoachPayload(user.id);
+    expect(payload.conditioning.weekCurrent).toEqual({
+      minutes: 40,
+      km: 5,
+      sessions: 2,
+    });
+    expect(payload.conditioning.weekPrevious).toEqual({
+      minutes: 60,
+      km: 10,
+      sessions: 1,
+    });
+    expect(payload.conditioning.weeklyTargetMin).toBe(150);
+  });
+
+  it('yields zeros (not nulls or crashes) for a zero-cardio user', async () => {
+    const user = await makeUser('no-cardio@test.dev');
+    const bench = await db.exercise.create({
+      data: { userId: user.id, name: 'Bench', muscleGroup: 'CHEST', category: 'COMPOUND' },
+    });
+    const session = await db.session.create({ data: { userId: user.id } });
+    await db.set.create({
+      data: { sessionId: session.id, exerciseId: bench.id, setNumber: 1, weight: 80, reps: 8 },
+    });
+
+    const payload = await buildCoachPayload(user.id);
+    expect(payload.conditioning.weekCurrent).toEqual({ minutes: 0, km: 0, sessions: 0 });
+    expect(payload.conditioning.weekPrevious).toBeNull();
+    expect(payload.conditioning.weeklyTargetMin).toBe(150);
+  });
+
+  it("does not count another user's cardio", async () => {
+    const { user: userA } = await makeCardioUser('conditioning-a@test.dev');
+    const { user: userB, run: runB } = await makeCardioUser('conditioning-b@test.dev');
+    const weekStart = isoWeekStart(new Date());
+    const inCurrentWeek = new Date(weekStart.getTime() + 60 * 60 * 1000);
+    await cardioSession(userB.id, runB.id, inCurrentWeek, [
+      { durationSec: 1800, distanceM: 5000 },
+    ]);
+
+    const payload = await buildCoachPayload(userA.id);
+    expect(payload.conditioning.weekCurrent).toEqual({ minutes: 0, km: 0, sessions: 0 });
+    expect(payload.conditioning.weekPrevious).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

Since #141 the coach payload deliberately excludes cardio from its strength signals (issue #140 follow-up), leaving the coach blind to conditioning while users log runs and the progress page tracks weekly minutes. This PR adds a dedicated, compact `CoachPayload.conditioning` section:

- `weekCurrent` / `weekPrevious` as `{ minutes, km, sessions }` aggregates, computed via the SHARED `lib/stats.ts` `weeklyConditioning` derivation over the already-fetched recent sets (no duplication; `distanceM` added to the existing select). `weekPrevious` is null when no cardio was logged that week, mirroring the strength summary's semantics; a zero-cardio user reads as zeros, never a crash.
- `weeklyTargetMin`: the existing 150 min/week guideline constant.
- Input-side prompt addition only: factor conditioning into recovery/fatigue reasoning, acknowledge guideline progress, never give medical advice, and keep the `<adjustments>` block about the lifting program. The output contract is unchanged - existing adjustments contract tests pass unmodified.
- Demo provider: the canned debrief gains a Conditioning section so the no-key flow exercises the field, with a test pinning that the `<adjustments>` block still closes the response.

## Tests

- Prompt: new positioning test pins the conditioning guidance (input-side, no medical advice, contract untouched).
- Demo provider: new test pins the conditioning references in the canned debrief.
- Integration: new `buildCoachPayload conditioning` suite - current/previous ISO week aggregation from seeded data, zero-cardio user yields zeros + null weekPrevious, cross-user isolation.

## How I tested

`bash scripts/verify.sh --full` - GREEN-GATE PASSED (lint, typecheck, unit, build, integration, E2E all green locally against the :5434 test Postgres).

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)