### PR TITLE
fix: reject out-of-range backup dates as 400, not a Prisma 500

### DIFF
--- a/app/api/backup/route.ts
+++ b/app/api/backup/route.ts
@@ -258,11 +258,26 @@ export async function GET() {
 // size-capped while being read. Version 1 files (pre-#168) stay importable:
 // every field/model added in v2 is optional and defaults to null/absent.
 
-// A date string that must actually parse (a legit export always writes ISO).
+// A date string that must actually parse AND fall within PostgreSQL's
+// timestamp range. JS Date.parse accepts dates far outside it (e.g. year
+// 275760), which would pass Zod and then throw deep in Prisma as a 500; we
+// reject them here so a malformed file is a clean 400 with the user's data
+// untouched (the route's documented contract).
 const dateString = z
   .string()
   .max(40)
-  .refine((s) => !Number.isNaN(Date.parse(s)), { message: 'Invalid date' });
+  .refine(
+    (s) => {
+      const t = Date.parse(s);
+      if (Number.isNaN(t)) return false;
+      // Postgres timestamp years run 4713 BC .. 294276 AD; JS Date itself
+      // caps at +/-8.64e15 ms. Bound to years [1, 9999] - well within both
+      // and far beyond any real training date.
+      const year = new Date(t).getUTCFullYear();
+      return year >= 1 && year <= 9999;
+    },
+    { message: 'Invalid or out-of-range date' },
+  );
 
 const importSchema = z.object({
   version: z.number().int().min(1).max(VERSION),

--- a/tests/integration/backup-route.test.ts
+++ b/tests/integration/backup-route.test.ts
@@ -462,6 +462,20 @@ describe('POST /api/backup - malformed and oversized input (issue #168)', () => 
     expect(await countsFor(user.id)).toEqual(before);
   });
 
+  it('rejects an out-of-range date as a clean 400, not a Prisma 500', async () => {
+    const user = await seedFullUser('victim-date@test.dev');
+    actAs(user.id);
+    const before = await countsFor(user.id);
+    const dump = await (await getBackup()).json();
+
+    // Year 275760 parses in JS Date but is far outside PostgreSQL's range;
+    // it must be rejected by validation, not 500 deep in Prisma.
+    dump.sessions[0].startedAt = '+275760-09-13T00:00:00.000Z';
+    const res = await postBackup(jsonReq({ payload: dump, confirmReplace: true }));
+    expect(res.status).toBe(400);
+    expect(await countsFor(user.id)).toEqual(before);
+  });
+
   it('rejects a non-JSON body and a missing confirmReplace', async () => {
     const user = await seedFullUser('victim2@test.dev');
     actAs(user.id);


### PR DESCRIPTION
Closes #172 (the one REAL finding from the independent post-merge review of #171).

A date outside PostgreSQL's timestamp range (e.g. year 275760) parsed in JS, passed the restore validation, and 500ed deep in Prisma instead of the documented clean 400. The transaction already rolled back so there was no data-integrity impact, but the route's stated contract ("a malformed file is a clean 400 with the user's data untouched") was violated. dateString now bounds the year to [1, 9999].

The review's other two findings are NITs (duplicate program-name relink; silently-dropped unmatched set on hand-edited files) - not in this PR; they only affect non-round-trip / hand-edited inputs.

## How I tested
- bash scripts/verify.sh --full - GREEN-GATE PASSED
- New integration test: a year-275760 startedAt is rejected 400 with the user's data untouched (was 500).

🤖 Generated with [Claude Code](https://claude.com/claude-code)