### PR TITLE
feat: 'What your coach sees' transparency card on the coach page

### DIFF
--- a/app/(app)/coach/page.tsx
+++ b/app/(app)/coach/page.tsx
@@ -2,15 +2,18 @@ import { Sparkles } from 'lucide-react';
 import { db } from '@/lib/db';
 import { requireSession } from '@/lib/auth';
 import { getLlmProvider } from '@/lib/llm';
+import { buildCoachPayload } from '@/lib/coach';
+import { summarizeCoachPayload } from '@/lib/coach-context';
 import {
   CoachClient,
   type ProgramExerciseDefaults,
 } from '@/components/coach/coach-client';
+import { CoachContextCard } from '@/components/coach/coach-context-card';
 
 export default async function CoachPage() {
   const auth = await requireSession();
 
-  const [history, activeProgram] = await Promise.all([
+  const [history, activeProgram, coachPayload] = await Promise.all([
     db.coachSession.findMany({
       where: { userId: auth.userId },
       orderBy: { createdAt: 'desc' },
@@ -36,7 +39,12 @@ export default async function CoachPage() {
         },
       },
     }),
+    // "What your coach sees" (issue #154): the SAME builder the debrief and
+    // chat routes use, so the card cannot drift from the payload the AI gets.
+    buildCoachPayload(auth.userId),
   ]);
+
+  const coachContext = summarizeCoachPayload(coachPayload);
 
   // Map exerciseName -> current program values (to pre-fill adjustments when
   // the coach does not provide an explicit value).
@@ -82,6 +90,8 @@ export default async function CoachPage() {
             </p>
           </div>
         </div>
+
+        <CoachContextCard summary={coachContext} />
 
         <CoachClient
           initialHistory={initialHistory}

--- a/components/coach/coach-context-card.test.tsx
+++ b/components/coach/coach-context-card.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CoachContextCard } from './coach-context-card';
+import type { CoachContextSummary } from '@/lib/coach-context';
+
+function emptySummary(): CoachContextSummary {
+  return {
+    goals: [],
+    stalledExercises: [],
+    deloadActive: false,
+    deloadRecommended: false,
+    deloadReasons: [],
+    conditioning: {
+      currentMinutes: 0,
+      currentKm: 0,
+      currentSessions: 0,
+      weeklyTargetMin: 150,
+    },
+    readiness: null,
+    weeksOfHistory: 0,
+    exercisesTracked: 0,
+  };
+}
+
+function fullSummary(): CoachContextSummary {
+  return {
+    goals: [
+      {
+        exerciseName: 'Bench Press',
+        targetWeight: 100,
+        targetReps: 5,
+        progressPct: 82,
+        achieved: false,
+      },
+      {
+        exerciseName: 'Squat',
+        targetWeight: 140,
+        targetReps: 3,
+        progressPct: 100,
+        achieved: true,
+      },
+    ],
+    stalledExercises: ['Overhead Press', 'Squat'],
+    deloadActive: false,
+    deloadRecommended: true,
+    deloadReasons: ['2 lifts stalled'],
+    conditioning: {
+      currentMinutes: 75,
+      currentKm: 12.5,
+      currentSessions: 2,
+      weeklyTargetMin: 150,
+    },
+    readiness: { daysAgo: 2, readiness: 4, sleepQuality: 3 },
+    weeksOfHistory: 6,
+    exercisesTracked: 8,
+  };
+}
+
+describe('CoachContextCard', () => {
+  it('is collapsed by default and expands on click', () => {
+    render(<CoachContextCard summary={fullSummary()} />);
+    expect(screen.getByText('What your coach sees')).toBeInTheDocument();
+    expect(screen.queryByText(/Stalled lifts/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /What your coach sees/ }));
+    expect(screen.getByText(/Stalled lifts: Overhead Press, Squat\./)).toBeInTheDocument();
+  });
+
+  it('renders every section of a full context when expanded', () => {
+    render(<CoachContextCard summary={fullSummary()} />);
+    fireEvent.click(screen.getByRole('button', { name: /What your coach sees/ }));
+
+    expect(screen.getByText(/6 weeks of recent history across 8 exercises\./)).toBeInTheDocument();
+    expect(screen.getByText(/Bench Press: 100 kg x 5/)).toBeInTheDocument();
+    expect(screen.getByText(/\(82% there\)/)).toBeInTheDocument();
+    expect(screen.getByText('achieved')).toBeInTheDocument();
+    expect(screen.getByText(/Deload recommended: 2 lifts stalled\./)).toBeInTheDocument();
+    expect(screen.getByText(/This week: 75 min · 12.5 km · 2 sessions/)).toBeInTheDocument();
+    expect(screen.getByText(/\(target 150 min\/week\)/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Last check-in 2 days ago: readiness 4\/5, sleep 3\/5\./),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('This structured summary - never your raw rows - is what the AI receives.'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders sensible empty states for a fresh user', () => {
+    render(<CoachContextCard summary={emptySummary()} />);
+    fireEvent.click(screen.getByRole('button', { name: /What your coach sees/ }));
+
+    expect(
+      screen.getByText(/No logged sessions yet - the coach starts learning from your first workout\./),
+    ).toBeInTheDocument();
+    expect(screen.getByText('No exercise goals set.')).toBeInTheDocument();
+    expect(screen.getByText('No stalled lifts detected.')).toBeInTheDocument();
+    expect(screen.getByText('No deload recommended.')).toBeInTheDocument();
+    expect(screen.getByText(/This week: 0 min · 0 sessions/)).toBeInTheDocument();
+    expect(screen.getByText('No readiness check-in in the last 7 days.')).toBeInTheDocument();
+  });
+
+  it('shows the active deload state instead of a recommendation', () => {
+    const summary = { ...fullSummary(), deloadActive: true };
+    render(<CoachContextCard summary={summary} />);
+    fireEvent.click(screen.getByRole('button', { name: /What your coach sees/ }));
+    expect(screen.getByText('A planned deload week is active.')).toBeInTheDocument();
+    expect(screen.queryByText(/Deload recommended/)).not.toBeInTheDocument();
+  });
+});

--- a/components/coach/coach-context-card.tsx
+++ b/components/coach/coach-context-card.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useState } from 'react';
+import { ChevronDown, ChevronRight, Eye } from 'lucide-react';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import type { CoachContextSummary } from '@/lib/coach-context';
+
+interface Props {
+  summary: CoachContextSummary;
+}
+
+// "What your coach sees" (issue #154, display-only): a collapsed-by-default
+// card that renders the same payload sections the AI debrief receives, so the
+// user can verify at a glance that the coach knows their training. The summary
+// is derived server-side from buildCoachPayload via summarizeCoachPayload -
+// no derivation is duplicated here.
+export function CoachContextCard({ summary }: Props) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+          className="flex w-full items-center gap-2 text-left"
+        >
+          {open ? (
+            <ChevronDown className="size-4 shrink-0 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
+          )}
+          <Eye className="size-4 text-primary" />
+          <h2 className="text-base font-semibold">What your coach sees</h2>
+        </button>
+        {!open && (
+          <p className="pl-6 text-xs text-muted-foreground">
+            The training context behind every debrief. Tap to expand.
+          </p>
+        )}
+      </CardHeader>
+      {open && (
+        <CardContent className="flex flex-col gap-4 text-sm">
+          <Section title="Training history">
+            {summary.weeksOfHistory > 0 ? (
+              <p>
+                {summary.weeksOfHistory} week{summary.weeksOfHistory === 1 ? '' : 's'} of
+                recent history across {summary.exercisesTracked} exercise
+                {summary.exercisesTracked === 1 ? '' : 's'}.
+              </p>
+            ) : (
+              <p className="text-muted-foreground">
+                No logged sessions yet - the coach starts learning from your first workout.
+              </p>
+            )}
+          </Section>
+
+          <Section title="Goals">
+            {summary.goals.length > 0 ? (
+              <ul className="flex flex-col gap-1">
+                {summary.goals.map((g) => (
+                  <li key={`${g.exerciseName}-${g.targetWeight}-${g.targetReps}`}>
+                    {g.exerciseName}: {g.targetWeight} kg x {g.targetReps}{' '}
+                    {g.achieved ? (
+                      <Badge variant="secondary">achieved</Badge>
+                    ) : (
+                      <span className="text-muted-foreground">({g.progressPct}% there)</span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-muted-foreground">No exercise goals set.</p>
+            )}
+          </Section>
+
+          <Section title="Fatigue">
+            {summary.stalledExercises.length > 0 ? (
+              <p>Stalled lifts: {summary.stalledExercises.join(', ')}.</p>
+            ) : (
+              <p className="text-muted-foreground">No stalled lifts detected.</p>
+            )}
+            {summary.deloadActive ? (
+              <p>A planned deload week is active.</p>
+            ) : summary.deloadRecommended ? (
+              <p>
+                Deload recommended
+                {summary.deloadReasons.length > 0
+                  ? `: ${summary.deloadReasons.join('; ')}`
+                  : ''}
+                .
+              </p>
+            ) : (
+              <p className="text-muted-foreground">No deload recommended.</p>
+            )}
+          </Section>
+
+          <Section title="Conditioning">
+            <p>
+              This week: {summary.conditioning.currentMinutes} min
+              {summary.conditioning.currentKm > 0
+                ? ` · ${summary.conditioning.currentKm} km`
+                : ''}
+              {` · ${summary.conditioning.currentSessions} session${
+                summary.conditioning.currentSessions === 1 ? '' : 's'
+              }`}{' '}
+              <span className="text-muted-foreground">
+                (target {summary.conditioning.weeklyTargetMin} min/week)
+              </span>
+            </p>
+          </Section>
+
+          <Section title="Readiness">
+            {summary.readiness ? (
+              <p>
+                Last check-in{' '}
+                {summary.readiness.daysAgo === 0
+                  ? 'today'
+                  : `${summary.readiness.daysAgo} day${
+                      summary.readiness.daysAgo === 1 ? '' : 's'
+                    } ago`}
+                : readiness {summary.readiness.readiness}/5, sleep{' '}
+                {summary.readiness.sleepQuality}/5.
+              </p>
+            ) : (
+              <p className="text-muted-foreground">No readiness check-in in the last 7 days.</p>
+            )}
+          </Section>
+
+          <p className="border-t pt-3 text-xs text-muted-foreground">
+            This structured summary - never your raw rows - is what the AI receives.
+          </p>
+        </CardContent>
+      )}
+    </Card>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {title}
+      </h3>
+      {children}
+    </div>
+  );
+}

--- a/lib/coach-context.test.ts
+++ b/lib/coach-context.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import type { CoachPayload } from '@/lib/coach';
+import { summarizeCoachPayload } from './coach-context';
+
+// summarizeCoachPayload only reshapes the payload buildCoachPayload already
+// assembled - these tests pin that mapping (and the only derived number, the
+// distinct-ISO-week count) for a full payload and for a fresh user.
+
+function emptyPayload(): CoachPayload {
+  return {
+    generatedAt: '2026-06-12T10:00:00.000Z',
+    userProfile: {
+      displayName: null,
+      sex: null,
+      heightCm: null,
+      bodyweight: null,
+      goal: null,
+      weeklyFrequency: null,
+    },
+    weekCurrent: { weekStart: '2026-06-08T00:00:00.000Z', sessions: [] },
+    weekPrevious: null,
+    activeProgram: null,
+    latestReadiness: null,
+    goals: [],
+    fatigue: {
+      stalledExercises: [],
+      deloadRecommended: false,
+      deloadReasons: [],
+      deloadActive: false,
+    },
+    conditioning: {
+      weekCurrent: { minutes: 0, km: 0, sessions: 0 },
+      weekPrevious: null,
+      weeklyTargetMin: 150,
+    },
+    recentProgress: [],
+  };
+}
+
+describe('summarizeCoachPayload', () => {
+  it('maps a fresh user to safe empty states', () => {
+    const summary = summarizeCoachPayload(emptyPayload());
+    expect(summary.goals).toEqual([]);
+    expect(summary.stalledExercises).toEqual([]);
+    expect(summary.deloadActive).toBe(false);
+    expect(summary.deloadRecommended).toBe(false);
+    expect(summary.readiness).toBeNull();
+    expect(summary.weeksOfHistory).toBe(0);
+    expect(summary.exercisesTracked).toBe(0);
+    expect(summary.conditioning).toEqual({
+      currentMinutes: 0,
+      currentKm: 0,
+      currentSessions: 0,
+      weeklyTargetMin: 150,
+    });
+  });
+
+  it('maps a full payload section by section', () => {
+    const payload = emptyPayload();
+    payload.goals = [
+      {
+        exerciseName: 'Bench Press',
+        targetWeight: 100,
+        targetReps: 5,
+        progressPct: 82,
+        achieved: false,
+      },
+    ];
+    payload.fatigue = {
+      stalledExercises: ['Squat'],
+      deloadRecommended: true,
+      deloadReasons: ['2 lifts stalled'],
+      deloadActive: false,
+    };
+    payload.conditioning = {
+      weekCurrent: { minutes: 75, km: 12.5, sessions: 2 },
+      weekPrevious: { minutes: 60, km: 10, sessions: 2 },
+      weeklyTargetMin: 150,
+    };
+    payload.latestReadiness = {
+      date: '2026-06-10T08:00:00.000Z',
+      daysAgo: 2,
+      readiness: 4,
+      sleepQuality: 3,
+      soreness: null,
+      note: null,
+    };
+    payload.recentProgress = [
+      {
+        exerciseId: 'e1',
+        exerciseName: 'Squat',
+        muscleGroup: 'legs',
+        usesBodyweight: false,
+        targetRepsMin: 5,
+        targetRepsMax: 8,
+        currentLoad: 120,
+        sessions: [
+          // Two sessions in the same ISO week + one the week after.
+          { date: '2026-06-01T10:00:00.000Z', maxWeight: 120, topSetReps: 5, estimated1RM: 140 },
+          { date: '2026-06-03T10:00:00.000Z', maxWeight: 120, topSetReps: 6, estimated1RM: 142 },
+          { date: '2026-06-09T10:00:00.000Z', maxWeight: 122.5, topSetReps: 5, estimated1RM: 143 },
+        ],
+      },
+      {
+        exerciseId: 'e2',
+        exerciseName: 'Bench Press',
+        muscleGroup: 'chest',
+        usesBodyweight: false,
+        targetRepsMin: 5,
+        targetRepsMax: 8,
+        currentLoad: 80,
+        sessions: [
+          { date: '2026-06-02T10:00:00.000Z', maxWeight: 80, topSetReps: 5, estimated1RM: 93 },
+        ],
+      },
+    ];
+
+    const summary = summarizeCoachPayload(payload);
+    expect(summary.goals).toEqual([
+      {
+        exerciseName: 'Bench Press',
+        targetWeight: 100,
+        targetReps: 5,
+        progressPct: 82,
+        achieved: false,
+      },
+    ]);
+    expect(summary.stalledExercises).toEqual(['Squat']);
+    expect(summary.deloadRecommended).toBe(true);
+    expect(summary.deloadReasons).toEqual(['2 lifts stalled']);
+    expect(summary.conditioning).toEqual({
+      currentMinutes: 75,
+      currentKm: 12.5,
+      currentSessions: 2,
+      weeklyTargetMin: 150,
+    });
+    expect(summary.readiness).toEqual({ daysAgo: 2, readiness: 4, sleepQuality: 3 });
+    // 2026-06-01/02/03 share an ISO week; 2026-06-09 starts the next one.
+    expect(summary.weeksOfHistory).toBe(2);
+    expect(summary.exercisesTracked).toBe(2);
+  });
+});

--- a/lib/coach-context.ts
+++ b/lib/coach-context.ts
@@ -1,0 +1,79 @@
+import type { CoachPayload } from '@/lib/coach';
+import { isoWeekStart } from '@/lib/stats';
+
+// ============================================================
+// "What your coach sees" summary (issue #154, display-only)
+// ============================================================
+// Maps the EXACT payload buildCoachPayload assembles for the AI into the
+// compact, human-readable summary the coach page card renders. This module
+// only reshapes fields the payload already carries - it never re-derives a
+// signal from raw rows, so the card cannot drift from what the coach reads.
+
+export interface CoachContextSummary {
+  goals: Array<{
+    exerciseName: string;
+    targetWeight: number;
+    targetReps: number;
+    progressPct: number;
+    achieved: boolean;
+  }>;
+  stalledExercises: string[];
+  deloadActive: boolean;
+  deloadRecommended: boolean;
+  deloadReasons: string[];
+  conditioning: {
+    currentMinutes: number;
+    currentKm: number;
+    currentSessions: number;
+    weeklyTargetMin: number;
+  };
+  // Null when no readiness check-in landed within the payload's 7-day window.
+  readiness: {
+    daysAgo: number;
+    readiness: number;
+    sleepQuality: number;
+  } | null;
+  // Distinct ISO weeks with at least one logged session inside the payload's
+  // 8-week progression window - how much history the coach actually sees.
+  weeksOfHistory: number;
+  // Distinct exercises with recent history in the payload.
+  exercisesTracked: number;
+}
+
+export function summarizeCoachPayload(payload: CoachPayload): CoachContextSummary {
+  const weekStarts = new Set<string>();
+  for (const exercise of payload.recentProgress) {
+    for (const session of exercise.sessions) {
+      weekStarts.add(isoWeekStart(new Date(session.date)).toISOString());
+    }
+  }
+
+  return {
+    goals: payload.goals.map((g) => ({
+      exerciseName: g.exerciseName,
+      targetWeight: g.targetWeight,
+      targetReps: g.targetReps,
+      progressPct: g.progressPct,
+      achieved: g.achieved,
+    })),
+    stalledExercises: payload.fatigue.stalledExercises,
+    deloadActive: payload.fatigue.deloadActive,
+    deloadRecommended: payload.fatigue.deloadRecommended,
+    deloadReasons: payload.fatigue.deloadReasons,
+    conditioning: {
+      currentMinutes: payload.conditioning.weekCurrent.minutes,
+      currentKm: payload.conditioning.weekCurrent.km,
+      currentSessions: payload.conditioning.weekCurrent.sessions,
+      weeklyTargetMin: payload.conditioning.weeklyTargetMin,
+    },
+    readiness: payload.latestReadiness
+      ? {
+          daysAgo: payload.latestReadiness.daysAgo,
+          readiness: payload.latestReadiness.readiness,
+          sleepQuality: payload.latestReadiness.sleepQuality,
+        }
+      : null,
+    weeksOfHistory: weekStarts.size,
+    exercisesTracked: payload.recentProgress.length,
+  };
+}


### PR DESCRIPTION
## Summary

Adds the issue #154 transparency card to the coach page: a collapsed-by-default 'What your coach sees' card rendering a compact human-readable summary of the SAME payload sections the AI debrief receives - goals with progress %, stalled lifts, deload active/recommended, weekly conditioning vs the 150 min/week target, latest readiness check-in age, and weeks of history covered.

- Display-only: no schema, API, or prompt changes. The payload the coach receives is untouched (pinned by the existing payload tests, which are unmodified).
- No duplicated derivations: the server component calls the shared `buildCoachPayload`, and a new pure mapper `summarizeCoachPayload` (lib/coach-context.ts) reshapes it for the card.
- Sensible empty states for a fresh user; footer line: 'This structured summary - never your raw rows - is what the AI receives.'

Closes #154

## How I tested

- `bash scripts/verify.sh` - GREEN-GATE PASSED (prisma generate + lint + typecheck + unit + build).
- New unit tests: lib/coach-context.test.ts (full payload mapping + fresh-user empty payload, distinct-ISO-week count).
- New component tests: components/coach/coach-context-card.test.tsx (collapsed by default, expands on click, all sections of a full context, empty states, active-deload state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)