### PR TITLE
fix: make the coach-context footer claim truthful about per-set data

### DIFF
--- a/components/coach/coach-context-card.test.tsx
+++ b/components/coach/coach-context-card.test.tsx
@@ -81,7 +81,7 @@ describe('CoachContextCard', () => {
       screen.getByText(/Last check-in 2 days ago: readiness 4\/5, sleep 3\/5\./),
     ).toBeInTheDocument();
     expect(
-      screen.getByText('This structured summary - never your raw rows - is what the AI receives.'),
+      screen.getByText('A compact summary like this, plus your recent set-by-set training logs, is what the AI receives - never your account data or anything outside your training history.'),
     ).toBeInTheDocument();
   });
 

--- a/components/coach/coach-context-card.tsx
+++ b/components/coach/coach-context-card.tsx
@@ -130,7 +130,7 @@ export function CoachContextCard({ summary }: Props) {
           </Section>
 
           <p className="border-t pt-3 text-xs text-muted-foreground">
-            This structured summary - never your raw rows - is what the AI receives.
+            A compact summary like this, plus your recent set-by-set training logs, is what the AI receives - never your account data or anything outside your training history.
           </p>
         </CardContent>
       )}


### PR DESCRIPTION
Closes #159 (the one REAL finding across the three independent reviews of batch 7).

The footer claim is now accurate: the AI receives the compact summary PLUS recent set-by-set logs - never account data or anything outside training history. Component test updated to pin the truthful wording.

bash scripts/verify.sh - GREEN-GATE PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)