### PR TITLE
feat: per-day conditioning in the coach payload + hybrid interference guidance

### DIFF
--- a/lib/coach-context.test.ts
+++ b/lib/coach-context.test.ts
@@ -31,6 +31,7 @@ function emptyPayload(): CoachPayload {
     conditioning: {
       weekCurrent: { minutes: 0, km: 0, sessions: 0 },
       weekPrevious: null,
+      days: [],
       weeklyTargetMin: 150,
     },
     recentProgress: [],
@@ -75,6 +76,7 @@ describe('summarizeCoachPayload', () => {
     payload.conditioning = {
       weekCurrent: { minutes: 75, km: 12.5, sessions: 2 },
       weekPrevious: { minutes: 60, km: 10, sessions: 2 },
+      days: [{ date: '2026-06-09', minutes: 75, km: 12.5 }],
       weeklyTargetMin: 150,
     };
     payload.latestReadiness = {

--- a/lib/coach.ts
+++ b/lib/coach.ts
@@ -3,6 +3,7 @@ import {
   applyBodyweight,
   best1RM,
   effectiveWeight,
+  dailyConditioning,
   exerciseProgress,
   isStalled,
   isoWeekStart,
@@ -104,6 +105,12 @@ interface ConditioningSummary {
   // Null when the previous ISO week had no cardio session (mirrors the
   // strength summary's weekPrevious semantics).
   weekPrevious: ConditioningWeek | null;
+  // Per-day cardio of the CURRENT ISO week (issue #153): the interference
+  // signal - WHEN the cardio happened, so the coach can spot a hard run next
+  // to a heavy lower-body day. Days without cardio are omitted (compact; a
+  // zero-cardio week is an empty array), sorted ascending by date. Input
+  // signal only; the output contract (the <adjustments> block) is unchanged.
+  days: Array<{ date: string; minutes: number; km: number }>;
   // The weekly guideline the progress page tracks (150 min/week).
   weeklyTargetMin: number;
 }
@@ -315,6 +322,17 @@ export async function buildCoachPayload(userId: string): Promise<CoachPayload> {
     { windowWeeks: 2, now },
   );
   const [conditioningPrev, conditioningCurrent] = conditioningWeeks;
+  // Per-day breakdown of the current ISO week (issue #153): the shared
+  // dailyConditioning derivation over the same already-fetched recent sets.
+  const conditioningDays = dailyConditioning(
+    recentSets.map((s) => ({
+      durationSec: s.durationSec,
+      distanceM: s.distanceM,
+      isWarmup: s.isWarmup,
+      sessionStartedAt: s.session.startedAt,
+    })),
+    { now },
+  );
   const conditioning: ConditioningSummary = {
     weekCurrent: {
       minutes: conditioningCurrent?.minutes ?? 0,
@@ -329,6 +347,7 @@ export async function buildCoachPayload(userId: string): Promise<CoachPayload> {
             sessions: conditioningPrev.sessions,
           }
         : null,
+    days: conditioningDays,
     weeklyTargetMin: WEEKLY_CONDITIONING_TARGET_MIN,
   };
 

--- a/lib/llm/demo.test.ts
+++ b/lib/llm/demo.test.ts
@@ -86,4 +86,20 @@ describe('demo provider', () => {
     // <adjustments> block still closes the response.
     expect(debrief.text.trimEnd().endsWith('</adjustments>')).toBe(true);
   });
+
+  // Issue #153: the canned debrief exercises the interference guidance so the
+  // no-key flow demonstrates the coach reasoning about cardio timing.
+  it('includes an interference-aware line in the canned debrief', async () => {
+    process.env.LLM_PROVIDER = 'demo';
+    const p = getLlmProvider();
+
+    const debrief = await p.complete({
+      system: 'You produce a debrief and an <adjustments> block.',
+      messages: [{ role: 'user', content: 'x' }],
+    });
+    expect(debrief.text).toMatch(/Interference check/i);
+    expect(debrief.text).toMatch(/move hard runs away from heavy lower-body days/i);
+    // Still ends with the unchanged output contract.
+    expect(debrief.text.trimEnd().endsWith('</adjustments>')).toBe(true);
+  });
 });

--- a/lib/llm/demo.ts
+++ b/lib/llm/demo.ts
@@ -33,6 +33,7 @@ Solid week: 3 sessions logged, total working volume up about 4% versus last week
 
 **Conditioning**
 - 95 of your 150 weekly target minutes logged (9.6 km across 2 cardio sessions), up from 60 minutes last week. Aerobic volume is climbing but still moderate, so it is not cutting into lifting recovery yet - keep the easy pace.
+- Interference check: your longer run landed the day before your leg session, so the same recovery budget got hit twice - move hard runs away from heavy lower-body days (easy cardio after lifting or on rest days) to protect leg progress.
 
 **Suggestions for next week**
 - Push bench to 72.5 kg for the first working sets - that lines up with your stated goal.

--- a/lib/prompts/coach-system-prompt.test.ts
+++ b/lib/prompts/coach-system-prompt.test.ts
@@ -67,6 +67,20 @@ describe('coach system prompt positioning', () => {
       /do not propose program\s+adjustments to chase the cardio target/i,
     );
   });
+
+  // Issue #153: per-day conditioning is an INPUT-side interference signal;
+  // cardio scheduling advice stays in prose, never in <adjustments>.
+  it('tells the coach to manage cardio/strength interference from the daily breakdown', () => {
+    expect(COACH_SYSTEM_PROMPT).toMatch(/conditioning\.days/);
+    expect(COACH_SYSTEM_PROMPT).toMatch(/days without cardio are omitted/i);
+    expect(COACH_SYSTEM_PROMPT).toMatch(
+      /separate hard runs from heavy\s+lower-body days/i,
+    );
+    expect(COACH_SYSTEM_PROMPT).toMatch(/explain WHY the timing matters/);
+    expect(COACH_SYSTEM_PROMPT).toMatch(
+      /cardio scheduling never goes in the <adjustments> block/i,
+    );
+  });
 });
 
 describe('program generation prompt positioning', () => {

--- a/lib/prompts/coach-system-prompt.ts
+++ b/lib/prompts/coach-system-prompt.ts
@@ -61,6 +61,16 @@ medical advice or prescribe cardio as treatment - and do not propose program
 adjustments to chase the cardio target: the <adjustments> block stays about
 the lifting program.
 
+conditioning.days breaks the current week's cardio down per day (date, minutes,
+km; days without cardio are omitted). Use it together with the dated strength
+sessions in weekCurrent to manage interference: when hard or long cardio lands
+on, or the day before, a heavy lower-body strength day (squats, deadlifts, leg
+work), flag the collision and suggest sequencing - separate hard runs from heavy
+lower-body days, put easy cardio after lifting or on rest days, and protect the
+shared recovery budget. Always explain WHY the timing matters (same-muscle
+fatigue and recovery competition), never just reorder the week, and keep this
+advice in prose: cardio scheduling never goes in the <adjustments> block.
+
 Be concise (max 600 words), actionable, factual. Cite studies when relevant
 (Schoenfeld, Helms, Israetel). Do not make up data that is not in the payload.
 

--- a/lib/stats.test.ts
+++ b/lib/stats.test.ts
@@ -3,6 +3,7 @@ import {
   applyBodyweight,
   best1RM,
   classifyWeeklySets,
+  dailyConditioning,
   effectiveWeight,
   estimate1RM,
   exerciseProgress,
@@ -577,5 +578,59 @@ describe('weeklyConditioning (issue #135)', () => {
       { windowWeeks: 4, now: NOW },
     );
     expect(points.every((p) => p.minutes === 0)).toBe(true);
+  });
+});
+
+describe('dailyConditioning (issue #153)', () => {
+  const NOW = new Date('2026-06-11T10:00:00Z'); // Thursday, ISO week 2026-W24 (Mon 06-08)
+  const run = (over: Record<string, unknown> = {}) => ({
+    durationSec: 1800,
+    distanceM: 5000,
+    isWarmup: false,
+    sessionStartedAt: new Date('2026-06-09T07:00:00Z'), // Tuesday of the current week
+    ...over,
+  });
+
+  it('returns an empty array for a zero-cardio week (days omitted, not zero-filled)', () => {
+    expect(dailyConditioning([], { now: NOW })).toEqual([]);
+    // A strength-only set is not cardio: still empty.
+    expect(dailyConditioning([run({ durationSec: null })], { now: NOW })).toEqual([]);
+  });
+
+  it('aggregates minutes and km per UTC calendar day, ascending', () => {
+    const days = dailyConditioning(
+      [
+        run({ sessionStartedAt: new Date('2026-06-10T18:00:00Z'), durationSec: 600, distanceM: null }),
+        run(), // Tuesday 30 min / 5 km
+        run({ sessionStartedAt: new Date('2026-06-09T18:30:00Z'), durationSec: 900, distanceM: 2500 }),
+      ],
+      { now: NOW },
+    );
+    expect(days).toEqual([
+      { date: '2026-06-09', minutes: 45, km: 7.5 },
+      { date: '2026-06-10', minutes: 10, km: 0 },
+    ]);
+  });
+
+  it('only covers the current ISO week and ignores warmup or non-cardio sets', () => {
+    const days = dailyConditioning(
+      [
+        run(),
+        run({ sessionStartedAt: new Date('2026-06-07T07:00:00Z') }), // Sunday of the prior week
+        run({ sessionStartedAt: new Date('2026-06-15T07:00:00Z') }), // Monday of the next week
+        run({ isWarmup: true, sessionStartedAt: new Date('2026-06-12T07:00:00Z') }),
+        run({ durationSec: null, sessionStartedAt: new Date('2026-06-12T07:00:00Z') }),
+      ],
+      { now: NOW },
+    );
+    expect(days).toEqual([{ date: '2026-06-09', minutes: 30, km: 5 }]);
+  });
+
+  it('includes the Monday boundary of the current week', () => {
+    const days = dailyConditioning(
+      [run({ sessionStartedAt: new Date('2026-06-08T00:00:00Z'), durationSec: 1200, distanceM: null })],
+      { now: NOW },
+    );
+    expect(days).toEqual([{ date: '2026-06-08', minutes: 20, km: 0 }]);
   });
 });

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -396,6 +396,56 @@ export function weeklyConditioning(
   return points;
 }
 
+export interface ConditioningDayPoint {
+  date: string; // YYYY-MM-DD, UTC calendar day
+  minutes: number; // total cardio duration that day, rounded to whole minutes
+  km: number; // total distance that day, km with 2 decimals (0 when none)
+}
+
+// Pure DAILY aggregation of cardio sets over the current ISO week (issue
+// #153): the interference signal for the coach - WHEN the cardio happened,
+// not just how much. Same rules as weeklyConditioning (non-warmup cardio
+// sets only; non-cardio sets ignored defensively), bucketed by UTC calendar
+// day of the session start. Days without cardio are OMITTED rather than
+// zero-filled: the payload stays compact (a zero-cardio week is an empty
+// array) and the dates make gaps unambiguous to the model.
+export function dailyConditioning(
+  sets: {
+    durationSec?: number | null;
+    distanceM?: number | null;
+    isWarmup: boolean;
+    sessionStartedAt: Date;
+  }[],
+  options: { now?: Date } = {},
+): ConditioningDayPoint[] {
+  const now = options.now ?? new Date();
+  const weekStart = isoWeekStart(now);
+  const weekEnd = new Date(weekStart);
+  weekEnd.setUTCDate(weekEnd.getUTCDate() + 7);
+
+  const byDay = new Map<string, { seconds: number; meters: number }>();
+  for (const s of sets) {
+    if (s.isWarmup || !isCardioSet(s)) continue;
+    if (s.sessionStartedAt < weekStart || s.sessionStartedAt >= weekEnd) continue;
+    const day = s.sessionStartedAt.toISOString().slice(0, 10);
+    let bucket = byDay.get(day);
+    if (!bucket) {
+      bucket = { seconds: 0, meters: 0 };
+      byDay.set(day, bucket);
+    }
+    bucket.seconds += s.durationSec ?? 0;
+    bucket.meters += s.distanceM ?? 0;
+  }
+
+  return [...byDay.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, bucket]) => ({
+      date,
+      minutes: Math.round(bucket.seconds / 60),
+      km: +(bucket.meters / 1000).toFixed(2),
+    }));
+}
+
 // ============================================================
 // Training consistency (per-week trained days + current streak)
 // ============================================================

--- a/tests/integration/core.test.ts
+++ b/tests/integration/core.test.ts
@@ -291,6 +291,27 @@ describe('buildCoachPayload conditioning (issue #145)', () => {
       sessions: 1,
     });
     expect(payload.conditioning.weeklyTargetMin).toBe(150);
+    // Per-day breakdown (issue #153): both current-week sessions started on
+    // the same UTC day; the previous-week session is outside the window.
+    expect(payload.conditioning.days).toEqual([
+      { date: inCurrentWeek.toISOString().slice(0, 10), minutes: 40, km: 5 },
+    ]);
+  });
+
+  it('splits the current week per day for the interference signal (issue #153)', async () => {
+    const { user, run } = await makeCardioUser('conditioning-days@test.dev');
+    const weekStart = isoWeekStart(new Date());
+    const monday = new Date(weekStart.getTime() + 60 * 60 * 1000);
+    const tuesday = new Date(weekStart.getTime() + 24 * 60 * 60 * 1000 + 60 * 60 * 1000);
+
+    await cardioSession(user.id, run.id, monday, [{ durationSec: 1800, distanceM: 5000 }]);
+    await cardioSession(user.id, run.id, tuesday, [{ durationSec: 600 }]);
+
+    const payload = await buildCoachPayload(user.id);
+    expect(payload.conditioning.days).toEqual([
+      { date: monday.toISOString().slice(0, 10), minutes: 30, km: 5 },
+      { date: tuesday.toISOString().slice(0, 10), minutes: 10, km: 0 },
+    ]);
   });
 
   it('yields zeros (not nulls or crashes) for a zero-cardio user', async () => {
@@ -307,6 +328,8 @@ describe('buildCoachPayload conditioning (issue #145)', () => {
     expect(payload.conditioning.weekCurrent).toEqual({ minutes: 0, km: 0, sessions: 0 });
     expect(payload.conditioning.weekPrevious).toBeNull();
     expect(payload.conditioning.weeklyTargetMin).toBe(150);
+    // Zero-cardio week: days is an empty array, never null (issue #153).
+    expect(payload.conditioning.days).toEqual([]);
   });
 
   it("does not count another user's cardio", async () => {
@@ -321,6 +344,7 @@ describe('buildCoachPayload conditioning (issue #145)', () => {
     const payload = await buildCoachPayload(userA.id);
     expect(payload.conditioning.weekCurrent).toEqual({ minutes: 0, km: 0, sessions: 0 });
     expect(payload.conditioning.weekPrevious).toBeNull();
+    expect(payload.conditioning.days).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

Interference awareness for hybrid lifters (issue #153): the coach already receives weekly conditioning aggregates (#149) but could not see WHEN the cardio happened, so it could not flag a long run the day before heavy squats.

- `conditioning.days` (current ISO week, `{ date, minutes, km }`) computed via a new shared `dailyConditioning` derivation in lib/stats.ts - a daily variant of `weeklyConditioning` with the same warmup/cardio rules, over the already-fetched recent sets (no extra query, no per-set dump). Decision documented in code: days without cardio are OMITTED (more compact than zero-filling; a zero-cardio week is an empty array and the dates make gaps unambiguous).
- Input-side prompt guidance in lib/prompts/coach-system-prompt.ts: read `conditioning.days` against the dated strength sessions, flag hard cardio adjacent to heavy lower-body days, suggest sequencing and explain WHY; cardio scheduling stays in prose - the `<adjustments>` output contract is unchanged.
- Demo provider: one interference-aware line in the canned debrief so the no-key flow exercises it.

## Reinforced controls (complex-feature directive)

- The diff is purely additive (191 insertions, 0 deletions). The existing adjustments contract tests (lib/coach-adjustments.test.ts and the demo contract assertions) are UNMODIFIED and pass.
- Zero-cardio safe: pinned by unit + integration tests (`days` is `[]`, never null).
- Cross-user isolation pinned in the integration test.
- The only touched existing test file fixtures gained the new `days` field for type compliance (lib/coach-context.test.ts from #156); no assertion was weakened.

Closes #153

## How I tested

- `bash scripts/verify.sh --full` - GREEN-GATE PASSED (lint, typecheck, unit, build, integration on :5434, 9/9 E2E).
- New unit tests: lib/stats.test.ts `dailyConditioning` (empty week, per-day aggregation ascending, ISO-week boundaries incl. Monday 00:00, warmup/non-cardio ignored).
- New integration tests: tests/integration/core.test.ts pin `conditioning.days` (same-day aggregation, multi-day split, zero-cardio empty, cross-user isolation).
- New prompt + demo provider tests pin the interference guidance and that the canned debrief still ends with the unchanged `</adjustments>` contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)