### PR TITLE
fix: make the backup export/restore cover every user-owned model and field

### DIFF
--- a/app/api/backup/route.ts
+++ b/app/api/backup/route.ts
@@ -1,30 +1,90 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
+import {
+  ExerciseCategory,
+  MessageRole,
+  MuscleGroup,
+  Sex,
+  TrainingGoal,
+  WeightUnit,
+} from '@prisma/client';
 import { db } from '@/lib/db';
 import { ApiError, handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
+import { AVG_HR_MAX, AVG_HR_MIN, MAX_DISTANCE_M, MAX_DURATION_SEC } from '@/lib/cardio';
+import { MAX_SUPERSET_GROUP, MIN_SUPERSET_GROUP } from '@/lib/supersets';
+import { sorenessSchema } from '@/lib/schemas/readiness';
 
 // ============================================================
-// Backup / Import JSON (LOT 11)
+// Backup / Import JSON (LOT 11, completed by issue #168)
 // ============================================================
-// The export covers all entities tied to the user (programs, workouts,
-// exercises, sessions, sets, coach sessions). The import recreates the content
-// for the current user by replacing the cuid ids with new ones, so it does not
-// break uniqueness constraints or pollute another user.
+// The export covers every entity tied to the user; the import recreates the
+// content for the current user with fresh cuid ids (relations are re-linked
+// by name), so it does not break uniqueness constraints or pollute another
+// user.
+//
+// Export inventory - systematic check against prisma/schema.prisma. When a
+// model or column is added to the schema, extend BOTH the export and the
+// import below, bump VERSION, and keep older versions importable.
+//
+// Exported models and fields:
+// - User: profile fields (displayName, bodyweight, sex, heightCm, goal,
+//   weeklyFrequency, unit, deloadUntil). email/createdAt ride along for
+//   reference but are NEVER imported (they identify the importing account).
+// - Exercise: name, muscleGroup, category, defaultRestSec, notes,
+//   usesBodyweight.
+// - Program / Workout / ProgramExercise: all user content incl supersetGroup.
+// - Session / Set: all user content incl durationSec, distanceM, avgHr.
+// - CoachSession, ExerciseGoal, BodyweightEntry, ReadinessCheckin,
+//   Conversation / Message: all user content.
+//
+// Intentionally excluded:
+// - User.id / email / passwordHash / createdAt (identity + credentials of the
+//   importing account; restoring them would hijack or corrupt the account).
+// - Every row id (regenerated on import; relations re-linked by name).
+// - Program.createdAt / Program.updatedAt and Exercise.createdAt (server-side
+//   bookkeeping with no user-facing meaning; reset to the import time).
 
-const VERSION = 1;
+const VERSION = 2;
+
+// Hard cap on the import body size, enforced while reading the stream (the
+// Content-Length header is attacker-controlled). Generous: a decade of daily
+// training exports to a few MB.
+const MAX_BACKUP_BYTES = 50 * 1024 * 1024;
 
 // GET /api/backup: returns an exportable JSON.
 export async function GET() {
   try {
     const userId = await requireApiUserId();
 
-    const [user, programs, exercises, sessions, coachSessions] = await Promise.all([
+    const [
+      user,
+      programs,
+      exercises,
+      sessions,
+      coachSessions,
+      exerciseGoals,
+      bodyweightEntries,
+      readinessCheckins,
+      conversations,
+    ] = await Promise.all([
       db.user.findUnique({
         where: { id: userId },
-        select: { email: true, createdAt: true },
+        select: {
+          email: true,
+          createdAt: true,
+          displayName: true,
+          bodyweight: true,
+          sex: true,
+          heightCm: true,
+          goal: true,
+          weeklyFrequency: true,
+          unit: true,
+          deloadUntil: true,
+        },
       }),
       db.program.findMany({
         where: { userId },
+        orderBy: { createdAt: 'asc' },
         include: {
           workouts: {
             orderBy: { order: 'asc' },
@@ -37,7 +97,7 @@ export async function GET() {
           },
         },
       }),
-      db.exercise.findMany({ where: { userId } }),
+      db.exercise.findMany({ where: { userId }, orderBy: { name: 'asc' } }),
       db.session.findMany({
         where: { userId },
         orderBy: { startedAt: 'asc' },
@@ -45,7 +105,25 @@ export async function GET() {
           sets: { orderBy: [{ exerciseId: 'asc' }, { setNumber: 'asc' }] },
         },
       }),
-      db.coachSession.findMany({ where: { userId } }),
+      db.coachSession.findMany({ where: { userId }, orderBy: { createdAt: 'asc' } }),
+      db.exerciseGoal.findMany({
+        where: { userId },
+        orderBy: { createdAt: 'asc' },
+        include: { exercise: { select: { name: true } } },
+      }),
+      db.bodyweightEntry.findMany({
+        where: { userId },
+        orderBy: { measuredAt: 'asc' },
+      }),
+      db.readinessCheckin.findMany({
+        where: { userId },
+        orderBy: { createdAt: 'asc' },
+      }),
+      db.conversation.findMany({
+        where: { userId },
+        orderBy: { createdAt: 'asc' },
+        include: { messages: { orderBy: { createdAt: 'asc' } } },
+      }),
     ]);
 
     if (!user) throw new ApiError(404, 'User not found.');
@@ -53,13 +131,25 @@ export async function GET() {
     const dump = {
       version: VERSION,
       exportedAt: new Date().toISOString(),
-      user,
+      user: { email: user.email, createdAt: user.createdAt },
+      // Profile fields restored onto the importing account (new in v2).
+      profile: {
+        displayName: user.displayName,
+        bodyweight: user.bodyweight,
+        sex: user.sex,
+        heightCm: user.heightCm,
+        goal: user.goal,
+        weeklyFrequency: user.weeklyFrequency,
+        unit: user.unit,
+        deloadUntil: user.deloadUntil?.toISOString() ?? null,
+      },
       exercises: exercises.map((e) => ({
         name: e.name,
         muscleGroup: e.muscleGroup,
         category: e.category,
         defaultRestSec: e.defaultRestSec,
         notes: e.notes,
+        usesBodyweight: e.usesBodyweight,
       })),
       programs: programs.map((p) => ({
         name: p.name,
@@ -82,12 +172,11 @@ export async function GET() {
             restSec: pe.restSec,
             tempo: pe.tempo,
             notes: pe.notes,
+            supersetGroup: pe.supersetGroup,
           })),
         })),
       })),
       sessions: sessions.map((s) => ({
-        // Local identifier used to link the sets, not exported as-is.
-        _localId: s.id,
         programName: programs.find((p) => p.id === s.programId)?.name ?? null,
         workoutName: programs
           .flatMap((p) => p.workouts)
@@ -101,6 +190,9 @@ export async function GET() {
           weight: set.weight,
           reps: set.reps,
           rir: set.rir,
+          durationSec: set.durationSec,
+          distanceM: set.distanceM,
+          avgHr: set.avgHr,
           notes: set.notes,
           isWarmup: set.isWarmup,
           isDropSet: set.isDropSet,
@@ -114,6 +206,35 @@ export async function GET() {
         response: c.response,
         appliedAt: c.appliedAt?.toISOString() ?? null,
         createdAt: c.createdAt.toISOString(),
+      })),
+      exerciseGoals: exerciseGoals.map((g) => ({
+        exerciseName: g.exercise.name,
+        targetWeight: g.targetWeight,
+        targetReps: g.targetReps,
+        createdAt: g.createdAt.toISOString(),
+        achievedAt: g.achievedAt?.toISOString() ?? null,
+      })),
+      bodyweightEntries: bodyweightEntries.map((b) => ({
+        weightKg: b.weightKg,
+        measuredAt: b.measuredAt.toISOString(),
+        note: b.note,
+      })),
+      readinessCheckins: readinessCheckins.map((r) => ({
+        readiness: r.readiness,
+        sleepQuality: r.sleepQuality,
+        soreness: r.soreness,
+        note: r.note,
+        createdAt: r.createdAt.toISOString(),
+      })),
+      conversations: conversations.map((c) => ({
+        title: c.title,
+        createdAt: c.createdAt.toISOString(),
+        updatedAt: c.updatedAt.toISOString(),
+        messages: c.messages.map((m) => ({
+          role: m.role,
+          content: m.content,
+          createdAt: m.createdAt.toISOString(),
+        })),
       })),
     };
 
@@ -132,81 +253,192 @@ export async function GET() {
 // ------------------------------------------------------------
 // Import
 // ------------------------------------------------------------
+// The payload is untrusted user input (an uploaded file): every value is
+// bounded, every date must parse, arrays are capped, and the whole body is
+// size-capped while being read. Version 1 files (pre-#168) stay importable:
+// every field/model added in v2 is optional and defaults to null/absent.
+
+// A date string that must actually parse (a legit export always writes ISO).
+const dateString = z
+  .string()
+  .max(40)
+  .refine((s) => !Number.isNaN(Date.parse(s)), { message: 'Invalid date' });
 
 const importSchema = z.object({
   version: z.number().int().min(1).max(VERSION),
-  exercises: z.array(
-    z.object({
-      name: z.string().trim().min(1).max(120),
-      muscleGroup: z.string(),
-      category: z.string(),
-      defaultRestSec: z.number().int().min(15).max(600),
-      notes: z.string().nullable().optional(),
-    }),
-  ),
-  programs: z.array(
-    z.object({
-      name: z.string().trim().min(1).max(200),
-      description: z.string().nullable().optional(),
-      phase: z.string(),
-      isActive: z.boolean(),
-      startDate: z.string(),
-      endDate: z.string().nullable().optional(),
-      workouts: z.array(
-        z.object({
-          name: z.string().trim().min(1).max(200),
-          dayOfWeek: z.number().int().min(1).max(7).nullable().optional(),
-          order: z.number().int(),
-          exercises: z.array(
+  exercises: z
+    .array(
+      z.object({
+        name: z.string().trim().min(1).max(120),
+        // A legit export only ever contains valid enum values; rejecting the
+        // rest here turns a Prisma 500 into a clean 400.
+        muscleGroup: z.nativeEnum(MuscleGroup),
+        category: z.nativeEnum(ExerciseCategory),
+        defaultRestSec: z.number().int().min(15).max(600),
+        notes: z.string().max(2000).nullable().optional(),
+        // v2; absent in v1 backups.
+        usesBodyweight: z.boolean().optional(),
+      }),
+    )
+    .max(2000),
+  programs: z
+    .array(
+      z.object({
+        name: z.string().trim().min(1).max(200),
+        description: z.string().max(5000).nullable().optional(),
+        phase: z.string().max(100),
+        isActive: z.boolean(),
+        startDate: dateString,
+        endDate: dateString.nullable().optional(),
+        workouts: z
+          .array(
             z.object({
-              exerciseName: z.string(),
-              order: z.number().int(),
-              targetSets: z.number().int().min(1).max(20),
-              targetRepsMin: z.number().int().min(1).max(50),
-              targetRepsMax: z.number().int().min(1).max(50),
-              targetRIR: z.number().int().min(0).max(5),
-              restSec: z.number().int().min(15).max(600),
-              tempo: z.string().nullable().optional(),
-              notes: z.string().nullable().optional(),
+              name: z.string().trim().min(1).max(200),
+              dayOfWeek: z.number().int().min(1).max(7).nullable().optional(),
+              order: z.number().int().min(0).max(1000),
+              exercises: z
+                .array(
+                  z.object({
+                    exerciseName: z.string().max(120),
+                    order: z.number().int().min(0).max(1000),
+                    targetSets: z.number().int().min(1).max(20),
+                    targetRepsMin: z.number().int().min(1).max(50),
+                    targetRepsMax: z.number().int().min(1).max(50),
+                    targetRIR: z.number().int().min(0).max(5),
+                    restSec: z.number().int().min(15).max(600),
+                    tempo: z.string().max(20).nullable().optional(),
+                    notes: z.string().max(2000).nullable().optional(),
+                    // v2; absent in v1 backups.
+                    supersetGroup: z
+                      .number()
+                      .int()
+                      .min(MIN_SUPERSET_GROUP)
+                      .max(MAX_SUPERSET_GROUP)
+                      .nullable()
+                      .optional(),
+                  }),
+                )
+                .max(200),
             }),
-          ),
-        }),
-      ),
-    }),
-  ),
-  sessions: z.array(
-    z.object({
-      programName: z.string().nullable().optional(),
-      workoutName: z.string().nullable().optional(),
-      startedAt: z.string(),
-      finishedAt: z.string().nullable().optional(),
-      notes: z.string().nullable().optional(),
-      sets: z.array(
-        z.object({
-          exerciseName: z.string().nullable(),
-          setNumber: z.number().int().min(1),
-          weight: z.number().min(0),
-          reps: z.number().int().min(0),
-          rir: z.number().int().nullable().optional(),
-          notes: z.string().nullable().optional(),
-          isWarmup: z.boolean(),
-          isDropSet: z.boolean(),
-          completedAt: z.string(),
-        }),
-      ),
-    }),
-  ),
+          )
+          .max(100),
+      }),
+    )
+    .max(200),
+  sessions: z
+    .array(
+      z.object({
+        programName: z.string().max(200).nullable().optional(),
+        workoutName: z.string().max(200).nullable().optional(),
+        startedAt: dateString,
+        finishedAt: dateString.nullable().optional(),
+        notes: z.string().max(5000).nullable().optional(),
+        sets: z
+          .array(
+            z.object({
+              exerciseName: z.string().max(120).nullable(),
+              setNumber: z.number().int().min(1).max(1000),
+              weight: z.number().min(0).max(5000),
+              reps: z.number().int().min(0).max(1000),
+              rir: z.number().int().min(0).max(10).nullable().optional(),
+              // v2 cardio fields; absent in v1 backups.
+              durationSec: z
+                .number()
+                .int()
+                .min(1)
+                .max(MAX_DURATION_SEC)
+                .nullable()
+                .optional(),
+              distanceM: z.number().min(0).max(MAX_DISTANCE_M).nullable().optional(),
+              avgHr: z.number().int().min(AVG_HR_MIN).max(AVG_HR_MAX).nullable().optional(),
+              notes: z.string().max(2000).nullable().optional(),
+              isWarmup: z.boolean(),
+              isDropSet: z.boolean(),
+              completedAt: dateString,
+            }),
+          )
+          .max(1000),
+      }),
+    )
+    .max(20000),
   coachSessions: z
     .array(
       z.object({
-        weekStart: z.string(),
-        weekEnd: z.string(),
-        prompt: z.string(),
-        response: z.string(),
-        appliedAt: z.string().nullable().optional(),
-        createdAt: z.string(),
+        weekStart: dateString,
+        weekEnd: dateString,
+        prompt: z.string().max(200_000),
+        response: z.string().max(200_000),
+        appliedAt: dateString.nullable().optional(),
+        createdAt: dateString,
       }),
     )
+    .max(5000)
+    .optional(),
+  // Everything below is new in v2 and absent from v1 backups.
+  profile: z
+    .object({
+      displayName: z.string().trim().min(1).max(80).nullable().optional(),
+      bodyweight: z.number().min(20).max(300).nullable().optional(),
+      sex: z.nativeEnum(Sex).nullable().optional(),
+      heightCm: z.number().int().min(100).max(250).nullable().optional(),
+      goal: z.nativeEnum(TrainingGoal).nullable().optional(),
+      weeklyFrequency: z.number().int().min(1).max(14).nullable().optional(),
+      unit: z.nativeEnum(WeightUnit).optional(),
+      deloadUntil: dateString.nullable().optional(),
+    })
+    .optional(),
+  exerciseGoals: z
+    .array(
+      z.object({
+        exerciseName: z.string().max(120),
+        targetWeight: z.number().positive().max(1000),
+        targetReps: z.number().int().min(1).max(100),
+        createdAt: dateString,
+        achievedAt: dateString.nullable().optional(),
+      }),
+    )
+    .max(2000)
+    .optional(),
+  bodyweightEntries: z
+    .array(
+      z.object({
+        weightKg: z.number().min(20).max(300),
+        measuredAt: dateString,
+        note: z.string().max(500).nullable().optional(),
+      }),
+    )
+    .max(20000)
+    .optional(),
+  readinessCheckins: z
+    .array(
+      z.object({
+        readiness: z.number().int().min(1).max(5),
+        sleepQuality: z.number().int().min(1).max(5),
+        soreness: sorenessSchema,
+        note: z.string().max(500).nullable().optional(),
+        createdAt: dateString,
+      }),
+    )
+    .max(20000)
+    .optional(),
+  conversations: z
+    .array(
+      z.object({
+        title: z.string().max(200).nullable().optional(),
+        createdAt: dateString,
+        updatedAt: dateString,
+        messages: z
+          .array(
+            z.object({
+              role: z.nativeEnum(MessageRole),
+              content: z.string().max(200_000),
+              createdAt: dateString,
+            }),
+          )
+          .max(2000),
+      }),
+    )
+    .max(2000)
     .optional(),
 });
 
@@ -217,43 +449,73 @@ const importBodySchema = z.object({
 });
 
 // POST /api/backup: clears the current user's data and recreates it from the
-// payload. Atomic: everything runs in a Prisma transaction.
+// payload. Atomic: everything runs in a Prisma transaction, so a failure
+// rolls back to the pre-import state.
 export async function POST(req: Request) {
   try {
     const userId = await requireApiUserId();
-    const { payload } = await parseJsonBody(req, importBodySchema);
+    const { payload } = await parseJsonBody(req, importBodySchema, {
+      maxBytes: MAX_BACKUP_BYTES,
+    });
 
     await db.$transaction(
       async (tx) => {
-        // 1. Purge the user's existing data (sets via cascade then sessions,
-        //    coach sessions, programs/workouts/program-exercises via cascade,
-        //    exercises).
+        // 1. Purge the user's existing data. Order matters where there is no
+        //    cascade: sets before sessions and exercises, goals before
+        //    exercises. Conversations cascade their messages; programs
+        //    cascade workouts and program exercises.
         await tx.set.deleteMany({ where: { session: { userId } } });
         await tx.session.deleteMany({ where: { userId } });
         await tx.coachSession.deleteMany({ where: { userId } });
+        await tx.exerciseGoal.deleteMany({ where: { userId } });
+        await tx.bodyweightEntry.deleteMany({ where: { userId } });
+        await tx.readinessCheckin.deleteMany({ where: { userId } });
+        await tx.conversation.deleteMany({ where: { userId } });
         // workouts/programExercises cascade via Program.
         await tx.program.deleteMany({ where: { userId } });
         await tx.exercise.deleteMany({ where: { userId } });
 
-        // 2. Recreate the exercises; we keep a name -> id index to link them.
+        // 2. Profile (v2): restore onto the current account. Identity fields
+        //    (email, password) are never touched.
+        if (payload.profile) {
+          const p = payload.profile;
+          await tx.user.update({
+            where: { id: userId },
+            data: {
+              ...(p.displayName !== undefined ? { displayName: p.displayName } : {}),
+              ...(p.bodyweight !== undefined ? { bodyweight: p.bodyweight } : {}),
+              ...(p.sex !== undefined ? { sex: p.sex } : {}),
+              ...(p.heightCm !== undefined ? { heightCm: p.heightCm } : {}),
+              ...(p.goal !== undefined ? { goal: p.goal } : {}),
+              ...(p.weeklyFrequency !== undefined
+                ? { weeklyFrequency: p.weeklyFrequency }
+                : {}),
+              ...(p.unit !== undefined ? { unit: p.unit } : {}),
+              ...(p.deloadUntil !== undefined
+                ? { deloadUntil: p.deloadUntil ? new Date(p.deloadUntil) : null }
+                : {}),
+            },
+          });
+        }
+
+        // 3. Recreate the exercises; we keep a name -> id index to link them.
         const exerciseIdByName = new Map<string, string>();
         for (const e of payload.exercises) {
           const created = await tx.exercise.create({
             data: {
               userId,
               name: e.name,
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              muscleGroup: e.muscleGroup as any,
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              category: e.category as any,
+              muscleGroup: e.muscleGroup,
+              category: e.category,
               defaultRestSec: e.defaultRestSec,
               notes: e.notes ?? null,
+              usesBodyweight: e.usesBodyweight ?? false,
             },
           });
           exerciseIdByName.set(e.name, created.id);
         }
 
-        // 3. Recreate programs / workouts / programExercises.
+        // 4. Recreate programs / workouts / programExercises.
         for (const p of payload.programs) {
           const program = await tx.program.create({
             data: {
@@ -290,13 +552,14 @@ export async function POST(req: Request) {
                   restSec: pe.restSec,
                   tempo: pe.tempo ?? null,
                   notes: pe.notes ?? null,
+                  supersetGroup: pe.supersetGroup ?? null,
                 },
               });
             }
           }
         }
 
-        // 4. Sessions + sets: we try to link to the program/workout by name,
+        // 5. Sessions + sets: we try to link to the program/workout by name,
         //    but accept leaving them nullable if not found.
         const programs = await tx.program.findMany({
           where: { userId },
@@ -319,26 +582,30 @@ export async function POST(req: Request) {
               notes: s.notes ?? null,
             },
           });
-          for (const set of s.sets) {
+          const setRows = s.sets.flatMap((set) => {
             const exId = set.exerciseName
               ? exerciseIdByName.get(set.exerciseName)
               : undefined;
-            if (!exId) continue;
-            await tx.set.create({
-              data: {
+            if (!exId) return [];
+            return [
+              {
                 sessionId: session.id,
                 exerciseId: exId,
                 setNumber: set.setNumber,
                 weight: set.weight,
                 reps: set.reps,
                 rir: set.rir ?? null,
+                durationSec: set.durationSec ?? null,
+                distanceM: set.distanceM ?? null,
+                avgHr: set.avgHr ?? null,
                 notes: set.notes ?? null,
                 isWarmup: set.isWarmup,
                 isDropSet: set.isDropSet,
                 completedAt: new Date(set.completedAt),
               },
-            });
-          }
+            ];
+          });
+          if (setRows.length > 0) await tx.set.createMany({ data: setRows });
         }
 
         for (const c of payload.coachSessions ?? []) {
@@ -354,8 +621,76 @@ export async function POST(req: Request) {
             },
           });
         }
+
+        // 6. Goals / bodyweight / readiness / conversations (v2). A goal
+        //    whose exercise is unknown is skipped, like sets above.
+        const goalRows = (payload.exerciseGoals ?? []).flatMap((g) => {
+          const exId = exerciseIdByName.get(g.exerciseName);
+          if (!exId) return [];
+          return [
+            {
+              userId,
+              exerciseId: exId,
+              targetWeight: g.targetWeight,
+              targetReps: g.targetReps,
+              createdAt: new Date(g.createdAt),
+              achievedAt: g.achievedAt ? new Date(g.achievedAt) : null,
+            },
+          ];
+        });
+        if (goalRows.length > 0) {
+          // One goal per (user, exercise): duplicates in the file would break
+          // the unique constraint, so keep the last one per exercise.
+          const lastPerExercise = new Map(goalRows.map((g) => [g.exerciseId, g]));
+          await tx.exerciseGoal.createMany({
+            data: Array.from(lastPerExercise.values()),
+          });
+        }
+
+        const bodyweightRows = (payload.bodyweightEntries ?? []).map((b) => ({
+          userId,
+          weightKg: b.weightKg,
+          measuredAt: new Date(b.measuredAt),
+          note: b.note ?? null,
+        }));
+        if (bodyweightRows.length > 0) {
+          await tx.bodyweightEntry.createMany({ data: bodyweightRows });
+        }
+
+        const readinessRows = (payload.readinessCheckins ?? []).map((r) => ({
+          userId,
+          readiness: r.readiness,
+          sleepQuality: r.sleepQuality,
+          soreness: r.soreness ?? undefined,
+          note: r.note ?? null,
+          createdAt: new Date(r.createdAt),
+        }));
+        if (readinessRows.length > 0) {
+          await tx.readinessCheckin.createMany({ data: readinessRows });
+        }
+
+        for (const c of payload.conversations ?? []) {
+          const conversation = await tx.conversation.create({
+            data: {
+              userId,
+              title: c.title ?? null,
+              createdAt: new Date(c.createdAt),
+              updatedAt: new Date(c.updatedAt),
+            },
+          });
+          if (c.messages.length > 0) {
+            await tx.message.createMany({
+              data: c.messages.map((m) => ({
+                conversationId: conversation.id,
+                role: m.role,
+                content: m.content,
+                createdAt: new Date(m.createdAt),
+              })),
+            });
+          }
+        }
       },
-      { timeout: 30_000 },
+      { timeout: 60_000 },
     );
 
     return NextResponse.json({ ok: true });

--- a/components/settings/backup-section.tsx
+++ b/components/settings/backup-section.tsx
@@ -124,7 +124,8 @@ export function BackupSection() {
                 <p className="mt-1 text-xs text-muted-foreground">
                   The file <code>{confirmingFile.name}</code> will replace{' '}
                   <strong>all</strong> your current data (programs,
-                  sessions, sets, debriefs). This action cannot be undone.
+                  sessions, sets, goals, bodyweight history, check-ins,
+                  coach conversations). This action cannot be undone.
                 </p>
                 <div className="mt-3 flex gap-2">
                   <Button

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -6,6 +6,42 @@ by the charter in [`07-autonomy.md`](07-autonomy.md).
 
 ---
 
+## 2026-06-12 (day) - Backup export/restore made complete (#168)
+
+**Context.** Maintainer tick on issue #168 (author JulienAu, trust-gated: login allowlist
+plus collaborator check HTTP 204): the backup route - the data-ownership wedge - silently
+dropped everything added since it shipped. Data-integrity work, so the reinforced
+controls applied: full local gate, tests at every touched layer, no migration needed
+(purely additive).
+
+**Decided / shipped.**
+- app/api/backup/route.ts rewritten against a systematic schema inventory (now documented
+  in the route header): export gains Set.durationSec/distanceM/avgHr,
+  ProgramExercise.supersetGroup, Exercise.usesBodyweight (a fourth silent drop the issue
+  had not listed), the profile incl deloadUntil, and the ExerciseGoal / BodyweightEntry /
+  ReadinessCheckin / Conversation+Message models. VERSION bumped to 2; version 1 files
+  keep importing (every v2 field/model is optional, defaulting to null/absent).
+- Restore hardened as untrusted input: 50 MiB streaming byte cap (readBodyWithCap),
+  bounds on every value reusing the writer schemas' limits (cardio caps, superset group
+  range, profile ranges, soreness map), array caps, dates must parse (400 instead of a
+  Prisma 500), enum fields validated with nativeEnum instead of the old `as any` casts.
+  The transaction (still all-or-nothing) now also purges/recreates the new models.
+- tests/integration/backup-route.test.ts: lossless round trip into a SECOND user
+  (field-for-field, order-insensitive re-export comparison) with ownership assertions;
+  a version-1-file restore; and adversarial cases - out-of-bounds value, non-JSON,
+  missing confirmReplace, mid-transaction unique-violation rollback leaving prior data
+  byte-identical, 50 MiB+ body (413), 20k+ array (400).
+- Full local gate (verify.sh --full) before the PR.
+
+**Challenged.** No subagent-spawning tool in this tick: per the charter backstop the PR
+merged on green full CI and is flagged for independent POST-MERGE review - correctness
+lens on the round trip and a security lens on the untrusted restore path.
+
+**Deferred to human.** Post-merge review above. #169 (major-version dep bumps) remains
+stop-for-human from the previous tick.
+
+---
+
 ## 2026-06-12 (night) - TCX hardening nits land (#161); triage follows
 
 **Context.** Maintainer tick. One implementation item: issue #161 (the advisory nits the

--- a/tests/integration/backup-route.test.ts
+++ b/tests/integration/backup-route.test.ts
@@ -1,0 +1,549 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { db } from '@/lib/db';
+import { getCurrentUserId } from '@/lib/auth';
+
+// Backup export/restore completeness (issue #168): the export must carry every
+// user-owned model/field, the restore must be a lossless, ownership-scoped
+// round trip, version 1 files must keep importing, and a malformed or
+// oversized file must be rejected without partially written data.
+
+// Auth is read through getCurrentUserId (via requireApiUserId in @/lib/api).
+vi.mock('@/lib/auth', () => ({ getCurrentUserId: vi.fn() }));
+const mockUserId = vi.mocked(getCurrentUserId);
+
+import { GET as getBackup, POST as postBackup } from '@/app/api/backup/route';
+
+function actAs(userId: string) {
+  mockUserId.mockResolvedValue(userId);
+}
+
+function jsonReq(body: unknown): Request {
+  return new Request('http://test.local/api/backup', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+// Order-insensitive deep normalization: sorts every array (the export order of
+// sets depends on regenerated cuids) and every object key, so two dumps can be
+// compared field-for-field.
+function sortDeep(v: unknown): unknown {
+  if (Array.isArray(v)) {
+    return v
+      .map(sortDeep)
+      .sort((a, b) => (JSON.stringify(a) < JSON.stringify(b) ? -1 : 1));
+  }
+  if (v && typeof v === 'object') {
+    return Object.fromEntries(
+      Object.entries(v as Record<string, unknown>)
+        .map(([k, val]) => [k, sortDeep(val)] as const)
+        .sort(([a], [b]) => (a < b ? -1 : 1)),
+    );
+  }
+  return v;
+}
+
+// Strips the fields that legitimately differ between two accounts/exports.
+function comparable(dump: Record<string, unknown>): unknown {
+  const { exportedAt: _exportedAt, user: _user, ...rest } = dump;
+  return sortDeep(rest);
+}
+
+// Seeds a user with at least one row in every exported model, exercising all
+// the fields issue #168 found missing.
+async function seedFullUser(email: string) {
+  const user = await db.user.create({
+    data: {
+      email,
+      passwordHash: 'x',
+      displayName: 'Julien',
+      bodyweight: 82.5,
+      sex: 'MALE',
+      heightCm: 181,
+      goal: 'HYPERTROPHY',
+      weeklyFrequency: 4,
+      unit: 'LB',
+      deloadUntil: new Date('2026-07-05T00:00:00.000Z'),
+    },
+  });
+  const bench = await db.exercise.create({
+    data: { userId: user.id, name: 'Bench Press', muscleGroup: 'CHEST', category: 'COMPOUND' },
+  });
+  const pullup = await db.exercise.create({
+    data: {
+      userId: user.id,
+      name: 'Pull-up',
+      muscleGroup: 'BACK_WIDTH',
+      category: 'COMPOUND',
+      usesBodyweight: true,
+    },
+  });
+  const running = await db.exercise.create({
+    data: { userId: user.id, name: 'Running', muscleGroup: 'OTHER', category: 'CARDIO' },
+  });
+  const program = await db.program.create({
+    data: {
+      userId: user.id,
+      name: 'Block 1',
+      phase: 'accumulation',
+      isActive: true,
+      startDate: new Date('2026-05-01T00:00:00.000Z'),
+      workouts: {
+        create: [
+          {
+            name: 'Upper A',
+            dayOfWeek: 1,
+            order: 1,
+            exercises: {
+              create: [
+                {
+                  exerciseId: bench.id,
+                  order: 1,
+                  targetSets: 3,
+                  targetRepsMin: 5,
+                  targetRepsMax: 8,
+                  targetRIR: 2,
+                  restSec: 120,
+                  supersetGroup: 1,
+                },
+                {
+                  exerciseId: pullup.id,
+                  order: 2,
+                  targetSets: 3,
+                  targetRepsMin: 6,
+                  targetRepsMax: 10,
+                  targetRIR: 2,
+                  restSec: 120,
+                  supersetGroup: 1,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    include: { workouts: true },
+  });
+  await db.session.create({
+    data: {
+      userId: user.id,
+      programId: program.id,
+      workoutId: program.workouts[0]?.id ?? null,
+      startedAt: new Date('2026-06-01T10:00:00.000Z'),
+      finishedAt: new Date('2026-06-01T11:00:00.000Z'),
+      notes: 'good session',
+      sets: {
+        create: [
+          {
+            exerciseId: bench.id,
+            setNumber: 1,
+            weight: 100,
+            reps: 5,
+            rir: 2,
+            isDropSet: true,
+            notes: 'top set',
+            completedAt: new Date('2026-06-01T10:10:00.000Z'),
+          },
+          {
+            exerciseId: running.id,
+            setNumber: 1,
+            weight: 0,
+            reps: 1,
+            durationSec: 1800,
+            distanceM: 5000,
+            avgHr: 152,
+            completedAt: new Date('2026-06-01T10:50:00.000Z'),
+          },
+        ],
+      },
+    },
+  });
+  await db.coachSession.create({
+    data: {
+      userId: user.id,
+      weekStart: new Date('2026-06-01T00:00:00.000Z'),
+      weekEnd: new Date('2026-06-07T00:00:00.000Z'),
+      prompt: 'week summary',
+      response: 'keep going',
+      createdAt: new Date('2026-06-07T18:00:00.000Z'),
+    },
+  });
+  await db.exerciseGoal.create({
+    data: {
+      userId: user.id,
+      exerciseId: bench.id,
+      targetWeight: 120,
+      targetReps: 5,
+      createdAt: new Date('2026-05-15T09:00:00.000Z'),
+      achievedAt: new Date('2026-06-01T10:10:00.000Z'),
+    },
+  });
+  await db.bodyweightEntry.createMany({
+    data: [
+      {
+        userId: user.id,
+        weightKg: 83.1,
+        measuredAt: new Date('2026-05-20T07:00:00.000Z'),
+        note: 'morning',
+      },
+      { userId: user.id, weightKg: 82.5, measuredAt: new Date('2026-06-05T07:00:00.000Z') },
+    ],
+  });
+  await db.readinessCheckin.create({
+    data: {
+      userId: user.id,
+      readiness: 4,
+      sleepQuality: 3,
+      soreness: { QUADS: 4, CHEST: 2 },
+      note: 'legs heavy',
+      createdAt: new Date('2026-06-01T09:00:00.000Z'),
+    },
+  });
+  await db.conversation.create({
+    data: {
+      userId: user.id,
+      title: 'Plateau on bench',
+      createdAt: new Date('2026-06-02T08:00:00.000Z'),
+      updatedAt: new Date('2026-06-02T08:05:00.000Z'),
+      messages: {
+        create: [
+          {
+            role: 'USER',
+            content: 'My bench is stuck.',
+            createdAt: new Date('2026-06-02T08:00:00.000Z'),
+          },
+          {
+            role: 'ASSISTANT',
+            content: 'Try a back-off set.',
+            createdAt: new Date('2026-06-02T08:05:00.000Z'),
+          },
+        ],
+      },
+    },
+  });
+  return user;
+}
+
+async function countsFor(userId: string) {
+  return {
+    exercises: await db.exercise.count({ where: { userId } }),
+    programs: await db.program.count({ where: { userId } }),
+    sessions: await db.session.count({ where: { userId } }),
+    sets: await db.set.count({ where: { session: { userId } } }),
+    coachSessions: await db.coachSession.count({ where: { userId } }),
+    goals: await db.exerciseGoal.count({ where: { userId } }),
+    bodyweightEntries: await db.bodyweightEntry.count({ where: { userId } }),
+    readinessCheckins: await db.readinessCheckin.count({ where: { userId } }),
+    conversations: await db.conversation.count({ where: { userId } }),
+    messages: await db.message.count({ where: { conversation: { userId } } }),
+  };
+}
+
+beforeEach(() => {
+  mockUserId.mockReset();
+});
+
+describe('GET /api/backup - export completeness (issue #168)', () => {
+  it('exports version 2 with the cardio fields, supersetGroup and the v2 models', async () => {
+    const user = await seedFullUser('a@test.dev');
+    actAs(user.id);
+
+    const res = await getBackup();
+    expect(res.status).toBe(200);
+    const dump = await res.json();
+
+    expect(dump.version).toBe(2);
+    expect(dump.profile).toMatchObject({
+      displayName: 'Julien',
+      bodyweight: 82.5,
+      sex: 'MALE',
+      heightCm: 181,
+      goal: 'HYPERTROPHY',
+      weeklyFrequency: 4,
+      unit: 'LB',
+      deloadUntil: '2026-07-05T00:00:00.000Z',
+    });
+
+    const pullup = dump.exercises.find(
+      (e: { name: string }) => e.name === 'Pull-up',
+    );
+    expect(pullup.usesBodyweight).toBe(true);
+
+    const sets = dump.sessions[0].sets as Array<Record<string, unknown>>;
+    const cardio = sets.find((s) => s.exerciseName === 'Running');
+    expect(cardio).toMatchObject({ durationSec: 1800, distanceM: 5000, avgHr: 152 });
+
+    const peGroups = dump.programs[0].workouts[0].exercises.map(
+      (pe: { supersetGroup: number | null }) => pe.supersetGroup,
+    );
+    expect(peGroups).toEqual([1, 1]);
+
+    expect(dump.exerciseGoals).toEqual([
+      {
+        exerciseName: 'Bench Press',
+        targetWeight: 120,
+        targetReps: 5,
+        createdAt: '2026-05-15T09:00:00.000Z',
+        achievedAt: '2026-06-01T10:10:00.000Z',
+      },
+    ]);
+    expect(dump.bodyweightEntries).toHaveLength(2);
+    expect(dump.readinessCheckins).toEqual([
+      {
+        readiness: 4,
+        sleepQuality: 3,
+        soreness: { QUADS: 4, CHEST: 2 },
+        note: 'legs heavy',
+        createdAt: '2026-06-01T09:00:00.000Z',
+      },
+    ]);
+    expect(dump.conversations).toHaveLength(1);
+    expect(dump.conversations[0].messages).toHaveLength(2);
+  });
+});
+
+describe('POST /api/backup - restore round trip (issue #168)', () => {
+  it('restores an export losslessly into a second user, ownership-scoped', async () => {
+    const userA = await seedFullUser('a@test.dev');
+    actAs(userA.id);
+    const dumpA = await (await getBackup()).json();
+    const countsA = await countsFor(userA.id);
+
+    const userB = await db.user.create({
+      data: { email: 'b@test.dev', passwordHash: 'x' },
+    });
+    actAs(userB.id);
+    const res = await postBackup(jsonReq({ payload: dumpA, confirmReplace: true }));
+    expect(res.status).toBe(200);
+
+    // Field-for-field lossless round trip (ids regenerated, so compare the
+    // re-export of user B against user A's export).
+    const dumpB = await (await getBackup()).json();
+    expect(comparable(dumpB)).toEqual(comparable(dumpA));
+
+    // Ownership-scoped: user A's data is untouched, user B owns a full copy.
+    expect(await countsFor(userA.id)).toEqual(countsA);
+    expect(await countsFor(userB.id)).toEqual(countsA);
+
+    // The goal was re-linked to user B's own copy of the exercise.
+    const goalB = await db.exerciseGoal.findFirst({
+      where: { userId: userB.id },
+      include: { exercise: true },
+    });
+    expect(goalB?.exercise.userId).toBe(userB.id);
+    expect(goalB?.exercise.name).toBe('Bench Press');
+
+    // The profile (including deload state) was restored onto user B.
+    const profileB = await db.user.findUnique({ where: { id: userB.id } });
+    expect(profileB?.displayName).toBe('Julien');
+    expect(profileB?.unit).toBe('LB');
+    expect(profileB?.deloadUntil?.toISOString()).toBe('2026-07-05T00:00:00.000Z');
+    expect(profileB?.email).toBe('b@test.dev');
+  });
+
+  it('still restores a version 1 backup (fields and models added in v2 absent)', async () => {
+    const user = await db.user.create({
+      data: { email: 'v1@test.dev', passwordHash: 'x', displayName: 'Keep Me' },
+    });
+    actAs(user.id);
+
+    // Shape produced by the pre-#168 route: no profile, no v2 models, sets
+    // and program exercises without the v2 fields.
+    const v1Payload = {
+      version: 1,
+      exportedAt: '2026-01-01T00:00:00.000Z',
+      user: { email: 'v1@test.dev', createdAt: '2025-01-01T00:00:00.000Z' },
+      exercises: [
+        {
+          name: 'Squat',
+          muscleGroup: 'QUADS',
+          category: 'COMPOUND',
+          defaultRestSec: 180,
+          notes: null,
+        },
+      ],
+      programs: [
+        {
+          name: 'Old Block',
+          description: null,
+          phase: 'base',
+          isActive: false,
+          startDate: '2025-11-01T00:00:00.000Z',
+          endDate: null,
+          workouts: [
+            {
+              name: 'Legs',
+              dayOfWeek: 2,
+              order: 1,
+              exercises: [
+                {
+                  exerciseName: 'Squat',
+                  order: 1,
+                  targetSets: 4,
+                  targetRepsMin: 5,
+                  targetRepsMax: 8,
+                  targetRIR: 1,
+                  restSec: 180,
+                  tempo: null,
+                  notes: null,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      sessions: [
+        {
+          programName: 'Old Block',
+          workoutName: 'Legs',
+          startedAt: '2025-11-03T10:00:00.000Z',
+          finishedAt: null,
+          notes: null,
+          sets: [
+            {
+              exerciseName: 'Squat',
+              setNumber: 1,
+              weight: 140,
+              reps: 5,
+              rir: 1,
+              notes: null,
+              isWarmup: false,
+              isDropSet: false,
+              completedAt: '2025-11-03T10:15:00.000Z',
+            },
+          ],
+        },
+      ],
+      coachSessions: [],
+    };
+
+    const res = await postBackup(jsonReq({ payload: v1Payload, confirmReplace: true }));
+    expect(res.status).toBe(200);
+
+    const counts = await countsFor(user.id);
+    expect(counts.exercises).toBe(1);
+    expect(counts.programs).toBe(1);
+    expect(counts.sets).toBe(1);
+    expect(counts.goals).toBe(0);
+    expect(counts.bodyweightEntries).toBe(0);
+    expect(counts.readinessCheckins).toBe(0);
+    expect(counts.conversations).toBe(0);
+
+    // v2 fields default to their pre-#168 values.
+    const squat = await db.exercise.findFirst({ where: { userId: user.id } });
+    expect(squat?.usesBodyweight).toBe(false);
+    const pe = await db.programExercise.findFirst({
+      where: { workout: { program: { userId: user.id } } },
+    });
+    expect(pe?.supersetGroup).toBeNull();
+    const set = await db.set.findFirst({ where: { session: { userId: user.id } } });
+    expect(set?.durationSec).toBeNull();
+    expect(set?.avgHr).toBeNull();
+
+    // No profile in a v1 file: the account's profile is left alone.
+    const profile = await db.user.findUnique({ where: { id: user.id } });
+    expect(profile?.displayName).toBe('Keep Me');
+  });
+});
+
+describe('POST /api/backup - malformed and oversized input (issue #168)', () => {
+  it('rejects out-of-bounds values without touching existing data', async () => {
+    const user = await seedFullUser('victim@test.dev');
+    actAs(user.id);
+    const before = await countsFor(user.id);
+    const dump = await (await getBackup()).json();
+
+    dump.sessions[0].sets[0].avgHr = 999; // out of the 40..250 range
+    const res = await postBackup(jsonReq({ payload: dump, confirmReplace: true }));
+    expect(res.status).toBe(400);
+
+    // Validation failed before the transaction: nothing was deleted.
+    expect(await countsFor(user.id)).toEqual(before);
+  });
+
+  it('rejects a non-JSON body and a missing confirmReplace', async () => {
+    const user = await seedFullUser('victim2@test.dev');
+    actAs(user.id);
+    const before = await countsFor(user.id);
+
+    const notJson = await postBackup(
+      new Request('http://test.local/api/backup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: 'not json {{{',
+      }),
+    );
+    expect(notJson.status).toBe(400);
+
+    const dump = await (await getBackup()).json();
+    const noConfirm = await postBackup(jsonReq({ payload: dump, confirmReplace: false }));
+    expect(noConfirm.status).toBe(400);
+
+    expect(await countsFor(user.id)).toEqual(before);
+  });
+
+  it('rolls back the whole restore when a row fails mid-transaction', async () => {
+    const user = await seedFullUser('victim3@test.dev');
+    actAs(user.id);
+    const before = await countsFor(user.id);
+    const dump = await (await getBackup()).json();
+    const pristine = JSON.parse(JSON.stringify(dump));
+
+    // Passes Zod but violates the (userId, name) unique constraint during the
+    // restore: the transaction must roll back, leaving the user's previous
+    // data fully intact (not wiped, not partially replaced).
+    dump.exercises.push({ ...dump.exercises[0] });
+    const res = await postBackup(jsonReq({ payload: dump, confirmReplace: true }));
+    expect(res.status).toBe(409);
+
+    expect(await countsFor(user.id)).toEqual(before);
+    const dumpAfter = await (await getBackup()).json();
+    expect(comparable(dumpAfter)).toEqual(comparable(pristine));
+  });
+
+  it('rejects an oversized body with 413 while reading it', async () => {
+    const user = await db.user.create({
+      data: { email: 'big@test.dev', passwordHash: 'x' },
+    });
+    actAs(user.id);
+
+    // 50 MiB cap: a body just past it must be cut off during the read.
+    const oversized = '{"payload": "' + 'x'.repeat(50 * 1024 * 1024) + '"}';
+    const res = await postBackup(
+      new Request('http://test.local/api/backup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: oversized,
+      }),
+    );
+    expect(res.status).toBe(413);
+  });
+
+  it('rejects an array past its cap (oversized backup shape)', async () => {
+    const user = await db.user.create({
+      data: { email: 'flood@test.dev', passwordHash: 'x' },
+    });
+    actAs(user.id);
+
+    const entries = Array.from({ length: 20001 }, (_, i) => ({
+      weightKg: 80,
+      measuredAt: new Date(1700000000000 + i * 1000).toISOString(),
+      note: null,
+    }));
+    const res = await postBackup(
+      jsonReq({
+        payload: {
+          version: 2,
+          exercises: [],
+          programs: [],
+          sessions: [],
+          bodyweightEntries: entries,
+        },
+        confirmReplace: true,
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(await db.bodyweightEntry.count({ where: { userId: user.id } })).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

The backup route (app/api/backup/route.ts) - the one route whose whole point is not losing data - silently dropped everything added since it shipped. This PR makes it complete and keeps it complete:

- **Export** now includes `Set.durationSec` / `distanceM` / `avgHr`, `ProgramExercise.supersetGroup`, `Exercise.usesBodyweight` (a fourth silent drop the issue had not listed), the profile (displayName, bodyweight, sex, heightCm, goal, weeklyFrequency, unit, **deloadUntil**) and the previously missing models: `ExerciseGoal`, `BodyweightEntry`, `ReadinessCheckin`, `Conversation` + `Message`.
- **VERSION bumped to 2**, and version 1 files keep importing: every v2 field/model is optional in the Zod schema and defaults to null/absent on restore.
- **Systematic inventory** documented in the route header: which prisma models/fields are exported and which are intentionally excluded (account identity/credentials, row ids, server-side bookkeeping timestamps) - so the next schema change has a checklist to extend.
- **Restore hardened as untrusted input** (same posture as the CSV/TCX imports): 50 MiB streaming byte cap via `readBodyWithCap`, bounds on every value reusing the writer schemas' limits (cardio caps from `lib/cardio`, superset group range from `lib/supersets`, profile ranges, `sorenessSchema`), array caps, dates that must parse and enum fields validated with `nativeEnum` (malformed input now 400s instead of reaching Prisma and 500ing; the old `as any` casts are gone). The restore stays a single all-or-nothing transaction, which now also purges/recreates the new models.
- Settings UI warning text updated to list the wider replace scope (no API change needed - the client passes the file through).

## How I tested

- `bash scripts/verify.sh --full` PASSED locally (prisma generate, lint, typecheck, unit, build, integration, E2E - 10/10 E2E green).
- New `tests/integration/backup-route.test.ts` (8 tests):
  - export completeness for every v2 field/model;
  - **lossless round trip**: seed a user with a cardio set (duration/distance/avgHr), a superset pair, a bodyweight-based exercise, a goal, bodyweight entries, a readiness check-in with soreness map, a conversation; export; restore as a **second** user; re-export and compare field-for-field (order-insensitive), plus ownership assertions (first user's data untouched, all restored rows owned by the second user);
  - **backward compat**: a version 1 file (pre-#168 shape, none of the new fields/models) restores cleanly, v2 fields defaulting to null/false, profile left alone;
  - **adversarial**: out-of-bounds value rejected before anything is deleted, non-JSON body, missing confirmReplace, a mid-transaction unique-constraint failure rolls back to byte-identical prior data, a 50 MiB+ body gets 413, a 20k+ element array gets 400.

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)