### PR TITLE
docs: write up the sixth batch (zero-finding reviews; supersets land; lessons L11 + L3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   single field of the set logger to fill the weight, reps, and effort fields
   (RPE maps to the stored RIR). Deterministic parser in the user's display
   unit; the classic fields keep working unchanged.
+- Supersets in programs (slice 1): pair exercises in the program builder and
+  they run as A1/A2 in the session - consecutive presentation, group badge,
+  and Next cycling within the group - while set logging, rest timing, and
+  program generation stay exactly as before.
+- The AI coach now sees your conditioning: weekly cardio minutes, distance,
+  and sessions (current and previous week) against the 150 min/week
+  guideline, as a dedicated payload section; the structured output contract
+  is unchanged.
+- The CSV history export now includes duration_sec and distance_m columns,
+  so cardio work round-trips out of the app just like it comes in; existing
+  column positions are unchanged.
 - Cardio, first-class: exercises can be CARDIO and their sets log duration
   (mm:ss) and distance instead of weight x reps - offline queue included -
   while staying out of every lifting metric (tonnage, e1RM, PRs, MEV/MRV,

--- a/README.md
+++ b/README.md
@@ -69,11 +69,13 @@ more about *how a repo can maintain itself* than about the gym app, start there.
   pull-ups, dips, etc.
 - Optional pre-session readiness/soreness check-in that auto-regulates
   suggested loads and explains why a load was held or reduced
+- Supersets: pair exercises in the program builder and run them as A1/A2 in
+  the session, with grouped navigation
 - Built-in program templates (5/3/1 BBB, GZCLP, nSuns, PPL, Upper/Lower,
   Starting Strength, StrongLifts 5x5, Madcow, PHUL, PHAT, Full Body),
   runnable as written and editable like any program
 - AI coach: weekly debrief and assisted program adjustments, aware of your
-  goals and fatigue signals
+  goals, fatigue signals, and weekly conditioning volume
 - Conversational AI coach: streaming chat grounded in your training data -
   including mid-session, with the live workout (sets so far, targets, today's
   readiness) attached in one tap
@@ -81,7 +83,7 @@ more about *how a repo can maintain itself* than about the gym app, start there.
 - Pluggable LLM provider: Anthropic SDK or any OpenRouter model
 - Import your training history from a Strong or Hevy CSV export (dry-run
   preview, duplicate-safe, cardio rows included); export everything back out
-  as CSV anytime
+  as CSV anytime, duration and distance included
 - Train in kilograms or pounds, a per-user preference (data is always stored in kg)
 - Installable PWA with offline session logging
 

--- a/docs/loops/06-orchestration.md
+++ b/docs/loops/06-orchestration.md
@@ -86,3 +86,12 @@ occasional "this PR needs a human". Everything mechanical between "there is work
 is shipped and documented" runs without a click. The job moved up an altitude: from
 writing the code to **authoring the loops that write it** - and this file is the loop that
 runs the loops.
+
+## Relaunch after a crashed tick (lesson L11)
+
+When a background tick dies mid-run (API error, harness kill), do not immediately relaunch
+into the same checkout: the dead agent can re-wake and write concurrently. First stop the
+dead task explicitly (TaskStop) or confirm it is gone; then `git status` - committed work
+survives in branches/PRs (resume from there), but unexpected working-tree changes are a
+stop-and-reground signal. The replacement tick's prompt should state what is already
+merged so it never redoes or fights prior work.

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -6,6 +6,34 @@ by the charter in [`07-autonomy.md`](07-autonomy.md).
 
 ---
 
+## 2026-06-12 (later) - Sixth batch: zero-finding reviews; supersets land; two process lessons
+
+**Context.** Sixth ideate batch (#144 export columns, #145 coach conditioning, #146
+supersets slice 1) implemented across two ticks (the first died waiting on CI - lesson L3
+relearned - and later re-woke as a concurrent writer during #145 - new lesson L11).
+
+**Decided / shipped.**
+- #148/#149/#150 all merged on green full CI; all three independent Opus reviews CLEAN -
+  the first zero-REAL-finding batch. The #150 reviewer proved the A1/A2 flow live on a
+  production build and exhaustively verified the no-trap navigation property; the #149
+  reviewer ran an injected-code scan after the zombie episode (nothing foreign).
+- Lessons graduated: L11 (stop a crashed tick before relaunching into the same checkout;
+  06-orchestration.md gains the relaunch-after-crash rule) and the L3 reminder is now
+  injected into tick prompts (poll CI in-process, never end a run "waiting").
+- Write-up: CHANGELOG, README (supersets, coach conditioning, export round-trip),
+  backlog verdicts, this entry. Captured pages unchanged (builder/session-runner are not
+  screenshot subjects); clips within the staleness cap. Demo redeploy follows the merge.
+
+**Challenged.** Two independent reviews, model-split. Accepted-change rate: 3 merged /
+0 abandoned (plus 2 docs PRs).
+
+**Deferred to human.** Nothing. Superset slices 2+ (shared rest, circuit timer), pace
+analytics, and cardio drill-down stay un-filed for the next starved cycle.
+
+---
+
+---
+
 ## 2026-06-12 - Coach conditioning payload (#145) + supersets slice 1 (#146) shipped
 
 **Context.** Maintainer tick executing the remaining two issues of the sixth ideate

--- a/docs/loops/ideas-backlog.md
+++ b/docs/loops/ideas-backlog.md
@@ -33,6 +33,6 @@ research and the product wedge). See `docs/loops/08-ideation-loop.md` for how th
 - shipped - first-class cardio sets (duration/distance + CARDIO category) (issue #133, 2026-06-11, PR #137 + fix #141) - multi-lens review CLEAN; one coach-payload pollution finding fixed same-day
 - shipped - importers map cardio rows onto the new fields (issue #134, 2026-06-11, PR #138) - security review CLEAN incl. 8 adversarial probes
 - shipped - conditioning card on the progress page (issue #135, 2026-06-11, PR #139) - correctness review CLEAN
-- proposed - include cardio duration/distance in the CSV history export (issue #144, 2026-06-12) - data-ownership gap confirmed by the #138 review; two trailing columns, positions pinned
-- proposed - dedicated conditioning section in the AI coach payload (issue #145, 2026-06-12) - the deliberate counterpart of the #141 pollution fix; #101 pattern, output contract unchanged
-- proposed - supersets slice 1: program-level pairing + A1/A2 session flow (issue #146, 2026-06-12) - the twice-deferred item, finally sliced; logging semantics untouched, later slices for rest/circuit behavior
+- shipped - include cardio duration/distance in the CSV history export (issue #144, 2026-06-12, PR #148) - column order pinned; closes the data-ownership gap
+- shipped - dedicated conditioning section in the AI coach payload (issue #145, 2026-06-12, PR #149) - review CLEAN on all seven lenses incl. the two-writers scan
+- shipped - supersets slice 1: program-level pairing + A1/A2 session flow (issue #146, 2026-06-12, PR #150) - review CLEAN; E2E proven live; later slices (shared rest, circuits) still un-filed

--- a/docs/loops/lessons.md
+++ b/docs/loops/lessons.md
@@ -137,3 +137,17 @@ Format per entry: trigger/evidence, the lesson (actionable), and **Status** = `g
   session for marginal gain in a batch-oriented loop. Accepted decision, not a gap.
 - **Status:** graduated -> CLAUDE.md (green-gate section), `ship-pr` step 3,
   `implement-issue` step 5.
+
+### L11 - A tick that died mid-run can come back as a zombie writer: stop it before relaunching
+- **Trigger:** a maintainer tick died on a transient API 529, the orchestrator relaunched a
+  fresh tick into the same checkout, and the dead tick later re-woke and wrote concurrently
+  in the working tree while the new tick was implementing #145 (the new tick caught it,
+  verified every line against the spec, and the independent review confirmed nothing
+  foreign landed - but only luck made the two writers converge on the same spec).
+- **Lesson:** "one writer per checkout" applies to dead agents too. Before relaunching a
+  replacement tick into the same working tree, explicitly stop the dead task (TaskStop) or
+  confirm it can no longer wake; on relaunch, the new tick should `git status` first and
+  treat unexpected tree changes as a stop-and-reground signal, not something to absorb.
+- **Status:** graduated -> `06-orchestration.md` (relaunch-after-crash rule) and the
+  orchestrator's memory; review prompts after any two-writer episode must include an
+  injected-code scan (done for #149, verdict clean).

--- a/docs/loops/review-digest.md
+++ b/docs/loops/review-digest.md
@@ -209,3 +209,28 @@ extra adversarial import probes - all passed.
 local-vs-UTC ISO-week doc mismatch repo-wide, and the warmup-only-cardio empty card),
 this write-up (incl. demo seed gaining 23 deterministic cardio sessions + fresh
 screenshots).
+
+---
+
+## 2026-06-12 (later) - sixth batch (#148/#149/#150): export round-trip, coach conditioning, supersets
+
+Merged: #148 (cardio columns in the CSV export), #149 (dedicated conditioning section in
+the coach payload), #150 (supersets slice 1: builder pairing + A1/A2 session flow). All
+three independent Opus reviews: CLEAN - the first zero-finding batch. The #150 reviewer
+proved the flow live on a production build (pair -> A1 badge -> log -> auto-advance to A2
+-> Next cycles back) and exhaustively checked the no-trap navigation property; the #149
+reviewer additionally scanned for injected code after a zombie-writer episode (clean).
+
+**Read first, in order:**
+
+1. **#150 - the superset structure.** `gh pr diff 150`. One nullable column; ALL
+   semantics derive on read in lib/supersets.ts. This is the foundation later slices
+   (shared rest, circuits) build on - worth understanding the renumber-on-read model.
+2. **#149 - what the coach knows now.** `gh pr diff 149`. Conditioning aggregates join
+   goals and fatigue in the payload; output contract byte-identical.
+3. **#148 - the export contract.** `gh pr diff 148`. Two trailing columns; existing
+   column positions pinned by test.
+
+**Process note:** lesson L11 (zombie writer after a crashed tick - stop the dead task
+before relaunching; see lessons.md) and the L3 reminder that background ticks must poll
+CI in-process landed this cycle.


### PR DESCRIPTION
Content-loop tail for the sixth batch (#148 CSV export columns, #149 coach conditioning section, #150 supersets slice 1).

- All three independent Opus reviews returned CLEAN - the first zero-REAL-finding batch. #150 was proven live on a production build (A1/A2 flow, exhaustive no-trap navigation check); #149 got an injected-code scan after the zombie-writer episode (clean).
- CHANGELOG + README updated (supersets, coach conditioning, export round-trip), claims checked against merged code.
- Lessons: L11 graduated (stop a crashed tick before relaunching into the same checkout - the dead one can re-wake as a concurrent writer; 06-orchestration.md gains the relaunch-after-crash rule) plus the L3 in-process CI polling reminder now travels in tick prompts.
- Media: none of the captured pages changed (builder/session-runner are not screenshot subjects); clips within the ~3-batch staleness cap.

bash scripts/verify.sh - GREEN-GATE PASSED.

After merge: triggering deploy-demo so the public demo picks up the batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)