### PR TITLE
chore: harden the TCX importer per the security review nits

### DIFF
--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -6,6 +6,35 @@ by the charter in [`07-autonomy.md`](07-autonomy.md).
 
 ---
 
+## 2026-06-12 (night) - TCX hardening nits land (#161); triage follows
+
+**Context.** Maintainer tick. One implementation item: issue #161 (the advisory nits the
+hostile security review of #158 suggested for the TCX importer). Author JulienAu,
+trust-gated (login allowlist + collaborator check HTTP 204). Additive, no migration.
+
+**Decided / shipped.**
+- PR closing #161: lib/import/tcx.ts now strips XML comments before any scanning (indexOf
+  single pass; an unterminated comment drops the rest, like a real parser), so a
+  comment-smuggled <Activity> is never seen and a commented-out DTD is correctly treated
+  as inert and accepted. The advisory DTD reject is tightened: after comment stripping,
+  any "<!" not followed by a letter (null-byte-split <!DOCTYPE, <![CDATA[, bare <!>) is
+  rejected as a malformed markup declaration. startedAt is clamped to 2000-01-01 .. now +
+  1 day (small clock skew tolerated). New fixtures lock every verified behavior in:
+  comment smuggling, commented DTD, unterminated comment, null-byte-split DOCTYPE,
+  CDATA, exponent/hex/Infinity/NaN numerics (notation cannot bypass the bounds), the
+  clamp boundaries, and a route-level re-confirm inside the duplicate window creating a
+  deliberate second session while reusing the exercise.
+- Full local gate (verify.sh --full) before the PR; merged on green CI.
+
+**Challenged.** No subagent-spawning tool available in this tick: per the charter's
+no-self-certification backstop, the PR merged on green full CI and is flagged for an
+independent POST-MERGE review (security lens - it touches the untrusted-XML parser).
+
+**Deferred to human.** Nothing. Triage ran after the merge; its outcome is in the run
+report (and amended here by a docs PR if it filed issues).
+
+---
+
 ## 2026-06-12 (evening) - Seventh batch: research-grounded; one trust fix; UTC helpers settled
 
 **Context.** The operator funded a deeper research pass this cycle (~26 searches, Opus).

--- a/lib/import/tcx.test.ts
+++ b/lib/import/tcx.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseTcx, tcxExerciseName, TCX_MAX_BYTES } from './tcx';
+import { parseTcx, tcxExerciseName, TCX_MAX_BYTES, TCX_MIN_STARTED_AT } from './tcx';
 
 // ============================================================
 // Happy-path fixtures
@@ -240,6 +240,77 @@ describe('parseTcx (hostile input)', () => {
     expect(parseTcx('not xml at all').ok).toBe(false);
   });
 
+  it('ignores an <Activity> smuggled inside an XML comment', () => {
+    // A real XML parser never sees commented-out markup; neither do we.
+    const res = parseTcx(
+      minimalTcx(
+        `<!-- <Activity Sport="Biking"><Id>2026-06-01T05:00:00Z</Id>` +
+          `<Lap><TotalTimeSeconds>9999</TotalTimeSeconds>` +
+          `<DistanceMeters>999999</DistanceMeters></Lap></Activity> -->` +
+          `<Activity Sport="Running"><Id>2026-06-08T07:00:00Z</Id>` +
+          `<Lap><TotalTimeSeconds>60</TotalTimeSeconds></Lap></Activity>`,
+      ),
+    );
+    expect(res.ok).toBe(true);
+    expect(res.activity).toMatchObject({
+      startedAt: new Date('2026-06-08T07:00:00Z'),
+      durationSec: 60,
+      distanceM: null,
+      sport: 'Running',
+    });
+  });
+
+  it('accepts a file whose DTD is commented out (inert by construction)', () => {
+    // Comments are stripped first, so a commented DOCTYPE is simply absent -
+    // exactly what a real XML parser would conclude.
+    const res = parseTcx(
+      `<?xml version="1.0"?><!-- <!DOCTYPE TrainingCenterDatabase SYSTEM "http://evil.example/x.dtd"> -->` +
+        minimalTcx(
+          `<Activity Sport="Running"><Id>2026-06-08T07:00:00Z</Id>` +
+            `<Lap><TotalTimeSeconds>60</TotalTimeSeconds></Lap></Activity>`,
+        ),
+    );
+    expect(res.ok).toBe(true);
+    expect(res.activity?.durationSec).toBe(60);
+  });
+
+  it('drops everything after an unterminated comment instead of scanning it', () => {
+    const res = parseTcx(
+      minimalTcx(
+        `<!-- never closed <Activity Sport="Running"><Id>2026-06-08T07:00:00Z</Id>` +
+          `<Lap><TotalTimeSeconds>60</TotalTimeSeconds></Lap></Activity>`,
+      ),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toMatch(/No activity found/);
+  });
+
+  it('rejects a null-byte-split <!DOCTYPE as a malformed markup declaration', () => {
+    // "<!" + NUL + "DOCTYPE" dodges the plain substring check but is not
+    // well-formed XML; the tightened "<!" scan rejects it outright, proving
+    // it can never smuggle a DTD past the gate.
+    const res = parseTcx(
+      `<?xml version="1.0"?><!\u0000DOCTYPE foo [<!\u0000ENTITY xxe SYSTEM "file:///etc/passwd">]>` +
+        minimalTcx(
+          `<Activity Sport="Running"><Id>2026-06-08T07:00:00Z</Id>` +
+            `<Lap><TotalTimeSeconds>60</TotalTimeSeconds></Lap></Activity>`,
+        ),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toMatch(/malformed markup declaration/);
+  });
+
+  it('rejects CDATA sections (no real TCX export emits them)', () => {
+    const res = parseTcx(
+      minimalTcx(
+        `<Activity Sport="Running"><Id>2026-06-08T07:00:00Z</Id>` +
+          `<Lap><TotalTimeSeconds><![CDATA[60]]></TotalTimeSeconds></Lap></Activity>`,
+      ),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toMatch(/malformed markup declaration/);
+  });
+
   it('rejects an activity with no usable start time', () => {
     const res = parseTcx(
       minimalTcx(
@@ -290,6 +361,98 @@ describe('parseTcx (bounds)', () => {
     );
     expect(res.ok).toBe(true);
     expect(res.activity?.avgHr).toBeNull();
+  });
+
+  // Number() accepts exponent and hex notation; lock in that both stay
+  // inside the same bounds as plain decimals (no notation slips past them).
+  it('accepts exponent notation but still enforces the bounds', () => {
+    const ok = parseTcx(
+      minimalTcx(
+        `<Activity Sport="Running"><Id>2026-06-08T07:00:00Z</Id>` +
+          `<Lap><TotalTimeSeconds>1.8e3</TotalTimeSeconds></Lap></Activity>`,
+      ),
+    );
+    expect(ok.ok).toBe(true);
+    expect(ok.activity?.durationSec).toBe(1800);
+
+    const overflow = parseTcx(
+      minimalTcx(
+        `<Activity Sport="Running"><Id>2026-06-08T07:00:00Z</Id>` +
+          `<Lap><TotalTimeSeconds>9e99</TotalTimeSeconds></Lap></Activity>`,
+      ),
+    );
+    expect(overflow.ok).toBe(false);
+    expect(overflow.fatalError).toMatch(/out of bounds/);
+  });
+
+  it('accepts hex notation as its numeric value, bounds still applied', () => {
+    // Number('0x3C') is 60; an absurd hex duration still hits the 24 h cap.
+    const ok = parseTcx(
+      minimalTcx(
+        `<Activity Sport="Running"><Id>2026-06-08T07:00:00Z</Id>` +
+          `<Lap><TotalTimeSeconds>0x3C</TotalTimeSeconds></Lap></Activity>`,
+      ),
+    );
+    expect(ok.ok).toBe(true);
+    expect(ok.activity?.durationSec).toBe(60);
+
+    const overflow = parseTcx(
+      minimalTcx(
+        `<Activity Sport="Running"><Id>2026-06-08T07:00:00Z</Id>` +
+          `<Lap><TotalTimeSeconds>0xFFFFFFFF</TotalTimeSeconds></Lap></Activity>`,
+      ),
+    );
+    expect(overflow.ok).toBe(false);
+    expect(overflow.fatalError).toMatch(/out of bounds/);
+  });
+
+  it('treats Infinity and NaN text as garbage laps', () => {
+    const res = parseTcx(
+      minimalTcx(
+        `<Activity Sport="Running"><Id>2026-06-08T07:00:00Z</Id>` +
+          `<Lap><TotalTimeSeconds>Infinity</TotalTimeSeconds></Lap>` +
+          `<Lap><TotalTimeSeconds>NaN</TotalTimeSeconds></Lap>` +
+          `<Lap><TotalTimeSeconds>60</TotalTimeSeconds></Lap></Activity>`,
+      ),
+    );
+    expect(res.ok).toBe(true);
+    expect(res.activity?.durationSec).toBe(60);
+  });
+});
+
+// ============================================================
+// Start-time clamp (issue #161): 2000-01-01 .. now + 1 day
+// ============================================================
+
+describe('parseTcx (startedAt clamp)', () => {
+  const lapWith = (id: string) =>
+    minimalTcx(
+      `<Activity Sport="Running"><Id>${id}</Id>` +
+        `<Lap><TotalTimeSeconds>60</TotalTimeSeconds></Lap></Activity>`,
+    );
+
+  it('rejects a start before 2000-01-01', () => {
+    const res = parseTcx(lapWith('1999-12-31T23:59:59Z'));
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toMatch(/start time out of range/);
+  });
+
+  it('rejects an extreme past and an extreme future start', () => {
+    expect(parseTcx(lapWith('1970-01-01T00:00:00Z')).ok).toBe(false);
+    expect(parseTcx(lapWith('9999-01-01T00:00:00Z')).ok).toBe(false);
+  });
+
+  it('accepts the 2000-01-01 boundary and a slightly future start (clock skew)', () => {
+    expect(parseTcx(lapWith(TCX_MIN_STARTED_AT.toISOString())).ok).toBe(true);
+    const soon = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    expect(parseTcx(lapWith(soon)).ok).toBe(true);
+  });
+
+  it('rejects a start more than a day in the future', () => {
+    const farFuture = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString();
+    const res = parseTcx(lapWith(farFuture));
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toMatch(/start time out of range/);
   });
 });
 

--- a/lib/import/tcx.ts
+++ b/lib/import/tcx.ts
@@ -18,8 +18,18 @@ import { IMPORT_CSV_MAX_BYTES } from '@/lib/import/csv';
 //   - NO entity resolution exists: there is no entity table and no decoding
 //     of any "&...;" sequence, so internal entities cannot expand (billion
 //     laughs) and external entities cannot be fetched (XXE).
+//   - XML comments are stripped before any scanning, so content smuggled
+//     inside "<!-- -->" (e.g. a fake <Activity>) is never seen - matching
+//     what a real XML parser would do. A DTD inside a comment is inert and
+//     therefore accepted after stripping.
 //   - Any document containing "<!DOCTYPE" or "<!ENTITY" is rejected outright
-//     before extraction, so a DTD is never even scanned past.
+//     before extraction, so a DTD is never even scanned past. After comments
+//     are stripped, any remaining "<!" not followed by a letter (a null-byte-
+//     split "<!\0DOCTYPE", "<![CDATA[", a bare "<!>") is rejected as a
+//     malformed markup declaration - none of these appear in a real export.
+//   - The activity start time is clamped to a sane window (2000-01-01 to
+//     now + 1 day), so an extreme or hostile timestamp cannot land a session
+//     in year 0 or 9999.
 //   - All scans are indexOf-based (no regex over attacker-sized input), so a
 //     huge attribute or a truncated tag cannot trigger pathological
 //     backtracking; unterminated structures simply stop matching.
@@ -65,6 +75,11 @@ const activitySchema = z.object({
 // Longest value we ever need (an ISO timestamp); anything longer is hostile
 // or garbage and is treated as absent.
 const MAX_VALUE_CHARS = 64;
+
+// Sane window for the activity start: nothing before consumer GPS watches
+// existed, nothing further out than tomorrow (small clock skew is fine).
+export const TCX_MIN_STARTED_AT = new Date('2000-01-01T00:00:00.000Z');
+const STARTED_AT_FUTURE_SLACK_MS = 24 * 60 * 60 * 1000;
 
 // ------------------------------------------------------------
 // indexOf-based tag helpers. They handle the narrow, non-nested TCX layout
@@ -165,6 +180,25 @@ function stripBlocks(xml: string, tag: string): string {
   }
 }
 
+// Removes every "<!-- ... -->" comment, single pass, indexOf-based. An
+// unterminated comment drops the rest of the document, exactly like a real
+// XML parser refusing to see past it.
+function stripComments(xml: string): string {
+  const open = '<!--';
+  const close = '-->';
+  if (!xml.includes(open)) return xml;
+  let out = '';
+  let from = 0;
+  for (;;) {
+    const at = xml.indexOf(open, from);
+    if (at === -1) return out + xml.slice(from);
+    out += xml.slice(from, at);
+    const end = xml.indexOf(close, at + open.length);
+    if (end === -1) return out; // unterminated comment: drop the rest
+    from = end + close.length;
+  }
+}
+
 function asFiniteNumber(text: string | null): number | null {
   if (text === null) return null;
   const n = Number(text);
@@ -180,16 +214,37 @@ function asFiniteNumber(text: string | null): number | null {
 const MAX_ACTIVITIES = 20;
 const MAX_LAPS = 1000;
 
-export function parseTcx(xml: string): TcxParseResult {
-  if (xml.length > TCX_MAX_BYTES) {
+export function parseTcx(input: string): TcxParseResult {
+  if (input.length > TCX_MAX_BYTES) {
     return fatal('File too large: the limit is 5 MB.');
   }
+
+  // Strip comments BEFORE any scanning so commented-out markup (a smuggled
+  // <Activity>, an inert commented DTD) is never seen, matching a real XML
+  // parser's view of the document.
+  const xml = stripComments(input);
 
   // Reject any DTD or entity declaration outright (XXE / billion-laughs by
   // construction cannot happen: we also never decode entities anywhere).
   const upper = xml.toUpperCase();
   if (upper.includes('<!DOCTYPE') || upper.includes('<!ENTITY')) {
     return fatal('Invalid TCX file: DTD and entity declarations are not allowed.');
+  }
+
+  // With comments already stripped, every remaining "<!" must open a normal
+  // markup declaration (a letter follows). Anything else - "<!\0DOCTYPE",
+  // "<![CDATA[", "<!>" - is malformed or evasive and no real export emits it.
+  {
+    let bang = xml.indexOf('<!');
+    while (bang !== -1) {
+      const next = xml[bang + 2];
+      const isLetter =
+        next !== undefined && ((next >= 'a' && next <= 'z') || (next >= 'A' && next <= 'Z'));
+      if (!isLetter) {
+        return fatal('Invalid TCX file: malformed markup declaration.');
+      }
+      bang = xml.indexOf('<!', bang + 2);
+    }
   }
 
   if (!xml.includes('<TrainingCenterDatabase')) {
@@ -280,6 +335,12 @@ export function parseTcx(xml: string): TcxParseResult {
   }
   if (!earliestStart) {
     return fatal('No activity start time found (missing or invalid Id / Lap StartTime).');
+  }
+  if (
+    earliestStart < TCX_MIN_STARTED_AT ||
+    earliestStart.getTime() > Date.now() + STARTED_AT_FUTURE_SLACK_MS
+  ) {
+    return fatal('Activity start time out of range: it must be between 2000-01-01 and tomorrow.');
   }
 
   const durationSec = Math.round(totalSeconds);

--- a/tests/integration/tcx-import-route.test.ts
+++ b/tests/integration/tcx-import-route.test.ts
@@ -180,6 +180,29 @@ describe('POST /api/import/tcx (confirm)', () => {
     expect(set?.exerciseId).toBe(own?.id);
   });
 
+  it('re-confirming inside the duplicate window still creates a second session (re-import on purpose)', async () => {
+    const user = await seedUser('tcx-reconfirm@test.dev');
+    actAs(user.id);
+
+    const first = await postImport(importReq({ xml: RUN_TCX, mode: 'confirm' }));
+    expect(first.status).toBe(200);
+
+    // The preview now warns about the just-imported session...
+    const preview = await postImport(importReq({ xml: RUN_TCX, mode: 'preview' }));
+    expect((await preview.json()).duplicateSessions).toEqual(['2026-05-20T07:30:00.000Z']);
+
+    // ...but confirm is never blocked by the warning: deliberate re-import works.
+    const second = await postImport(importReq({ xml: RUN_TCX, mode: 'confirm' }));
+    expect(second.status).toBe(200);
+    const body = await second.json();
+    expect(body.createdSessions).toBe(1);
+    expect(body.duplicateSessions).toEqual(['2026-05-20T07:30:00.000Z']);
+
+    expect(await db.session.count({ where: { userId: user.id } })).toBe(2);
+    // The exercise is reused, not duplicated.
+    expect(await db.exercise.count({ where: { userId: user.id, name: 'Running' } })).toBe(1);
+  });
+
   it('refuses to write cardio onto a non-cardio exercise with the default name', async () => {
     const user = await seedUser('tcx-conflict@test.dev');
     actAs(user.id);


### PR DESCRIPTION
Implements the advisory nits from the hostile security review of #158 (the TCX importer), exactly as scoped in the issue. Additive, no migration; touches lib/import/tcx.ts and its tests (unit + one route-level integration fixture).

## What changed

- **XML comments are stripped before any scanning** (single-pass, indexOf-based; an unterminated comment drops the rest of the document). A comment-smuggled `<Activity>` is never seen, and a commented-out DTD is correctly treated as inert and accepted - matching what a real XML parser would conclude.
- **Tightened advisory DTD reject**: after comment stripping, any `<!` not followed by a letter (a null-byte-split `<!DOCTYPE`, `<![CDATA[`, a bare `<!>`) is rejected as a malformed markup declaration. The existing `<!DOCTYPE` / `<!ENTITY` substring rejects are unchanged.
- **startedAt clamped to a sane window**: 2000-01-01 .. now + 1 day (small clock skew tolerated), with a clear fatal message.
- **New fixtures lock the verified behaviors in** (assertions on rejection/inertness, not just no-crash): comment-smuggled activity, commented DTD, unterminated comment, null-byte-split DOCTYPE, CDATA, exponent/hex/Infinity/NaN numeric notation (none can bypass the bounds), clamp boundaries (1970 / 1999 / 2000-01-01 / +1h / +3d / 9999), and a route-level re-confirm inside the duplicate window that deliberately creates a second session while reusing the exercise.
- Autonomy-log entry for this run rides along in docs/loops/autonomy-log.md.

## How I tested

- `bash scripts/verify.sh --full` PASSED locally before this PR: prisma generate + lint + typecheck + unit (33 TCX parser tests) + build + integration (118 passed, incl. the new re-confirm fixture) + E2E (10 passed).

## Review note

No subagent-spawning tool is available in this tick: per the charter's no-self-certification backstop this PR merges only on green full CI and is explicitly flagged for an independent POST-MERGE review with a security lens (it touches the untrusted-XML parser).

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)