### PR TITLE
feat: show last-time cardio performance in the session

### DIFF
--- a/app/(app)/session/[id]/page.tsx
+++ b/app/(app)/session/[id]/page.tsx
@@ -106,5 +106,6 @@ function serializePerf(p: LastPerformance): SerializedLastPerformance {
     sets: p.sets,
     maxWeight: p.maxWeight,
     repsAtMaxWeight: p.repsAtMaxWeight,
+    cardio: p.cardio,
   };
 }

--- a/components/session/exercise-card.test.tsx
+++ b/components/session/exercise-card.test.tsx
@@ -44,6 +44,7 @@ const lastPerf: SerializedLastPerformance = {
   ],
   maxWeight: 100,
   repsAtMaxWeight: 10,
+  cardio: null,
 };
 
 function renderCard(readiness: ReadinessSignal | null, deloadActive = false) {
@@ -96,5 +97,64 @@ describe('ExerciseCard readiness explainer', () => {
     renderCard(null, true);
     expect(screen.getByText('Lighter - planned deload week')).toBeInTheDocument();
     expect(screen.getByText('90 kg')).toBeInTheDocument();
+  });
+});
+
+// Issue #176: a cardio exercise with prior history shows a "Last session"
+// reference (duration / distance / avgHr) instead of a load. The strength
+// branch above pins that strength cards are unchanged.
+const cardioExo: Exercise = { ...exo, id: 'c1', name: 'Running', category: 'CARDIO' };
+const cardioPe: ProgramExercise & { exercise: Exercise } = {
+  ...pe,
+  exerciseId: 'c1',
+  exercise: cardioExo,
+};
+
+function renderCardioCard(cardio: SerializedLastPerformance['cardio'] | undefined) {
+  const lastPerformance: SerializedLastPerformance | undefined =
+    cardio === undefined
+      ? undefined
+      : {
+          sessionStartedAt: new Date().toISOString(),
+          sets: [{ weight: 0, reps: 1, rir: null }],
+          maxWeight: 0,
+          repsAtMaxWeight: 1,
+          cardio,
+        };
+  return render(
+    <ExerciseCard
+      programExercise={cardioPe}
+      lastPerformance={lastPerformance}
+      readiness={null}
+      deloadActive={false}
+      unit="KG"
+    />,
+  );
+}
+
+describe('ExerciseCard cardio last-performance', () => {
+  it('shows duration, distance and avgHr for a cardio exercise with history', () => {
+    renderCardioCard({ durationSec: 1800, distanceM: 5000, avgHr: 152 });
+    expect(screen.getByText(/Last session/)).toBeInTheDocument();
+    expect(screen.getByText('30:00 · 5 km · 152 bpm')).toBeInTheDocument();
+  });
+
+  it('omits distance and bpm for a duration-only cardio set', () => {
+    renderCardioCard({ durationSec: 1500, distanceM: 0, avgHr: null });
+    expect(screen.getByText('25:00')).toBeInTheDocument();
+    expect(screen.queryByText(/bpm/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/km/)).not.toBeInTheDocument();
+  });
+
+  it('shows nothing (no crash) for a cardio exercise with no prior history', () => {
+    renderCardioCard(undefined);
+    expect(screen.queryByText(/Last session/)).not.toBeInTheDocument();
+  });
+
+  it('shows nothing when the last session for the exercise had no cardio set', () => {
+    // Defensive: a strength record on a cardio-categorized card must not render
+    // a misleading load line; the cardio branch gates on the cardio totals.
+    renderCardioCard(null);
+    expect(screen.queryByText(/Last session/)).not.toBeInTheDocument();
   });
 });

--- a/components/session/exercise-card.tsx
+++ b/components/session/exercise-card.tsx
@@ -15,7 +15,17 @@ import {
   type SuggestionResult,
 } from '@/lib/progression';
 import { formatWeight } from '@/lib/units';
+import { formatCardioSet } from '@/lib/cardio';
 import type { SerializedLastPerformance } from './session-runner';
+
+// Last-session reference line for a cardio exercise (issue #176): duration and
+// distance via the shared cardio formatter, with average heart rate appended
+// when the previous session recorded one. Distance and bpm are simply omitted
+// when absent, so a duration-only cardio set shows just the duration.
+function cardioLastLine(cardio: NonNullable<SerializedLastPerformance['cardio']>): string {
+  const base = formatCardioSet(cardio.durationSec, cardio.distanceM);
+  return cardio.avgHr != null ? `${base} · ${cardio.avgHr} bpm` : base;
+}
 
 interface Props {
   programExercise: ProgramExercise & { exercise: Exercise };
@@ -124,15 +134,17 @@ export function ExerciseCard({
           )}
         </p>
 
-        {!isCardio && lastPerformance && (
+        {lastPerformance && (!isCardio || lastPerformance.cardio) && (
           <div className="rounded-md bg-secondary/50 p-3 text-sm">
             <div className="flex items-center gap-2 text-muted-foreground">
               <span className="text-xs">Last session ({lastDate})</span>
             </div>
             <p className="font-medium">
-              {lastPerformance.maxWeight === 0
-                ? `${lastPerformance.repsAtMaxWeight} reps bodyweight`
-                : `${formatWeight(lastPerformance.maxWeight, unit, { decimals: 2, group: false })} × ${lastPerformance.repsAtMaxWeight} reps`}
+              {isCardio && lastPerformance.cardio
+                ? cardioLastLine(lastPerformance.cardio)
+                : lastPerformance.maxWeight === 0
+                  ? `${lastPerformance.repsAtMaxWeight} reps bodyweight`
+                  : `${formatWeight(lastPerformance.maxWeight, unit, { decimals: 2, group: false })} × ${lastPerformance.repsAtMaxWeight} reps`}
             </p>
           </div>
         )}

--- a/components/session/session-runner.tsx
+++ b/components/session/session-runner.tsx
@@ -41,6 +41,10 @@ export interface SerializedLastPerformance {
   sets: { weight: number; reps: number; rir: number | null }[];
   maxWeight: number;
   repsAtMaxWeight: number;
+  // Cardio totals for the last session (issue #176): null for strength
+  // exercises. Carried so the exercise card can show a cardio "Last session"
+  // reference (duration / distance / avgHr).
+  cardio: { durationSec: number; distanceM: number; avgHr: number | null } | null;
 }
 
 type ProgramExerciseWithExercise = ProgramExercise & { exercise: Exercise };

--- a/lib/last-performance.ts
+++ b/lib/last-performance.ts
@@ -9,6 +9,10 @@ export interface LastPerformance {
   maxWeight: number;
   // Reps at that max load (the highest rep count reached at maxWeight).
   repsAtMaxWeight: number;
+  // Cardio totals for the session (issue #176): summed duration/distance and
+  // an averaged heart rate across the session's cardio sets. Null for strength
+  // exercises (no cardio sets), so the session UI can branch on `cardio`.
+  cardio: { durationSec: number; distanceM: number; avgHr: number | null } | null;
 }
 
 // Fetches the previous performances for a list of exerciseIds, excluding the
@@ -40,20 +44,46 @@ export async function getLastPerformances(
       });
       if (!lastSet) return;
 
-      const sets = await db.set.findMany({
+      const rows = await db.set.findMany({
         where: {
           sessionId: lastSet.sessionId,
           exerciseId,
           isWarmup: false,
         },
         orderBy: { setNumber: 'asc' },
-        select: { weight: true, reps: true, rir: true },
+        select: {
+          weight: true,
+          reps: true,
+          rir: true,
+          durationSec: true,
+          distanceM: true,
+          avgHr: true,
+        },
       });
+
+      const sets = rows.map(({ weight, reps, rir }) => ({ weight, reps, rir }));
 
       const maxWeight = Math.max(...sets.map((s) => s.weight));
       const repsAtMaxWeight = Math.max(
         ...sets.filter((s) => s.weight === maxWeight).map((s) => s.reps),
       );
+
+      // Cardio totals (issue #176): a cardio set carries durationSec != null.
+      // Sum duration/distance over the session's cardio sets and average the
+      // heart rate across the sets that recorded one. Null when there are no
+      // cardio sets (a strength exercise), so the UI branches cleanly.
+      const cardioRows = rows.filter((r) => r.durationSec != null);
+      let cardio: LastPerformance['cardio'] = null;
+      if (cardioRows.length > 0) {
+        const durationSec = cardioRows.reduce((acc, r) => acc + (r.durationSec ?? 0), 0);
+        const distanceM = cardioRows.reduce((acc, r) => acc + (r.distanceM ?? 0), 0);
+        const hrRows = cardioRows.filter((r) => r.avgHr != null);
+        const avgHr =
+          hrRows.length > 0
+            ? Math.round(hrRows.reduce((acc, r) => acc + (r.avgHr ?? 0), 0) / hrRows.length)
+            : null;
+        cardio = { durationSec, distanceM, avgHr };
+      }
 
       result.set(exerciseId, {
         exerciseId,
@@ -61,6 +91,7 @@ export async function getLastPerformances(
         sets,
         maxWeight,
         repsAtMaxWeight,
+        cardio,
       });
     }),
   );

--- a/tests/integration/last-performance.test.ts
+++ b/tests/integration/last-performance.test.ts
@@ -54,6 +54,48 @@ describe('getLastPerformances', () => {
     // Warmup excluded: 3 working sets only.
     expect(perf!.sets).toHaveLength(3);
     expect(perf!.sets.some((s) => s.weight === 60)).toBe(false);
+    // Strength exercise: no cardio totals (issue #176).
+    expect(perf!.cardio).toBeNull();
+  });
+
+  it('sums cardio duration/distance and averages heart rate (issue #176)', async () => {
+    const user = await makeUser('lp-cardio@test.dev');
+    const exo = await db.exercise.create({
+      data: { userId: user.id, name: 'Running', muscleGroup: 'OTHER', category: 'CARDIO' },
+    });
+
+    const session = await db.session.create({ data: { userId: user.id, startedAt: at(1) } });
+    // Two cardio sets: 20:00 / 3 km / 150 bpm and 10:00 / 2 km (no HR).
+    await db.set.createMany({
+      data: [
+        {
+          sessionId: session.id,
+          exerciseId: exo.id,
+          setNumber: 1,
+          weight: 0,
+          reps: 1,
+          durationSec: 1200,
+          distanceM: 3000,
+          avgHr: 150,
+          completedAt: at(1),
+        },
+        {
+          sessionId: session.id,
+          exerciseId: exo.id,
+          setNumber: 2,
+          weight: 0,
+          reps: 1,
+          durationSec: 600,
+          distanceM: 2000,
+          avgHr: null,
+          completedAt: at(1),
+        },
+      ],
+    });
+
+    const map = await getLastPerformances(user.id, [exo.id], null);
+    const perf = map.get(exo.id);
+    expect(perf?.cardio).toEqual({ durationSec: 1800, distanceM: 5000, avgHr: 150 });
   });
 
   it('excludes the current session via excludeSessionId', async () => {


### PR DESCRIPTION
Shows the "Last session" reference for cardio exercises in the session, mirroring the strength block that was previously gated off for cardio.

## What changed
- `lib/last-performance.ts`: the serialized shape now carries summed cardio totals (`durationSec`/`distanceM`/`avgHr`), null for strength exercises.
- `components/session/exercise-card.tsx`: the last-performance block branches on `isCardio` instead of being hidden; cardio renders `<mm:ss> · <distance> · <avgHr> bpm` via the shared `lib/cardio.ts` formatters, omitting distance/bpm when absent.
- No schema/API/prompt change; reuses data already fetched for the session.

## How I tested
- `bash scripts/verify.sh` passed (prisma generate + lint + typecheck + unit + build).
- Component tests cover the cardio branch (full data, duration-only, no-history, and a defensive no-cardio-record case); strength behavior is pinned by the existing tests. An integration test asserts the cardio totals (sum duration/distance, average HR) - exercised by CI's `--full` tier.

Closes #176