### PR TITLE
docs: amend the 2026-06-12 night run entry with the triage outcome

### DIFF
--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -24,14 +24,24 @@ trust-gated (login allowlist + collaborator check HTTP 204). Additive, no migrat
   CDATA, exponent/hex/Infinity/NaN numerics (notation cannot bypass the bounds), the
   clamp boundaries, and a route-level re-confirm inside the duplicate window creating a
   deliberate second session while reusing the exercise.
-- Full local gate (verify.sh --full) before the PR; merged on green CI.
+- Full local gate (verify.sh --full) before the PR; PR #167 merged on green 5-check CI.
 
 **Challenged.** No subagent-spawning tool available in this tick: per the charter's
 no-self-certification backstop, the PR merged on green full CI and is flagged for an
 independent POST-MERGE review (security lens - it touches the untrusted-XML parser).
 
-**Deferred to human.** Nothing. Triage ran after the merge; its outcome is in the run
-report (and amended here by a docs PR if it filed issues).
+**Deferred to human.** Triage ran after the merge (this amendment rides in a docs PR):
+- Filed #168: the backup export/restore route silently drops everything added since it
+  shipped (Set.durationSec/distanceM/avgHr, ProgramExercise.supersetGroup, and the
+  ExerciseGoal / BodyweightEntry / ReadinessCheckin models) and has zero integration
+  coverage - the L8 silent-data-loss class on the one route meant to prevent it.
+- Filed #169 (STOP-FOR-HUMAN): npm audit reports 6 high / 1 moderate advisories, all
+  fixable only by major bumps - next 14.2.35 needs >=15.5.16 for its runtime advisories;
+  the eslint-config-next/glob and next-pwa/workbox chains are dev/build-time. Per the
+  charter the loop must not auto-implement this; the issue records the decision needed.
+- Not due / nothing to file: gate spot-check (last run 2026-06-11); permissions re-audit
+  (hardened 2026-06-09; deny list re-read this run and intact - rm -rf, force-push
+  variants, reset --hard, curl, wget all still denied; no allow-list scope creep found).
 
 ---
 


### PR DESCRIPTION
Tiny docs PR completing the run journal for tonight's maintainer tick, as promised in the entry that rode in #167:

- Records the two triage issues filed after the #167 merge: #168 (backup export/restore silently drops post-LOT-11 data, zero coverage) and #169 (npm audit high advisories on next 14.2.35, stop-for-human major bumps).
- Records the not-due checks: gate spot-check (last 2026-06-11) and permissions re-audit (deny list re-read and intact, no scope creep).

## How I tested

- bash scripts/verify.sh PASSED (docs-only change; one transient unit-tier flake on the first run, green twice on re-run with no diff change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)