### PR TITLE
feat: cardio pace and speed (derived) on the session summary and history

### DIFF
--- a/app/(app)/history/[id]/page.tsx
+++ b/app/(app)/history/[id]/page.tsx
@@ -8,7 +8,7 @@ import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { MUSCLE_GROUP_LABELS } from '@/lib/schemas/exercise';
 import { applyBodyweight, best1RM, totalVolume } from '@/lib/stats';
-import { formatCardioSet, formatDistance, formatDuration } from '@/lib/cardio';
+import { formatCardioSet, formatDistance, formatDuration, formatPace, formatSpeed } from '@/lib/cardio';
 import { formatWeight } from '@/lib/units';
 import { DeleteSessionButton } from '@/components/history/delete-session-button';
 
@@ -177,12 +177,25 @@ export default async function HistorySessionPage({ params }: Params) {
               );
               const exoVolume = totalVolume(enrichedExoSets);
               const e1rm = best1RM(enrichedExoSets);
-              // Cardio recap (issue #133): totals across the logged sets.
+              // Cardio recap (issue #133): totals across the logged sets, with
+              // derived pace and speed (issue #177) appended when a distance was
+              // covered (omitted for duration-only cardio).
+              const cardioDurationTotal = entry.sets.reduce(
+                (acc, s) => acc + (s.durationSec ?? 0),
+                0,
+              );
+              const cardioDistanceTotal = entry.sets.reduce(
+                (acc, s) => acc + (s.distanceM ?? 0),
+                0,
+              );
               const cardioTotal = isCardio
-                ? formatCardioSet(
-                    entry.sets.reduce((acc, s) => acc + (s.durationSec ?? 0), 0),
-                    entry.sets.reduce((acc, s) => acc + (s.distanceM ?? 0), 0),
-                  )
+                ? [
+                    formatCardioSet(cardioDurationTotal, cardioDistanceTotal),
+                    formatPace(cardioDurationTotal, cardioDistanceTotal, unit),
+                    formatSpeed(cardioDurationTotal, cardioDistanceTotal, unit),
+                  ]
+                    .filter(Boolean)
+                    .join(' · ')
                 : null;
               return (
                 <li key={exerciseId}>
@@ -226,11 +239,17 @@ export default async function HistorySessionPage({ params }: Params) {
                               <th className="py-1.5 font-medium">#</th>
                               <th className="py-1.5 font-medium">Duration</th>
                               <th className="py-1.5 font-medium">Distance</th>
+                              <th className="py-1.5 font-medium">Pace</th>
                               <th className="py-1.5 font-medium">Avg HR</th>
                             </tr>
                           </thead>
                           <tbody>
-                            {entry.sets.map((s) => (
+                            {entry.sets.map((s) => {
+                              const pace =
+                                s.durationSec != null
+                                  ? formatPace(s.durationSec, s.distanceM, unit)
+                                  : null;
+                              return (
                               <tr key={s.id} className="border-b border-border/40">
                                 <td className="py-1.5">{s.setNumber}</td>
                                 <td className="py-1.5">
@@ -241,11 +260,13 @@ export default async function HistorySessionPage({ params }: Params) {
                                     ? formatDistance(s.distanceM)
                                     : '-'}
                                 </td>
+                                <td className="py-1.5">{pace ?? '-'}</td>
                                 <td className="py-1.5">
                                   {s.avgHr != null ? `${s.avgHr} bpm` : '-'}
                                 </td>
                               </tr>
-                            ))}
+                              );
+                            })}
                           </tbody>
                         </table>
                       ) : (

--- a/components/session/session-summary.test.tsx
+++ b/components/session/session-summary.test.tsx
@@ -141,3 +141,74 @@ describe('SessionSummary PR section', () => {
     expect(screen.queryByText('Personal records this session')).toBeNull();
   });
 });
+
+// Issue #177: cardio recap shows derived pace and speed in the user's unit,
+// and omits them for a duration-only cardio set (no NaN/Infinity).
+const cardioExo: Exercise = { ...exo, id: 'c1', name: 'Running', category: 'CARDIO' };
+const cardioPe: ProgramExercise & { exercise: Exercise } = {
+  ...pe,
+  id: 'cpe',
+  exerciseId: 'c1',
+  targetSets: 1,
+  exercise: cardioExo,
+};
+
+function cardioSet(over: Partial<PendingSet>): PendingSet {
+  return pendingSet({
+    exerciseId: 'c1',
+    weight: 0,
+    reps: 1,
+    durationSec: 1800,
+    distanceM: 5000,
+    ...over,
+  });
+}
+
+describe('SessionSummary cardio pace/speed', () => {
+  it('shows pace and speed in metric for a distance cardio set', () => {
+    render(
+      <SessionSummary
+        session={session}
+        sets={[cardioSet({ localId: 'c' })]}
+        programExercises={[cardioPe]}
+        unit="KG"
+        onBack={() => {}}
+        onFinish={() => {}}
+        finishing={false}
+      />,
+    );
+    // 30:00 over 5 km -> 6:00 /km and 10 km/h.
+    expect(screen.getByText(/30:00 · 5 km · 6:00 \/km · 10 km\/h/)).toBeTruthy();
+  });
+
+  it('shows pace and speed in imperial when the unit is LB', () => {
+    render(
+      <SessionSummary
+        session={session}
+        sets={[cardioSet({ localId: 'c' })]}
+        programExercises={[cardioPe]}
+        unit="LB"
+        onBack={() => {}}
+        onFinish={() => {}}
+        finishing={false}
+      />,
+    );
+    expect(screen.getByText(/9:39 \/mi · 6\.2 mph/)).toBeTruthy();
+  });
+
+  it('omits pace and speed for a duration-only cardio set', () => {
+    render(
+      <SessionSummary
+        session={session}
+        sets={[cardioSet({ localId: 'c', distanceM: null })]}
+        programExercises={[cardioPe]}
+        unit="KG"
+        onBack={() => {}}
+        onFinish={() => {}}
+        finishing={false}
+      />,
+    );
+    expect(screen.queryByText(/\/km/)).toBeNull();
+    expect(screen.queryByText(/km\/h/)).toBeNull();
+  });
+});

--- a/components/session/session-summary.tsx
+++ b/components/session/session-summary.tsx
@@ -12,7 +12,7 @@ import { toast } from 'sonner';
 import type { PendingSet } from '@/lib/indexeddb';
 import { formatWeight } from '@/lib/units';
 import { detectPRs, type PRType } from '@/lib/records';
-import { formatCardioSet } from '@/lib/cardio';
+import { formatCardioSet, formatPace, formatSpeed } from '@/lib/cardio';
 
 // Prior (previous-session) non-warmup sets per exerciseId, used as the PR
 // baseline. Same source as the in-session badge (getLastPerformances): a PR
@@ -129,12 +129,15 @@ export function SessionSummary({
       doneSets: exoSets.length,
       targetSets,
       maxWeight: isCardio || exoSets.length === 0 ? 0 : Math.max(...exoSets.map((s) => s.weight)),
-      // Cardio recap: total duration and distance across the logged sets.
+      // Cardio recap: total duration and distance across the logged sets,
+      // plus derived pace and speed (issue #177) when the session covered a
+      // distance. Pace/speed are omitted for duration-only cardio.
       cardioLabel:
         isCardio && exoSets.length
-          ? formatCardioSet(
+          ? cardioRecap(
               exoSets.reduce((acc, s) => acc + (s.durationSec ?? 0), 0),
               exoSets.reduce((acc, s) => acc + (s.distanceM ?? 0), 0),
+              unit,
             )
           : null,
       complete: exoSets.length >= targetSets,
@@ -266,6 +269,16 @@ export function SessionSummary({
       </div>
     </main>
   );
+}
+
+// Cardio recap line for a session's totals: "30:00 · 5 km · 6:00 /km · 10 km/h".
+// Pace and speed (issue #177) are appended only when the session covered a
+// distance; a duration-only cardio session shows just the duration.
+function cardioRecap(durationSec: number, distanceM: number, unit: WeightUnit): string {
+  const base = formatCardioSet(durationSec, distanceM);
+  const pace = formatPace(durationSec, distanceM, unit);
+  const speed = formatSpeed(durationSec, distanceM, unit);
+  return [base, pace, speed].filter(Boolean).join(' · ');
 }
 
 function Stat({ label, value }: { label: string; value: string | number }) {

--- a/lib/cardio.test.ts
+++ b/lib/cardio.test.ts
@@ -3,9 +3,13 @@ import {
   formatCardioSet,
   formatDistance,
   formatDuration,
+  formatPace,
+  formatSpeed,
   isCardioSet,
   MAX_DURATION_SEC,
+  paceSecPerKm,
   parseDurationToSec,
+  speedKmh,
 } from './cardio';
 
 describe('isCardioSet', () => {
@@ -75,5 +79,63 @@ describe('formatCardioSet', () => {
   it('shows duration only when distance is absent or zero', () => {
     expect(formatCardioSet(750, null)).toBe('12:30');
     expect(formatCardioSet(750, 0)).toBe('12:30');
+  });
+});
+
+describe('paceSecPerKm', () => {
+  it('derives seconds per kilometer', () => {
+    // 30:00 over 5 km -> 6:00 /km.
+    expect(paceSecPerKm(1800, 5000)).toBe(360);
+  });
+
+  it('returns null for zero/absent distance (no divide-by-zero)', () => {
+    expect(paceSecPerKm(1800, 0)).toBeNull();
+    expect(paceSecPerKm(1800, null)).toBeNull();
+    expect(paceSecPerKm(1800, undefined)).toBeNull();
+  });
+});
+
+describe('speedKmh', () => {
+  it('derives kilometers per hour', () => {
+    // 5 km in 30:00 -> 10 km/h.
+    expect(speedKmh(1800, 5000)).toBe(10);
+  });
+
+  it('returns null for zero/absent distance or zero duration', () => {
+    expect(speedKmh(1800, 0)).toBeNull();
+    expect(speedKmh(1800, null)).toBeNull();
+    expect(speedKmh(0, 5000)).toBeNull();
+  });
+});
+
+describe('formatPace', () => {
+  it('formats metric pace as mm:ss /km', () => {
+    expect(formatPace(1800, 5000, 'KG')).toBe('6:00 /km');
+  });
+
+  it('formats imperial pace as mm:ss /mi', () => {
+    // 6:00 /km -> 6:00 * 1.60934 = 579.4 s/mi -> 9:39.
+    expect(formatPace(1800, 5000, 'LB')).toBe('9:39 /mi');
+  });
+
+  it('returns null when there is no distance', () => {
+    expect(formatPace(1800, 0, 'KG')).toBeNull();
+    expect(formatPace(1800, null, 'LB')).toBeNull();
+  });
+});
+
+describe('formatSpeed', () => {
+  it('formats metric speed as km/h', () => {
+    expect(formatSpeed(1800, 5000, 'KG')).toBe('10 km/h');
+  });
+
+  it('formats imperial speed as mph', () => {
+    // 10 km/h -> 10 / 1.60934 = 6.21 mph -> 6.2.
+    expect(formatSpeed(1800, 5000, 'LB')).toBe('6.2 mph');
+  });
+
+  it('returns null when there is no distance', () => {
+    expect(formatSpeed(1800, 0, 'KG')).toBeNull();
+    expect(formatSpeed(1800, null, 'LB')).toBeNull();
   });
 });

--- a/lib/cardio.ts
+++ b/lib/cardio.ts
@@ -1,3 +1,5 @@
+import type { WeightUnit } from '@prisma/client';
+
 // ============================================================
 // Cardio sets (issue #133) - duration/distance helpers
 // ============================================================
@@ -78,4 +80,65 @@ export function formatCardioSet(
     return `${duration} · ${formatDistance(distanceM)}`;
   }
   return duration;
+}
+
+// ============================================================
+// Pace and speed (issue #177) - pure, unit-aware derivations
+// ============================================================
+// The single number runners/cyclists train on. Both are derived from the
+// stored duration and distance; both return null when there is no distance
+// (e.g. a duration-only erg set) so callers never divide by zero or render
+// NaN/Infinity. Storage stays metric (meters/seconds); the unit only affects
+// the display helpers below.
+
+// Pace as seconds per kilometer, or null when distance is absent/zero.
+export function paceSecPerKm(
+  durationSec: number,
+  distanceM: number | null | undefined,
+): number | null {
+  if (distanceM == null || distanceM <= 0) return null;
+  return durationSec / (distanceM / 1000);
+}
+
+// Speed in kilometers per hour, or null when distance is absent/zero.
+export function speedKmh(
+  durationSec: number,
+  distanceM: number | null | undefined,
+): number | null {
+  if (distanceM == null || distanceM <= 0 || durationSec <= 0) return null;
+  return distanceM / 1000 / (durationSec / 3600);
+}
+
+// Formats pace for display, respecting the user's unit: "6:00 /km" in metric,
+// "9:39 /mi" in imperial. Returns null when distance is absent (no pace to
+// show). The mm:ss part reuses formatDuration so it stays consistent.
+export function formatPace(
+  durationSec: number,
+  distanceM: number | null | undefined,
+  unit: WeightUnit,
+): string | null {
+  const secPerKm = paceSecPerKm(durationSec, distanceM);
+  if (secPerKm == null) return null;
+  if (unit === 'LB') {
+    const secPerMile = secPerKm * (MILES_TO_METERS / 1000);
+    return `${formatDuration(secPerMile)} /mi`;
+  }
+  return `${formatDuration(secPerKm)} /km`;
+}
+
+// Formats speed for display, respecting the user's unit: "10 km/h" in metric,
+// "6.2 mph" in imperial. Returns null when distance is absent. One decimal,
+// trailing zeros trimmed.
+export function formatSpeed(
+  durationSec: number,
+  distanceM: number | null | undefined,
+  unit: WeightUnit,
+): string | null {
+  const kmh = speedKmh(durationSec, distanceM);
+  if (kmh == null) return null;
+  if (unit === 'LB') {
+    const mph = kmh * (1000 / MILES_TO_METERS);
+    return `${+mph.toFixed(1)} mph`;
+  }
+  return `${+kmh.toFixed(1)} km/h`;
 }


### PR DESCRIPTION
Surfaces pace (min/km or min/mi) and speed (km/h or mph) - the numbers runners and cyclists train on - derived from the duration/distance the app already stores.

## What changed
- `lib/cardio.ts`: pure `paceSecPerKm` / `speedKmh` derivations (null on zero/absent distance, never divide by zero) and unit-aware `formatPace` / `formatSpeed` (metric vs imperial).
- `components/session/session-summary.tsx`: the per-exercise cardio recap appends pace and speed (omitted for duration-only cardio).
- `app/(app)/history/[id]/page.tsx`: the cardio total appends pace/speed and the per-set table gains a Pace column.
- Display-only; no schema/API/coach-payload change. Strength rows unchanged.

## How I tested
- `bash scripts/verify.sh` passed (prisma generate + lint + typecheck + unit + build).
- Colocated unit tests for the helpers (metric + imperial + zero-distance null), and component tests for the summary recap (metric, imperial, duration-only).

Closes #177