### PR TITLE
feat: supersets in programs - builder pairing and A1/A2 session flow (slice 1)

### DIFF
--- a/app/api/program-exercises/[id]/route.ts
+++ b/app/api/program-exercises/[id]/route.ts
@@ -40,6 +40,9 @@ export async function PUT(req: Request, { params }: Params) {
         restSec: data.restSec,
         tempo: data.tempo ?? null,
         notes: data.notes ?? null,
+        // Superset pairing (issue #146): absent = leave unchanged (Prisma
+        // skips undefined), null = unpair, number = (re)pair.
+        supersetGroup: data.supersetGroup,
       },
       include: { exercise: true },
     });

--- a/app/api/workouts/[id]/program-exercises/route.ts
+++ b/app/api/workouts/[id]/program-exercises/route.ts
@@ -47,6 +47,8 @@ export async function POST(req: Request, { params }: Params) {
         restSec: data.restSec,
         tempo: data.tempo ?? null,
         notes: data.notes ?? null,
+        // Superset pairing (issue #146): optional at creation, null = standalone.
+        supersetGroup: data.supersetGroup ?? null,
       },
       include: { exercise: true },
     });

--- a/components/programs/program-exercise-row.tsx
+++ b/components/programs/program-exercise-row.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
+import { Link2, MoreHorizontal, Pencil, Trash2, Unlink } from 'lucide-react';
 import type { Exercise, ProgramExercise } from '@prisma/client';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
@@ -22,9 +22,21 @@ type ProgramExerciseWithExercise = ProgramExercise & { exercise: Exercise };
 interface Props {
   programExercise: ProgramExerciseWithExercise;
   catalog: Exercise[];
+  // Superset pairing (issue #146, slice 1). The label ("A1") is derived by the
+  // parent from group membership and order; the actions are null when not
+  // applicable (first row cannot pair up, a standalone row cannot unpair).
+  supersetLabel?: string | null;
+  onPairWithPrevious?: (() => void) | null;
+  onUnpair?: (() => void) | null;
 }
 
-export function ProgramExerciseRow({ programExercise, catalog }: Props) {
+export function ProgramExerciseRow({
+  programExercise,
+  catalog,
+  supersetLabel = null,
+  onPairWithPrevious = null,
+  onUnpair = null,
+}: Props) {
   const router = useRouter();
   const [editOpen, setEditOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
@@ -60,6 +72,7 @@ export function ProgramExerciseRow({ programExercise, catalog }: Props) {
           <div className="min-w-0">
             <p className="truncate text-sm font-medium">{programExercise.exercise.name}</p>
             <div className="mt-1 flex flex-wrap gap-1.5 text-xs text-muted-foreground">
+              {supersetLabel && <Badge>Superset {supersetLabel}</Badge>}
               <Badge variant="secondary">
                 {MUSCLE_GROUP_LABELS[programExercise.exercise.muscleGroup]}
               </Badge>
@@ -94,6 +107,18 @@ export function ProgramExerciseRow({ programExercise, catalog }: Props) {
                 <Pencil className="mr-2 size-4" />
                 Edit
               </DropdownMenuItem>
+              {onPairWithPrevious && (
+                <DropdownMenuItem onSelect={() => onPairWithPrevious()}>
+                  <Link2 className="mr-2 size-4" />
+                  Pair with previous
+                </DropdownMenuItem>
+              )}
+              {onUnpair && (
+                <DropdownMenuItem onSelect={() => onUnpair()}>
+                  <Unlink className="mr-2 size-4" />
+                  Unpair superset
+                </DropdownMenuItem>
+              )}
               <DropdownMenuSeparator />
               <DropdownMenuItem
                 onSelect={handleDelete}

--- a/components/programs/workout-card.tsx
+++ b/components/programs/workout-card.tsx
@@ -24,6 +24,7 @@ import { ProgramExerciseRow } from '@/components/programs/program-exercise-row';
 import { WorkoutFormDialog } from '@/components/programs/workout-form-dialog';
 import { ProgramExerciseFormDialog } from '@/components/programs/program-exercise-form-dialog';
 import { DAY_LABELS } from '@/lib/schemas/workout';
+import { buildSupersetView, smallestFreeGroup } from '@/lib/supersets';
 
 type ProgramExerciseWithExercise = ProgramExercise & { exercise: Exercise };
 type WorkoutWithExercises = Workout & { exercises: ProgramExerciseWithExercise[] };
@@ -58,6 +59,64 @@ export function WorkoutCard({ workout, catalog }: Props) {
 
   const dayLabel =
     workout.dayOfWeek != null ? DAY_LABELS[workout.dayOfWeek - 1] ?? null : null;
+
+  // Superset pairing (issue #146, slice 1): rows render in presentation order
+  // (group members together) with A1/A2 labels derived on read.
+  const supersetView = buildSupersetView(workout.exercises);
+
+  async function updateSupersetGroup(
+    pe: ProgramExerciseWithExercise,
+    supersetGroup: number | null,
+  ): Promise<boolean> {
+    const res = await fetch(`/api/program-exercises/${pe.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        exerciseId: pe.exerciseId,
+        targetSets: pe.targetSets,
+        targetRepsMin: pe.targetRepsMin,
+        targetRepsMax: pe.targetRepsMax,
+        targetRIR: pe.targetRIR,
+        restSec: pe.restSec,
+        tempo: pe.tempo,
+        notes: pe.notes,
+        supersetGroup,
+      }),
+    });
+    if (!res.ok) {
+      const data = (await res.json().catch(() => null)) as { error?: string } | null;
+      toast.error(data?.error ?? 'Could not update the superset.');
+      return false;
+    }
+    return true;
+  }
+
+  // Pairs a row with the one above it (in presentation order): joins the
+  // previous row's group, creating a fresh group for both when the previous
+  // row is standalone.
+  async function handlePairWithPrevious(index: number) {
+    const pe = supersetView.ordered[index];
+    const previous = supersetView.ordered[index - 1];
+    if (!pe || !previous) return;
+    let group = previous.supersetGroup;
+    if (group == null) {
+      group = smallestFreeGroup(workout.exercises);
+      if (group == null) {
+        toast.error('Superset limit reached for this session.');
+        return;
+      }
+      if (!(await updateSupersetGroup(previous, group))) return;
+    }
+    if (!(await updateSupersetGroup(pe, group))) return;
+    toast.success('Exercises paired as a superset.');
+    router.refresh();
+  }
+
+  async function handleUnpair(pe: ProgramExerciseWithExercise) {
+    if (!(await updateSupersetGroup(pe, null))) return;
+    toast.success('Superset removed.');
+    router.refresh();
+  }
 
   return (
     <Card>
@@ -109,11 +168,28 @@ export function WorkoutCard({ workout, catalog }: Props) {
           </p>
         ) : (
           <ul className="flex flex-col gap-2">
-            {workout.exercises.map((pe) => (
-              <li key={pe.id}>
-                <ProgramExerciseRow programExercise={pe} catalog={catalog} />
-              </li>
-            ))}
+            {supersetView.ordered.map((pe, index) => {
+              const previous = supersetView.ordered[index - 1];
+              const alreadyPairedWithPrevious =
+                pe.supersetGroup != null &&
+                previous != null &&
+                previous.supersetGroup === pe.supersetGroup;
+              return (
+                <li key={pe.id}>
+                  <ProgramExerciseRow
+                    programExercise={pe}
+                    catalog={catalog}
+                    supersetLabel={supersetView.labels.get(pe.id) ?? null}
+                    onPairWithPrevious={
+                      index > 0 && !alreadyPairedWithPrevious
+                        ? () => handlePairWithPrevious(index)
+                        : null
+                    }
+                    onUnpair={pe.supersetGroup != null ? () => handleUnpair(pe) : null}
+                  />
+                </li>
+              );
+            })}
           </ul>
         )}
 

--- a/components/session/exercise-card.test.tsx
+++ b/components/session/exercise-card.test.tsx
@@ -29,6 +29,7 @@ const pe: ProgramExercise & { exercise: Exercise } = {
   restSec: 120,
   tempo: null,
   notes: null,
+  supersetGroup: null,
   exercise: exo,
 };
 

--- a/components/session/session-runner.tsx
+++ b/components/session/session-runner.tsx
@@ -26,6 +26,7 @@ import {
   type PendingSet,
 } from '@/lib/indexeddb';
 import { readinessForSuggestion, type ReadinessSignal } from '@/lib/progression';
+import { buildSupersetView, nextAutoAdvanceIndex, nextNavIndex } from '@/lib/supersets';
 import { isReadinessAutoRegulationEnabled } from '@/lib/preferences';
 import { bindAutoSync, flushPendingSets, queueSet } from '@/lib/sync';
 import { hydrateFromServerSets } from '@/lib/sync-hydration';
@@ -78,7 +79,11 @@ export function SessionRunner({
 }: SessionRunnerProps) {
   const router = useRouter();
   const workout = session.workout!;
-  const programExercises = workout.exercises;
+  // Supersets (issue #146, slice 1): run the workout in presentation order -
+  // members of a superset group come consecutively with A1/A2 labels. For a
+  // workout without supersets this is exactly the stored order.
+  const supersetView = useMemo(() => buildSupersetView(workout.exercises), [workout.exercises]);
+  const programExercises = supersetView.ordered;
 
   const [hydrated, setHydrated] = useState(false);
   const [currentIdx, setCurrentIdx] = useState(0);
@@ -196,13 +201,18 @@ export function SessionRunner({
 
     vibrate(VIBRATION_PATTERNS.validate);
 
-    // Start the rest. If the set completes the goal and there is a next
-    // exercise, prepare the auto-advance at the end of the timer.
-    const isLastTargetSet =
-      !values.isWarmup &&
-      existing.filter((s) => !s.isWarmup).length + 1 >= currentPE.targetSets;
-    const nextIdx =
-      isLastTargetSet && currentIdx + 1 < programExercises.length ? currentIdx + 1 : null;
+    // Start the rest, preparing the auto-advance at the end of the timer.
+    // Standalone exercise (unchanged behavior): advance once the set
+    // completes the target. Superset member (issue #146): alternate to the
+    // next member of the group that still has sets, the A1/A2 flow.
+    const remainingAfterThisSet = (pe: ProgramExerciseWithExercise) => {
+      const logged = setsByExercise.get(pe.exerciseId)?.filter((s) => !s.isWarmup).length ?? 0;
+      const justLogged = pe.exerciseId === currentPE.exerciseId ? 1 : 0;
+      return pe.targetSets - logged - justLogged;
+    };
+    const nextIdx = values.isWarmup
+      ? null
+      : nextAutoAdvanceIndex(supersetView, currentIdx, remainingAfterThisSet);
 
     setMode({
       kind: 'rest',
@@ -277,8 +287,14 @@ export function SessionRunner({
     setCurrentIdx((i) => Math.max(0, i - 1));
     setMode({ kind: 'input' });
   }
+  // Next is linear for standalone exercises (unchanged) and cycles within a
+  // superset group before advancing past it (issue #146).
+  const remainingNow = (pe: ProgramExerciseWithExercise) =>
+    pe.targetSets - (setsByExercise.get(pe.exerciseId)?.filter((s) => !s.isWarmup).length ?? 0);
+  const navNextIdx = nextNavIndex(supersetView, currentIdx, remainingNow);
   function goNext() {
-    setCurrentIdx((i) => Math.min(programExercises.length - 1, i + 1));
+    if (navNextIdx == null) return;
+    setCurrentIdx(navNextIdx);
     setMode({ kind: 'input' });
   }
 
@@ -318,6 +334,11 @@ export function SessionRunner({
             <p className="text-sm font-medium">
               Exercise {currentIdx + 1}/{programExercises.length} · {currentPE.exercise.name}
             </p>
+            {supersetView.labels.has(currentPE.id) && (
+              <Badge variant="secondary" className="mt-1">
+                Superset {supersetView.labels.get(currentPE.id)}
+              </Badge>
+            )}
             {deloadActive && (
               <Badge variant="secondary" className="mt-1 text-emerald-700 dark:text-emerald-400">
                 Deload week
@@ -417,9 +438,7 @@ export function SessionRunner({
             variant="outline"
             size="sm"
             onClick={goNext}
-            disabled={
-              currentIdx === programExercises.length - 1 || mode.kind !== 'input'
-            }
+            disabled={navNextIdx == null || mode.kind !== 'input'}
             className="min-h-tap"
           >
             <span className="mr-1">Next</span>

--- a/components/session/session-summary.test.tsx
+++ b/components/session/session-summary.test.tsx
@@ -28,6 +28,7 @@ const pe: ProgramExercise & { exercise: Exercise } = {
   restSec: 120,
   tempo: null,
   notes: null,
+  supersetGroup: null,
   exercise: exo,
 };
 

--- a/components/session/set-input.test.tsx
+++ b/components/session/set-input.test.tsx
@@ -28,6 +28,7 @@ const pe: ProgramExercise & { exercise: Exercise } = {
   restSec: 120,
   tempo: null,
   notes: null,
+  supersetGroup: null,
   exercise: exo,
 };
 

--- a/components/session/sets-list.test.tsx
+++ b/components/session/sets-list.test.tsx
@@ -28,6 +28,7 @@ const pe: ProgramExercise & { exercise: Exercise } = {
   restSec: 120,
   tempo: null,
   notes: null,
+  supersetGroup: null,
   exercise: exo,
 };
 

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -6,6 +6,48 @@ by the charter in [`07-autonomy.md`](07-autonomy.md).
 
 ---
 
+## 2026-06-12 - Coach conditioning payload (#145) + supersets slice 1 (#146) shipped
+
+**Context.** Maintainer tick executing the remaining two issues of the sixth ideate
+batch, strictly serialized (PR merged before the next branch). Both issues authored by
+JulienAu (trust-gated, collaborator-verified 204). PR #148 (#144, cardio CSV export) had
+already merged.
+
+**Decided / shipped.**
+- PR #149 (Closes #145): dedicated `CoachPayload.conditioning` section -
+  weekCurrent/weekPrevious `{ minutes, km, sessions }` plus the 150 min/week guideline -
+  computed via the SHARED lib/stats.ts weeklyConditioning derivation over the
+  already-fetched recent sets (no duplication). Input-side prompt guidance only; the
+  `<adjustments>` output contract untouched and its tests passed unmodified. Demo
+  provider's canned debrief exercises the section. Tests: prompt positioning, demo
+  contract-closure pin, integration suite (aggregation, zero-cardio user -> zeros + null
+  weekPrevious, isolation). Full local gate green before the PR; CI green; squash-merged.
+- PR #150 (Closes #146): supersets slice 1, program-level only. Additive nullable
+  `ProgramExercise.supersetGroup` migration validated on the test DB (migrate deploy +
+  clean migrate diff); rollback baseline `autonomy-baseline-2026-06-12` tagged on main
+  before merge. All user-facing semantics derive on read in the new pure lib
+  (`lib/supersets.ts`): A1/A2/B1 labels, presentation order (group members consecutive),
+  auto-advance alternation, Next-button cycling that never traps the user in an
+  unfinished group. Builder gains pair-with-previous / unpair menu actions riding the
+  existing PUT route (absent field preserves pairing, null unpairs - pinned). Logging
+  semantics, rest timer, generation/templates/imports/coach payload untouched. Tests at
+  every layer: 14 unit (derivations), schema bounds, route integration (persistence,
+  absent-vs-null, ownership), new E2E pairing two exercises and running the A1/A2 flow;
+  standalone flows pinned by the existing suite plus explicit pinned-behavior unit cases.
+- One local typecheck red on the way (stale `.next` types; cleared) and one expected
+  fixture fallout (ProgramExercise test fixtures gained `supersetGroup: null`) - no
+  assertion weakened.
+
+**Challenged.** No subagent spawning available in this nested run, so per the charter's
+no-self-certify rule both PRs merged on green FULL CI (integration + E2E) and are flagged
+for independent post-merge review: multi-lens for both, does-it-actually-work for #146.
+
+**Deferred to human.** Nothing blocked. Later superset slices (shared-rest enforcement,
+circuit timer, logging semantics, generation/template awareness) stay un-filed until a
+starved cycle.
+
+---
+
 ## 2026-06-12 - Conditioning batch reviewed (3x CLEAN + 1 fix); write-up + demo refresh
 
 **Context.** The cardio foundation batch (#137/#138/#139) merged yesterday with the

--- a/lib/progression.test.ts
+++ b/lib/progression.test.ts
@@ -49,6 +49,7 @@ function makePe(
     restSec: 120,
     tempo: null,
     notes: null,
+    supersetGroup: null,
     ...overrides,
     exercise,
   };

--- a/lib/schemas/program-exercise.test.ts
+++ b/lib/schemas/program-exercise.test.ts
@@ -40,4 +40,23 @@ describe('programExerciseInputSchema', () => {
     expect(programExerciseInputSchema.safeParse({ ...valid, targetRIR: 6 }).success).toBe(false);
     expect(programExerciseInputSchema.safeParse({ ...valid, restSec: 14 }).success).toBe(false);
   });
+
+  // Superset pairing (issue #146, slice 1).
+  it('accepts a superset group within bounds, null, or absent (distinct states)', () => {
+    const withGroup = programExerciseInputSchema.parse({ ...valid, supersetGroup: 3 });
+    expect(withGroup.supersetGroup).toBe(3);
+
+    const cleared = programExerciseInputSchema.parse({ ...valid, supersetGroup: null });
+    expect(cleared.supersetGroup).toBeNull();
+
+    // Absent stays absent (undefined), so an update can leave it unchanged.
+    const absent = programExerciseInputSchema.parse(valid);
+    expect(absent.supersetGroup).toBeUndefined();
+  });
+
+  it('rejects out-of-bounds or non-integer superset groups', () => {
+    expect(programExerciseInputSchema.safeParse({ ...valid, supersetGroup: 0 }).success).toBe(false);
+    expect(programExerciseInputSchema.safeParse({ ...valid, supersetGroup: 10 }).success).toBe(false);
+    expect(programExerciseInputSchema.safeParse({ ...valid, supersetGroup: 1.5 }).success).toBe(false);
+  });
 });

--- a/lib/schemas/program-exercise.ts
+++ b/lib/schemas/program-exercise.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { MAX_SUPERSET_GROUP, MIN_SUPERSET_GROUP } from '@/lib/supersets';
 
 export const programExerciseInputSchema = z
   .object({
@@ -10,6 +11,16 @@ export const programExerciseInputSchema = z
     restSec: z.coerce.number().int().min(15).max(600),
     tempo: z.string().trim().max(20).optional().nullable(),
     notes: z.string().trim().max(2000).optional().nullable(),
+    // Superset pairing (issue #146, slice 1): exercises of one workout sharing
+    // a group number form a superset. null clears the pairing; ABSENT leaves
+    // it unchanged on update (so the edit form never wipes a pairing).
+    supersetGroup: z
+      .number()
+      .int()
+      .min(MIN_SUPERSET_GROUP)
+      .max(MAX_SUPERSET_GROUP)
+      .nullable()
+      .optional(),
   })
   .refine((v) => v.targetRepsMax >= v.targetRepsMin, {
     message: 'Reps max must be >= reps min',

--- a/lib/supersets.test.ts
+++ b/lib/supersets.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildSupersetView,
+  nextAutoAdvanceIndex,
+  nextNavIndex,
+  smallestFreeGroup,
+  MAX_SUPERSET_GROUP,
+} from './supersets';
+
+interface Item {
+  id: string;
+  order: number;
+  supersetGroup: number | null;
+}
+
+function item(id: string, order: number, supersetGroup: number | null = null): Item {
+  return { id, order, supersetGroup };
+}
+
+describe('buildSupersetView', () => {
+  it('keeps standalone exercises in order with no labels', () => {
+    const view = buildSupersetView([item('b', 2), item('a', 1), item('c', 3)]);
+    expect(view.ordered.map((i) => i.id)).toEqual(['a', 'b', 'c']);
+    expect(view.labels.size).toBe(0);
+    expect(view.groupById.size).toBe(0);
+  });
+
+  it('labels group members A1/A2 and letters follow group appearance', () => {
+    const view = buildSupersetView([
+      item('bench', 1, 7),
+      item('row', 2, 7),
+      item('squat', 3),
+      item('curl', 4, 2),
+      item('ext', 5, 2),
+    ]);
+    expect(view.ordered.map((i) => i.id)).toEqual(['bench', 'row', 'squat', 'curl', 'ext']);
+    // Stored numbers (7 then 2) are cosmetic: letters renumber on read.
+    expect(view.labels.get('bench')).toBe('A1');
+    expect(view.labels.get('row')).toBe('A2');
+    expect(view.labels.get('curl')).toBe('B1');
+    expect(view.labels.get('ext')).toBe('B2');
+    expect(view.labels.has('squat')).toBe(false);
+  });
+
+  it('pulls non-adjacent members together at the first member position', () => {
+    const view = buildSupersetView([
+      item('a1', 1, 1),
+      item('solo', 2),
+      item('a2', 3, 1),
+    ]);
+    expect(view.ordered.map((i) => i.id)).toEqual(['a1', 'a2', 'solo']);
+    expect(view.labels.get('a2')).toBe('A2');
+  });
+
+  it('treats a singleton group as standalone (no label, no group)', () => {
+    const view = buildSupersetView([item('a', 1, 3), item('b', 2)]);
+    expect(view.ordered.map((i) => i.id)).toEqual(['a', 'b']);
+    expect(view.labels.size).toBe(0);
+    expect(view.groupById.has('a')).toBe(false);
+  });
+
+  it('supports groups of three (A1/A2/A3)', () => {
+    const view = buildSupersetView([
+      item('x', 1, 1),
+      item('y', 2, 1),
+      item('z', 3, 1),
+    ]);
+    expect(view.labels.get('z')).toBe('A3');
+  });
+});
+
+describe('nextAutoAdvanceIndex', () => {
+  // remaining() already accounts for the set just logged on the current item.
+  it('standalone: advances only once the target sets are complete (pinned behavior)', () => {
+    const view = buildSupersetView([item('a', 1), item('b', 2)]);
+    expect(nextAutoAdvanceIndex(view, 0, () => 2)).toBeNull(); // sets left -> stay
+    expect(nextAutoAdvanceIndex(view, 0, () => 0)).toBe(1); // complete -> advance
+    expect(nextAutoAdvanceIndex(view, 1, () => 0)).toBeNull(); // last exercise
+  });
+
+  it('superset: alternates to the other member that still has sets', () => {
+    const view = buildSupersetView([item('a1', 1, 1), item('a2', 2, 1), item('b', 3)]);
+    // Logged a set on A1, A2 still has sets -> go to A2 even if A1 has more.
+    expect(nextAutoAdvanceIndex(view, 0, () => 1)).toBe(1);
+    // Logged a set on A2, A1 still has sets -> back to A1.
+    expect(nextAutoAdvanceIndex(view, 1, () => 1)).toBe(0);
+  });
+
+  it('superset: stays on the current member when the others are done', () => {
+    const view = buildSupersetView([item('a1', 1, 1), item('a2', 2, 1), item('b', 3)]);
+    const remaining = (i: Item) => (i.id === 'a1' ? 2 : 0);
+    expect(nextAutoAdvanceIndex(view, 0, remaining)).toBeNull();
+  });
+
+  it('superset: advances past the group once every member is complete', () => {
+    const view = buildSupersetView([item('a1', 1, 1), item('a2', 2, 1), item('b', 3)]);
+    expect(nextAutoAdvanceIndex(view, 1, () => 0)).toBe(2);
+    // Group at the end of the workout -> nothing after it.
+    const tail = buildSupersetView([item('b', 1), item('a1', 2, 1), item('a2', 3, 1)]);
+    expect(nextAutoAdvanceIndex(tail, 2, () => 0)).toBeNull();
+  });
+});
+
+describe('nextNavIndex', () => {
+  it('standalone: next exercise, null at the end (pinned behavior)', () => {
+    const view = buildSupersetView([item('a', 1), item('b', 2)]);
+    expect(nextNavIndex(view, 0, () => 5)).toBe(1);
+    expect(nextNavIndex(view, 1, () => 5)).toBeNull();
+  });
+
+  it('cycles within the group before advancing', () => {
+    const view = buildSupersetView([item('a1', 1, 1), item('a2', 2, 1), item('b', 3)]);
+    // A1 -> A2 (linear within the group).
+    expect(nextNavIndex(view, 0, () => 1)).toBe(1);
+    // A2 (last member) -> back to A1 while A1 has sets remaining.
+    expect(nextNavIndex(view, 1, (i) => (i.id === 'a1' ? 1 : 0))).toBe(0);
+    // A2 -> past the group once A1 is done (never traps the user in place).
+    expect(nextNavIndex(view, 1, (i) => (i.id === 'a2' ? 1 : 0))).toBe(2);
+    expect(nextNavIndex(view, 1, () => 0)).toBe(2);
+  });
+
+  it('group at the end of the workout still cycles, then disables', () => {
+    const view = buildSupersetView([item('b', 1), item('a1', 2, 1), item('a2', 3, 1)]);
+    expect(nextNavIndex(view, 2, (i) => (i.id === 'a1' ? 1 : 0))).toBe(1);
+    expect(nextNavIndex(view, 2, () => 0)).toBeNull();
+  });
+});
+
+describe('smallestFreeGroup', () => {
+  it('returns the smallest unused group number', () => {
+    expect(smallestFreeGroup([item('a', 1, 1), item('b', 2, 3)])).toBe(2);
+    expect(smallestFreeGroup([])).toBe(1);
+  });
+
+  it('returns null when all group numbers are taken', () => {
+    const items = Array.from({ length: MAX_SUPERSET_GROUP }, (_, i) =>
+      item(`x${i}`, i, i + 1),
+    );
+    expect(smallestFreeGroup(items)).toBeNull();
+  });
+});

--- a/lib/supersets.ts
+++ b/lib/supersets.ts
@@ -1,0 +1,168 @@
+// ============================================================
+// Supersets (issue #146, slice 1) - program-level pairing
+// ============================================================
+// Exercises of one workout sharing the same ProgramExercise.supersetGroup
+// number form a superset; null means standalone. The stored numbers are
+// arbitrary bookkeeping: everything user-facing (A1/A2 labels, presentation
+// order) is derived on read by these pure helpers, so unpairing or deleting
+// a member never requires renumbering writes. A group needs at least two
+// members to count as a superset - a singleton group renders as standalone.
+
+export interface SupersetItem {
+  id: string;
+  order: number;
+  supersetGroup: number | null;
+}
+
+// Bounds shared by the Zod schema and the builder UI: group numbers 1-9,
+// i.e. at most 9 supersets per workout (letters A-I).
+export const MIN_SUPERSET_GROUP = 1;
+export const MAX_SUPERSET_GROUP = 9;
+
+export interface SupersetView<T extends SupersetItem> {
+  // Items sorted by `order`, except that members of a real superset group
+  // (>= 2 members) are pulled together at the first member's position,
+  // keeping their relative order. Standalone items keep their position.
+  ordered: T[];
+  // item id -> "A1" / "A2" / "B1"... only for members of real groups.
+  // Letters follow the order groups first appear in; numbers follow the
+  // member order within the group.
+  labels: Map<string, string>;
+  // item id -> the stored group number, only for members of real groups
+  // (singleton groups are treated as standalone and excluded).
+  groupById: Map<string, number>;
+}
+
+export function buildSupersetView<T extends SupersetItem>(items: T[]): SupersetView<T> {
+  const sorted = [...items].sort((a, b) => a.order - b.order);
+  const memberCount = new Map<number, number>();
+  for (const it of sorted) {
+    if (it.supersetGroup != null) {
+      memberCount.set(it.supersetGroup, (memberCount.get(it.supersetGroup) ?? 0) + 1);
+    }
+  }
+
+  const ordered: T[] = [];
+  const labels = new Map<string, string>();
+  const groupById = new Map<string, number>();
+  const emitted = new Set<string>();
+  let letterIndex = 0;
+
+  for (const it of sorted) {
+    if (emitted.has(it.id)) continue;
+    const group = it.supersetGroup;
+    if (group != null && (memberCount.get(group) ?? 0) >= 2) {
+      const letter = String.fromCharCode(65 + letterIndex); // A, B, C...
+      letterIndex += 1;
+      let memberNumber = 1;
+      for (const member of sorted) {
+        if (member.supersetGroup === group && !emitted.has(member.id)) {
+          ordered.push(member);
+          emitted.add(member.id);
+          labels.set(member.id, `${letter}${memberNumber}`);
+          groupById.set(member.id, group);
+          memberNumber += 1;
+        }
+      }
+    } else {
+      ordered.push(it);
+      emitted.add(it.id);
+    }
+  }
+  return { ordered, labels, groupById };
+}
+
+// The contiguous [start, end] index span of the current item's group in the
+// presentation order, or null when the item is standalone.
+function groupSpan<T extends SupersetItem>(
+  view: SupersetView<T>,
+  currentIdx: number,
+): { start: number; end: number } | null {
+  const current = view.ordered[currentIdx];
+  if (!current) return null;
+  const group = view.groupById.get(current.id);
+  if (group == null) return null;
+  let start = currentIdx;
+  while (start > 0 && view.groupById.get(view.ordered[start - 1]!.id) === group) start -= 1;
+  let end = currentIdx;
+  while (
+    end + 1 < view.ordered.length &&
+    view.groupById.get(view.ordered[end + 1]!.id) === group
+  ) {
+    end += 1;
+  }
+  return { start, end };
+}
+
+// Where the runner should auto-advance to once the rest after a logged
+// working set ends. `remaining` returns how many target working sets are
+// still to log for an item (<= 0 when complete), INCLUDING the set just
+// logged on the current item.
+// - Standalone (unchanged behavior): the next exercise once the current one
+//   has completed its target sets, otherwise stay (null).
+// - Superset member (the A1/A2 flow): alternate to the next member of the
+//   group (cycling) that still has sets remaining; when every member is
+//   complete, the exercise right after the group; otherwise stay.
+export function nextAutoAdvanceIndex<T extends SupersetItem>(
+  view: SupersetView<T>,
+  currentIdx: number,
+  remaining: (item: T, idx: number) => number,
+): number | null {
+  const items = view.ordered;
+  const current = items[currentIdx];
+  if (!current) return null;
+
+  const span = groupSpan(view, currentIdx);
+  if (!span) {
+    if (remaining(current, currentIdx) > 0) return null;
+    return currentIdx + 1 < items.length ? currentIdx + 1 : null;
+  }
+
+  const size = span.end - span.start + 1;
+  for (let step = 1; step < size; step += 1) {
+    const idx = span.start + ((currentIdx - span.start + step) % size);
+    if (remaining(items[idx]!, idx) > 0) return idx;
+  }
+  // Every other member is done: stay while the current one has sets left.
+  if (remaining(current, currentIdx) > 0) return null;
+  return span.end + 1 < items.length ? span.end + 1 : null;
+}
+
+// Where the Next button goes (manual navigation, presentation order).
+// - Standalone (unchanged behavior): the next exercise, or null at the end
+//   of the workout (button disabled).
+// - Superset member: linear within the group; from the LAST member it cycles
+//   back to the first OTHER member that still has working sets remaining,
+//   and advances past the group otherwise. Deliberately never points at the
+//   current item itself, so repeated taps can always leave the group - a
+//   user is never trapped cycling in place.
+export function nextNavIndex<T extends SupersetItem>(
+  view: SupersetView<T>,
+  currentIdx: number,
+  remaining: (item: T, idx: number) => number,
+): number | null {
+  const items = view.ordered;
+  const current = items[currentIdx];
+  if (!current) return null;
+
+  const span = groupSpan(view, currentIdx);
+  if (!span) {
+    return currentIdx + 1 < items.length ? currentIdx + 1 : null;
+  }
+  if (currentIdx < span.end) return currentIdx + 1;
+  // Last member: cycle back while another member is unfinished.
+  for (let idx = span.start; idx < span.end; idx += 1) {
+    if (idx !== currentIdx && remaining(items[idx]!, idx) > 0) return idx;
+  }
+  return span.end + 1 < items.length ? span.end + 1 : null;
+}
+
+// The smallest free group number of a workout (for "pair with previous" when
+// the previous row has no group yet), or null when all are in use.
+export function smallestFreeGroup(items: SupersetItem[]): number | null {
+  const used = new Set(items.map((i) => i.supersetGroup).filter((g) => g != null));
+  for (let g = MIN_SUPERSET_GROUP; g <= MAX_SUPERSET_GROUP; g += 1) {
+    if (!used.has(g)) return g;
+  }
+  return null;
+}

--- a/prisma/migrations/20260612090000_add_superset_group/migration.sql
+++ b/prisma/migrations/20260612090000_add_superset_group/migration.sql
@@ -1,0 +1,5 @@
+-- Superset pairing (issue #146, slice 1): additive nullable column. Exercises
+-- of the same workout sharing a group number form a superset; NULL (the
+-- default for every existing row) means standalone. No backfill, no
+-- constraint beyond the column - bounds live in the Zod schema.
+ALTER TABLE "ProgramExercise" ADD COLUMN "supersetGroup" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -184,6 +184,10 @@ model ProgramExercise {
   restSec       Int
   tempo         String?
   notes         String?
+  // Superset pairing (issue #146, slice 1, additive): exercises of the same
+  // workout sharing a group number form a superset; NULL = standalone. The
+  // stored number is arbitrary - A1/A2 labels renumber on read (lib/supersets).
+  supersetGroup Int?
 }
 
 model Session {

--- a/tests/e2e/supersets.spec.ts
+++ b/tests/e2e/supersets.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// Supersets slice 1 (issue #146): pair two exercises in the program builder
+// (A1/A2 labels), then run the workout - the session runner presents the pair
+// consecutively with the superset badge, auto-advances A1 -> A2 after a set,
+// and Next cycles back into the group while it has sets remaining. Setup data
+// is seeded through the authenticated API (the browser context shares cookies
+// with page.request).
+
+async function seedPairableWorkout(page: Page): Promise<{
+  programId: string;
+  workoutId: string;
+}> {
+  const benchRes = await page.request.post('/api/exercises', {
+    data: { name: 'E2E Bench', muscleGroup: 'CHEST', category: 'COMPOUND' },
+  });
+  expect(benchRes.ok()).toBeTruthy();
+  const bench = await benchRes.json();
+
+  const rowRes = await page.request.post('/api/exercises', {
+    data: { name: 'E2E Row', muscleGroup: 'BACK_THICKNESS', category: 'COMPOUND' },
+  });
+  expect(rowRes.ok()).toBeTruthy();
+  const row = await rowRes.json();
+
+  const programRes = await page.request.post('/api/programs', {
+    data: { name: 'E2E Superset Program', phase: 'Base' },
+  });
+  expect(programRes.ok()).toBeTruthy();
+  const program = await programRes.json();
+
+  const workoutRes = await page.request.post(`/api/programs/${program.id}/workouts`, {
+    data: { name: 'Upper A' },
+  });
+  expect(workoutRes.ok()).toBeTruthy();
+  const workout = await workoutRes.json();
+
+  for (const exercise of [bench, row]) {
+    const peRes = await page.request.post(`/api/workouts/${workout.id}/program-exercises`, {
+      data: {
+        exerciseId: exercise.id,
+        targetSets: 2,
+        targetRepsMin: 8,
+        targetRepsMax: 12,
+        targetRIR: 2,
+        restSec: 15,
+      },
+    });
+    expect(peRes.ok()).toBeTruthy();
+  }
+  return { programId: program.id, workoutId: workout.id };
+}
+
+test('a lifter can pair two exercises as a superset and run the A1/A2 flow', async ({
+  page,
+}) => {
+  // Sign up through the API (fresh user; the cookie lands in the context). A
+  // unique X-Forwarded-For keeps this spec in its own register rate-limit
+  // bucket.
+  const registerRes = await page.request.post('/api/auth/register', {
+    headers: { 'x-forwarded-for': '10.111.0.4' },
+    data: {
+      displayName: 'Superset E2E',
+      email: `e2e-superset-${Date.now()}@test.dev`,
+      password: 'supersecret',
+    },
+  });
+  expect(registerRes.ok()).toBeTruthy();
+
+  const { programId, workoutId } = await seedPairableWorkout(page);
+
+  // Builder: pair the second exercise with the previous one.
+  await page.goto(`/programs/${programId}`);
+  await expect(page.getByText('E2E Row')).toBeVisible();
+  await page.getByRole('button', { name: 'Exercise actions' }).nth(1).click();
+  await page.getByRole('menuitem', { name: 'Pair with previous' }).click();
+
+  // Both rows now carry their derived superset labels.
+  await expect(page.getByText('Superset A1')).toBeVisible();
+  await expect(page.getByText('Superset A2')).toBeVisible();
+
+  // Unpair would be offered too (pairing is reversible), but keep the pair.
+  // Start a session on the workout.
+  const sessionRes = await page.request.post('/api/sessions', {
+    data: { workoutId },
+  });
+  expect(sessionRes.ok()).toBeTruthy();
+  const session = await sessionRes.json();
+
+  // Runner: A1 first, with the superset badge.
+  await page.goto(`/session/${session.id}`);
+  await expect(page.getByText('Superset A1')).toBeVisible();
+  await expect(page.getByText(/Exercise 1\/2 · E2E Bench/)).toBeVisible();
+
+  // Log a working set on A1; after the rest, the runner auto-advances to A2
+  // (the alternating superset flow), not to a second bench set.
+  await page.getByLabel('Quick entry').fill('60x8@2');
+  await page.getByRole('button', { name: /log the set/i }).click();
+  await page.getByRole('button', { name: /skip/i }).click();
+  await expect(page.getByText('Superset A2')).toBeVisible();
+  await expect(page.getByText(/Exercise 2\/2 · E2E Row/)).toBeVisible();
+
+  // Next from the last member cycles back into the group while sets remain.
+  await page.getByRole('button', { name: /next/i }).click();
+  await expect(page.getByText('Superset A1')).toBeVisible();
+  await expect(page.getByText(/Exercise 1\/2 · E2E Bench/)).toBeVisible();
+});

--- a/tests/integration/superset-route.test.ts
+++ b/tests/integration/superset-route.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { db } from '@/lib/db';
+import { getCurrentUserId } from '@/lib/auth';
+
+// Supersets slice 1 (issue #146): the supersetGroup column rides the existing
+// program-exercise routes. Pinned here: persistence on create and update, the
+// absent-vs-null update semantics (absent preserves, null unpairs), the Zod
+// bounds, and that ownership still gates the write.
+
+vi.mock('@/lib/auth', () => ({ getCurrentUserId: vi.fn() }));
+const mockUserId = vi.mocked(getCurrentUserId);
+
+import { POST as postProgramExercise } from '@/app/api/workouts/[id]/program-exercises/route';
+import { PUT as putProgramExercise } from '@/app/api/program-exercises/[id]/route';
+
+function actAs(userId: string) {
+  mockUserId.mockResolvedValue(userId);
+}
+
+function jsonReq(method: string, body: unknown): Request {
+  return new Request('http://test.local/api', {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+const targets = {
+  targetSets: 3,
+  targetRepsMin: 8,
+  targetRepsMax: 12,
+  targetRIR: 2,
+  restSec: 90,
+};
+
+async function seed(email: string) {
+  const user = await db.user.create({ data: { email, passwordHash: 'x' } });
+  const bench = await db.exercise.create({
+    data: { userId: user.id, name: 'Bench', muscleGroup: 'CHEST', category: 'COMPOUND' },
+  });
+  const row = await db.exercise.create({
+    data: { userId: user.id, name: 'Row', muscleGroup: 'BACK_THICKNESS', category: 'COMPOUND' },
+  });
+  const program = await db.program.create({
+    data: { userId: user.id, name: 'P', phase: 'Base' },
+  });
+  const workout = await db.workout.create({
+    data: { programId: program.id, name: 'Day A', order: 1 },
+  });
+  return { user, bench, row, workout };
+}
+
+beforeEach(() => {
+  mockUserId.mockReset();
+});
+
+describe('program-exercise routes - supersetGroup (issue #146)', () => {
+  it('creates with a group, and defaults to null (standalone) when absent', async () => {
+    const { user, bench, row, workout } = await seed('superset-create@test.dev');
+    actAs(user.id);
+
+    const standalone = await postProgramExercise(
+      jsonReq('POST', { exerciseId: bench.id, ...targets }),
+      { params: { id: workout.id } },
+    );
+    expect(standalone.status).toBe(201);
+    expect((await standalone.json()).supersetGroup).toBeNull();
+
+    const paired = await postProgramExercise(
+      jsonReq('POST', { exerciseId: row.id, ...targets, supersetGroup: 2 }),
+      { params: { id: workout.id } },
+    );
+    expect(paired.status).toBe(201);
+    expect((await paired.json()).supersetGroup).toBe(2);
+  });
+
+  it('updates: number pairs, absent preserves, null unpairs', async () => {
+    const { user, bench, workout } = await seed('superset-update@test.dev');
+    actAs(user.id);
+    const pe = await db.programExercise.create({
+      data: { workoutId: workout.id, exerciseId: bench.id, order: 1, ...targets },
+    });
+
+    // Pair.
+    const pairRes = await putProgramExercise(
+      jsonReq('PUT', { exerciseId: bench.id, ...targets, supersetGroup: 1 }),
+      { params: { id: pe.id } },
+    );
+    expect(pairRes.status).toBe(200);
+    expect((await pairRes.json()).supersetGroup).toBe(1);
+
+    // An update WITHOUT the field (e.g. the edit-targets form) must preserve
+    // the pairing.
+    const editRes = await putProgramExercise(
+      jsonReq('PUT', { exerciseId: bench.id, ...targets, targetSets: 4 }),
+      { params: { id: pe.id } },
+    );
+    expect(editRes.status).toBe(200);
+    const edited = await editRes.json();
+    expect(edited.targetSets).toBe(4);
+    expect(edited.supersetGroup).toBe(1);
+
+    // Explicit null unpairs.
+    const unpairRes = await putProgramExercise(
+      jsonReq('PUT', { exerciseId: bench.id, ...targets, supersetGroup: null }),
+      { params: { id: pe.id } },
+    );
+    expect(unpairRes.status).toBe(200);
+    expect((await unpairRes.json()).supersetGroup).toBeNull();
+  });
+
+  it('rejects out-of-bounds groups with a 400', async () => {
+    const { user, bench, workout } = await seed('superset-bounds@test.dev');
+    actAs(user.id);
+
+    const res = await postProgramExercise(
+      jsonReq('POST', { exerciseId: bench.id, ...targets, supersetGroup: 10 }),
+      { params: { id: workout.id } },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('still gates the update on ownership (404 for another user)', async () => {
+    const { user, bench, workout } = await seed('superset-owner@test.dev');
+    const intruder = await db.user.create({
+      data: { email: 'superset-intruder@test.dev', passwordHash: 'x' },
+    });
+    const pe = await db.programExercise.create({
+      data: { workoutId: workout.id, exerciseId: bench.id, order: 1, ...targets },
+    });
+
+    actAs(intruder.id);
+    const res = await putProgramExercise(
+      jsonReq('PUT', { exerciseId: bench.id, ...targets, supersetGroup: 1 }),
+      { params: { id: pe.id } },
+    );
+    expect(res.status).toBe(404);
+    expect((await db.programExercise.findUnique({ where: { id: pe.id } }))?.supersetGroup).toBeNull();
+    void user;
+  });
+});


### PR DESCRIPTION
## Summary

Slice 1 of supersets, PROGRAM-LEVEL ONLY per the issue: pairing exercises so the builder and the session runner present them as a superset. Set-logging semantics, the rest timer, AI generation, templates, imports and the coach payload are deliberately untouched (later slices).

- **Schema**: additive nullable `ProgramExercise.supersetGroup` (Int?). Migration validated on the test DB: `prisma migrate deploy` clean, `prisma migrate diff` reports no difference. Rollback baseline `autonomy-baseline-2026-06-12` tagged and pushed on main before merge.
- **Derivations on read** (`lib/supersets.ts`, pure + unit-tested): stored group numbers are arbitrary bookkeeping; A1/A2/B1 labels, presentation order (group members consecutive at the first member's position), rest-end auto-advance (alternates to the next member with sets remaining - the A1/A2 flow) and Next-button cycling (cycles back into an unfinished group, but never points at the current item, so the user is never trapped) all renumber/derive on read.
- **Zod**: `supersetGroup` 1..9, nullable, optional - absent is distinct from null so an update without the field preserves the pairing (the edit-targets form never wipes it) and explicit null unpairs. Pinned by schema and integration tests.
- **Builder**: "Pair with previous" / "Unpair superset" per exercise row (dropdown), `Superset A1` badges; pairing joins the previous row's group or creates the smallest free one (both rows updated). Rides the existing ownership-gated routes.
- **Runner**: presentation order, superset badge + label in the header, auto-advance alternation, Next cycling; standalone exercises behave exactly as before (pinned in unit tests; the whole existing E2E suite still passes).

## Tests

- 14 new unit tests for the derivation lib (incl. pinned standalone behavior and the no-trap navigation cases)
- Schema bounds + absent/null/number tri-state
- Integration: create/update persistence, absent-preserves vs null-unpairs, 400 on out-of-bounds, 404 + no-write for a non-owner
- New E2E: pair two exercises in the builder, run the session through the A1/A2 flow (badge, auto-advance to A2, Next cycling back to A1)
- Test fixtures gained `supersetGroup: null` (type completeness); no assertion changed

## How I tested

`bash scripts/verify.sh --full` - GREEN-GATE PASSED (lint, typecheck, unit, build, integration, E2E - all 9 E2E specs green incl. the new supersets spec).

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)