### PR TITLE
feat/issue 175 cardio tcx export

### DIFF
--- a/app/(app)/history/[id]/page.tsx
+++ b/app/(app)/history/[id]/page.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import { ArrowLeft, Calendar, Clock, Dumbbell } from 'lucide-react';
+import { ArrowLeft, Calendar, Clock, Download, Dumbbell } from 'lucide-react';
 import { db } from '@/lib/db';
 import { requireSession } from '@/lib/auth';
 import { Button } from '@/components/ui/button';
@@ -83,6 +83,9 @@ export default async function HistorySessionPage({ params }: Params) {
   );
   const volume = totalVolume(enrichedAllSets);
   const workingSetCount = session.sets.filter((s) => !s.isWarmup).length;
+  // TCX export (issue #175) is offered only when the session has cardio sets;
+  // the route 400s otherwise, so the button must mirror that condition.
+  const hasCardio = session.sets.some((s) => s.durationSec != null);
   const durationMin =
     session.finishedAt && session.startedAt
       ? Math.round((session.finishedAt.getTime() - session.startedAt.getTime()) / 60000)
@@ -98,11 +101,21 @@ export default async function HistorySessionPage({ params }: Params) {
               <span className="ml-1">History</span>
             </Link>
           </Button>
-          <DeleteSessionButton
-            sessionId={session.id}
-            workoutName={session.workout?.name ?? null}
-            startedAt={session.startedAt}
-          />
+          <div className="flex items-center gap-2">
+            {hasCardio && (
+              <Button asChild variant="outline" size="sm">
+                <a href={`/api/cardio/tcx?sessionId=${session.id}`} download>
+                  <Download className="size-4" />
+                  <span className="ml-1">Download .tcx</span>
+                </a>
+              </Button>
+            )}
+            <DeleteSessionButton
+              sessionId={session.id}
+              workoutName={session.workout?.name ?? null}
+              startedAt={session.startedAt}
+            />
+          </div>
         </div>
 
         <Card>

--- a/app/api/cardio/tcx/route.ts
+++ b/app/api/cardio/tcx/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { ApiError, handleApiError, requireApiUserId } from '@/lib/api';
+import { serializeTcx, sportForExerciseName, type TcxExportActivity } from '@/lib/import/tcx-export';
+
+// GET /api/cardio/tcx?sessionId=...
+// Exports a session's cardio sets as a minimal, valid TCX 1.0 Activity (the
+// outbound half of data ownership, issue #175). Ownership-scoped exactly like
+// /api/history/csv: a session that is not the caller's returns 404 (never
+// another user's data). A session with no cardio sets returns 400 - there is
+// nothing to export as TCX, and the UI does not show the button for it.
+export async function GET(req: Request) {
+  try {
+    const userId = await requireApiUserId();
+    const url = new URL(req.url);
+    const sessionId = url.searchParams.get('sessionId');
+    if (!sessionId) {
+      throw new ApiError(400, 'Missing sessionId.');
+    }
+
+    // Ownership is enforced in the query: scoping on userId means a foreign
+    // sessionId simply yields no row -> 404, identical-looking to a missing one,
+    // so we never confirm another user's session exists.
+    const session = await db.session.findFirst({
+      where: { id: sessionId, userId },
+      select: {
+        id: true,
+        startedAt: true,
+        sets: {
+          where: { durationSec: { not: null } },
+          orderBy: { setNumber: 'asc' },
+          select: {
+            durationSec: true,
+            distanceM: true,
+            avgHr: true,
+            exercise: { select: { name: true } },
+          },
+        },
+      },
+    });
+
+    if (!session) {
+      throw new ApiError(404, 'Session not found.');
+    }
+    if (session.sets.length === 0) {
+      throw new ApiError(400, 'This session has no cardio sets to export.');
+    }
+
+    // The activity sport comes from the first cardio set's exercise; a TCX
+    // Activity carries a single Sport, and a session is overwhelmingly one
+    // discipline. Each cardio set becomes one Lap.
+    const sport = sportForExerciseName(session.sets[0]!.exercise.name);
+    const activity: TcxExportActivity = {
+      startedAt: session.startedAt,
+      sport,
+      laps: session.sets.map((s) => ({
+        durationSec: s.durationSec!,
+        distanceM: s.distanceM,
+        avgHr: s.avgHr,
+      })),
+    };
+
+    const body = serializeTcx(activity);
+    const filename = `gymcoach-${session.startedAt.toISOString().slice(0, 10)}.tcx`;
+    return new NextResponse(body, {
+      headers: {
+        'Content-Type': 'application/vnd.garmin.tcx+xml; charset=utf-8',
+        'Content-Disposition': `attachment; filename="${filename}"`,
+      },
+    });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -6,6 +6,50 @@ by the charter in [`07-autonomy.md`](07-autonomy.md).
 
 ---
 
+## 2026-06-13 - Cardio axis rounded out: last-time reference, pace/speed, TCX export (#176/#177/#175)
+
+**Context.** Maintainer tick running the cardio-axis batch, strictly serialized by ascending
+size (each PR MERGED before the next branch was cut). All three issues authored by JulienAu,
+trust-gated (login allowlist + collaborator check HTTP 204). Inherited model this cycle (Fable
+unavailable) - fine, proceeded. #169 (Next.js major bump) left untouched as stop-for-human.
+
+**Decided / shipped.**
+- **#176 (PR #179, merged).** The in-session "Last session" reference was gated off for cardio
+  (`!isCardio` in exercise-card.tsx). Extended the last-performance shape to carry summed cardio
+  totals (durationSec/distanceM averaged-HR; null for strength) and branched the card on isCardio
+  so cardio shows "<mm:ss> . <distance> . <avgHr> bpm" via the shared lib/cardio formatters.
+  Display-only, no schema/API/prompt change. Component tests cover the cardio branch (full data,
+  duration-only, no-history, defensive no-cardio-record); integration test pins the totals math.
+- **#177 (PR #180, merged).** Pure, unit-aware pace/speed derivations in lib/cardio.ts
+  (paceSecPerKm, speedKmh, formatPace, formatSpeed) returning null on zero/absent distance - no
+  divide-by-zero, no NaN/Infinity. Surfaced on the post-session summary recap and the history
+  detail (totals + a per-set Pace column), in the user's unit (min/km+km/h metric, min/mi+mph
+  imperial). Display-only. Colocated unit tests (metric/imperial/zero) + summary component tests.
+- **#175 (PR #181, merged on green --full).** The outbound half of data ownership: GET
+  /api/cardio/tcx?sessionId=... emits a minimal valid TCX 1.0 Activity (one Lap per cardio set),
+  ownership-scoped exactly like the CSV export (foreign session -> 404; 400 on a non-cardio
+  session or missing sessionId). Pure serializer lib/import/tcx-export.ts emits a FIXED minimal
+  structure (no DTD/entities) and xmlEscapes the five XML metacharacters on every interpolated
+  value; sport mapping is the inverse of the import's name<->sport. A "Download .tcx" action
+  sits on the finished-session detail page, shown only when the session has cardio.
+  - *Deviation noted:* the issue named app/(app)/session/[id] for the button, but that route
+    redirects finished sessions to home; the session-detail surface that actually renders a
+    completed session is app/(app)/history/[id], so the action landed there (the issue's clear
+    intent - download a completed cardio session from its detail view).
+  - Round-trip test (serializeTcx -> parseTcx) pins identical duration/distance/avgHr; xmlEscape
+    unit tests cover all five metacharacters and a markup-injection attempt; integration tests
+    pin ownership (404), cardio-only (400), missing-sessionId (400), and the round trip through
+    the route. Complex change (new route + new surface), so ran verify.sh --full before the PR.
+
+**Challenged.** No subagent-spawning tool available in this nested tick. Per the charter
+backstop, each PR merged only on green full CI and is FLAGGED here for independent POST-MERGE
+review: correctness lens on #176/#177; correctness + an XML-escaping/ownership lens on #175.
+
+**Deferred to human.** The post-merge review above. #169 (Next.js major bump) remains
+stop-for-human, untouched.
+
+---
+
 ## 2026-06-12 (day) - Backup export/restore made complete (#168)
 
 **Context.** Maintainer tick on issue #168 (author JulienAu, trust-gated: login allowlist

--- a/lib/import/tcx-export.test.ts
+++ b/lib/import/tcx-export.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { parseTcx } from './tcx';
+import { serializeTcx, sportForExerciseName, xmlEscape, type TcxExportActivity } from './tcx-export';
+
+describe('xmlEscape', () => {
+  it('neutralizes all five XML metacharacters', () => {
+    expect(xmlEscape('a & b < c > d " e \' f')).toBe(
+      'a &amp; b &lt; c &gt; d &quot; e &apos; f',
+    );
+  });
+
+  it('escapes & first so introduced entities are not double-escaped', () => {
+    expect(xmlEscape('<&>')).toBe('&lt;&amp;&gt;');
+  });
+
+  it('a value with markup cannot break out of its element', () => {
+    const escaped = xmlEscape('</Id><script>alert(1)</script>');
+    expect(escaped).not.toContain('<');
+    expect(escaped).not.toContain('>');
+  });
+});
+
+describe('sportForExerciseName', () => {
+  it('maps the known cardio names (inverse of the import) case-insensitively', () => {
+    expect(sportForExerciseName('Running')).toBe('Running');
+    expect(sportForExerciseName('running')).toBe('Running');
+    expect(sportForExerciseName('Cycling')).toBe('Biking');
+    expect(sportForExerciseName('Rowing machine')).toBe('Other');
+    expect(sportForExerciseName('Cardio (imported)')).toBe('Other');
+  });
+});
+
+describe('serializeTcx round-trip', () => {
+  it('round-trips a one-lap running session through the parser to the same totals', () => {
+    const startedAt = new Date('2026-06-10T07:30:00.000Z');
+    const activity: TcxExportActivity = {
+      startedAt,
+      sport: 'Running',
+      laps: [{ durationSec: 1800, distanceM: 5000, avgHr: 152 }],
+    };
+
+    const xml = serializeTcx(activity);
+    const parsed = parseTcx(xml);
+
+    expect(parsed.ok).toBe(true);
+    expect(parsed.activity).not.toBeNull();
+    expect(parsed.activity!.durationSec).toBe(1800);
+    expect(parsed.activity!.distanceM).toBe(5000);
+    expect(parsed.activity!.avgHr).toBe(152);
+    expect(parsed.activity!.sport).toBe('Running');
+    expect(parsed.activity!.startedAt.toISOString()).toBe(startedAt.toISOString());
+  });
+
+  it('round-trips multiple laps, summing duration/distance (HR duration-weighted)', () => {
+    const activity: TcxExportActivity = {
+      startedAt: new Date('2026-06-10T07:30:00.000Z'),
+      sport: 'Biking',
+      laps: [
+        { durationSec: 1200, distanceM: 3000, avgHr: 150 },
+        { durationSec: 600, distanceM: 2000, avgHr: 150 },
+      ],
+    };
+    const parsed = parseTcx(serializeTcx(activity));
+    expect(parsed.ok).toBe(true);
+    expect(parsed.activity!.durationSec).toBe(1800);
+    expect(parsed.activity!.distanceM).toBe(5000);
+    expect(parsed.activity!.avgHr).toBe(150);
+    expect(parsed.activity!.sport).toBe('Biking');
+  });
+
+  it('omits distance and HR for a duration-only set and still parses', () => {
+    const activity: TcxExportActivity = {
+      startedAt: new Date('2026-06-10T07:30:00.000Z'),
+      sport: 'Other',
+      laps: [{ durationSec: 900, distanceM: null, avgHr: null }],
+    };
+    const xml = serializeTcx(activity);
+    expect(xml).not.toContain('DistanceMeters');
+    expect(xml).not.toContain('AverageHeartRateBpm');
+    const parsed = parseTcx(xml);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.activity!.durationSec).toBe(900);
+    expect(parsed.activity!.distanceM).toBeNull();
+    expect(parsed.activity!.avgHr).toBeNull();
+  });
+
+  it('emits no DTD or entity declaration', () => {
+    const xml = serializeTcx({
+      startedAt: new Date('2026-06-10T07:30:00.000Z'),
+      sport: 'Running',
+      laps: [{ durationSec: 60, distanceM: 100, avgHr: null }],
+    });
+    expect(xml.toUpperCase()).not.toContain('<!DOCTYPE');
+    expect(xml.toUpperCase()).not.toContain('<!ENTITY');
+  });
+});

--- a/lib/import/tcx-export.ts
+++ b/lib/import/tcx-export.ts
@@ -1,0 +1,95 @@
+import type { TcxSport } from '@/lib/import/tcx';
+
+// ============================================================
+// TCX activity file serializer (issue #175) - pure, no DB
+// ============================================================
+// The outbound half of data ownership: a finished cardio session out as a
+// minimal, valid TCX 1.0/2.0 Activity that Strava and analysis tools accept.
+// One <Lap> per cardio set (TotalTimeSeconds / DistanceMeters /
+// AverageHeartRateBpm), no GPS Trackpoints - totals alone are enough.
+//
+// SECURITY: we only ever emit a FIXED minimal structure - no DTD, no DOCTYPE,
+// no external entities, no processing instructions beyond the XML declaration.
+// Every text value we interpolate (even though TCX here carries only numbers
+// and ISO timestamps) is passed through xmlEscape so a hostile note/name or a
+// future free-text field can never break out of its element or inject markup.
+
+// One cardio set's totals. distanceM/avgHr are omitted when absent (a
+// duration-only erg set has no distance; a watch may not record heart rate).
+export interface TcxExportLap {
+  durationSec: number;
+  distanceM: number | null;
+  avgHr: number | null;
+}
+
+export interface TcxExportActivity {
+  // Activity start (the <Id> and first lap StartTime). Serialized as ISO 8601.
+  startedAt: Date;
+  sport: TcxSport;
+  laps: TcxExportLap[];
+}
+
+// Neutralizes the five XML metacharacters so no emitted text can break the
+// document. '&' must be replaced first so the entities we introduce are not
+// themselves re-escaped.
+export function xmlEscape(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+// Maps our stored exercise name to the TCX Sport attribute. This is the
+// inverse of tcxExerciseName (the import's sport -> name mapping): 'Running'
+// -> Running, 'Cycling' -> Biking, everything else -> Other. Case-insensitive
+// on the known names so a manually renamed exercise still maps sensibly.
+export function sportForExerciseName(name: string): TcxSport {
+  const normalized = name.trim().toLowerCase();
+  if (normalized === 'running') return 'Running';
+  if (normalized === 'cycling') return 'Biking';
+  return 'Other';
+}
+
+function lapXml(lap: TcxExportLap, startTime: string): string {
+  // TotalTimeSeconds is required; DistanceMeters and the HR block are emitted
+  // only when present. Intensity=Active and a Manual trigger keep the lap
+  // valid for strict consumers without inventing data.
+  const lines: string[] = [];
+  lines.push(`      <Lap StartTime="${xmlEscape(startTime)}">`);
+  lines.push(`        <TotalTimeSeconds>${lap.durationSec}</TotalTimeSeconds>`);
+  if (lap.distanceM != null && lap.distanceM > 0) {
+    lines.push(`        <DistanceMeters>${lap.distanceM}</DistanceMeters>`);
+  }
+  if (lap.avgHr != null) {
+    lines.push('        <AverageHeartRateBpm>');
+    lines.push(`          <Value>${lap.avgHr}</Value>`);
+    lines.push('        </AverageHeartRateBpm>');
+  }
+  lines.push('        <Intensity>Active</Intensity>');
+  lines.push('        <TriggerMethod>Manual</TriggerMethod>');
+  lines.push('      </Lap>');
+  return lines.join('\n');
+}
+
+// Serializes one cardio session to a TCX document string. The structure is
+// fixed; only numeric totals and the ISO start timestamp vary. Every laps'
+// StartTime reuses the activity start (we do not store per-lap clock times),
+// which is valid and round-trips through the parser to the same totals.
+export function serializeTcx(activity: TcxExportActivity): string {
+  const startIso = xmlEscape(activity.startedAt.toISOString());
+  const sport = xmlEscape(activity.sport);
+  const laps = activity.laps.map((lap) => lapXml(lap, activity.startedAt.toISOString())).join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<TrainingCenterDatabase xmlns="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2">
+  <Activities>
+    <Activity Sport="${sport}">
+      <Id>${startIso}</Id>
+${laps}
+    </Activity>
+  </Activities>
+</TrainingCenterDatabase>
+`;
+}

--- a/tests/integration/cardio-tcx-route.test.ts
+++ b/tests/integration/cardio-tcx-route.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { db } from '@/lib/db';
+import { getCurrentUserId } from '@/lib/auth';
+import { parseTcx } from '@/lib/import/tcx';
+
+// TCX export route (issue #175): ownership-scoped, cardio-only, and the emitted
+// document round-trips through the existing parser to the same totals.
+
+vi.mock('@/lib/auth', () => ({ getCurrentUserId: vi.fn() }));
+const mockUserId = vi.mocked(getCurrentUserId);
+
+import { GET as getTcx } from '@/app/api/cardio/tcx/route';
+
+function actAs(userId: string) {
+  mockUserId.mockResolvedValue(userId);
+}
+
+async function getFor(sessionId: string | null) {
+  const url = sessionId
+    ? `http://test.local/api/cardio/tcx?sessionId=${sessionId}`
+    : 'http://test.local/api/cardio/tcx';
+  return getTcx(new Request(url));
+}
+
+async function makeUser(email: string) {
+  return db.user.create({ data: { email, passwordHash: 'x' } });
+}
+
+beforeEach(() => {
+  mockUserId.mockReset();
+});
+
+describe('GET /api/cardio/tcx (issue #175)', () => {
+  it('exports a cardio session that round-trips through the parser', async () => {
+    const user = await makeUser('tcx-export@test.dev');
+    const running = await db.exercise.create({
+      data: { userId: user.id, name: 'Running', muscleGroup: 'OTHER', category: 'CARDIO' },
+    });
+    const session = await db.session.create({
+      data: {
+        userId: user.id,
+        startedAt: new Date('2026-06-01T10:00:00.000Z'),
+        finishedAt: new Date('2026-06-01T10:30:00.000Z'),
+      },
+    });
+    await db.set.create({
+      data: {
+        sessionId: session.id,
+        exerciseId: running.id,
+        setNumber: 1,
+        weight: 0,
+        reps: 1,
+        durationSec: 1800,
+        distanceM: 5000,
+        avgHr: 152,
+      },
+    });
+
+    actAs(user.id);
+    const res = await getFor(session.id);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Disposition')).toContain('gymcoach-2026-06-01.tcx');
+
+    const parsed = parseTcx(await res.text());
+    expect(parsed.ok).toBe(true);
+    expect(parsed.activity!.durationSec).toBe(1800);
+    expect(parsed.activity!.distanceM).toBe(5000);
+    expect(parsed.activity!.avgHr).toBe(152);
+    expect(parsed.activity!.sport).toBe('Running');
+  });
+
+  it("returns 404 for another user's session (ownership-scoped, no leak)", async () => {
+    const owner = await makeUser('tcx-owner@test.dev');
+    const running = await db.exercise.create({
+      data: { userId: owner.id, name: 'Running', muscleGroup: 'OTHER', category: 'CARDIO' },
+    });
+    const session = await db.session.create({
+      data: { userId: owner.id, startedAt: new Date('2026-06-02T10:00:00.000Z') },
+    });
+    await db.set.create({
+      data: {
+        sessionId: session.id,
+        exerciseId: running.id,
+        setNumber: 1,
+        weight: 0,
+        reps: 1,
+        durationSec: 1200,
+        distanceM: 3000,
+      },
+    });
+
+    const stranger = await makeUser('tcx-stranger@test.dev');
+    actAs(stranger.id);
+    const res = await getFor(session.id);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 for a session with no cardio sets', async () => {
+    const user = await makeUser('tcx-strength@test.dev');
+    const bench = await db.exercise.create({
+      data: { userId: user.id, name: 'Bench', muscleGroup: 'CHEST', category: 'COMPOUND' },
+    });
+    const session = await db.session.create({
+      data: { userId: user.id, startedAt: new Date('2026-06-03T10:00:00.000Z') },
+    });
+    await db.set.create({
+      data: { sessionId: session.id, exerciseId: bench.id, setNumber: 1, weight: 100, reps: 5 },
+    });
+
+    actAs(user.id);
+    const res = await getFor(session.id);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when sessionId is missing', async () => {
+    const user = await makeUser('tcx-nosid@test.dev');
+    actAs(user.id);
+    const res = await getFor(null);
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
The outbound half of file-based data ownership: export a finished cardio session as a TCX file that Strava and analysis tools accept.

## What changed
- `lib/import/tcx-export.ts`: pure serializer emitting a fixed minimal TCX 1.0 Activity (one `<Lap>` per cardio set, no GPS trackpoints, no DTD/entities). `xmlEscape` neutralizes the five XML metacharacters on every interpolated value; `sportForExerciseName` is the inverse of the import's sport<->name mapping.
- `GET /api/cardio/tcx?sessionId=...`: ownership-scoped exactly like the CSV export (foreign session -> 404, never another user's data); 400 on a session with no cardio sets and on a missing sessionId.
- A "Download .tcx" action on the finished-session detail page (`app/(app)/history/[id]`), shown only when the session has at least one cardio set.

### Note on the surface
The issue named `app/(app)/session/[id]` for the button, but that route redirects finished sessions to home; the detail view that renders a completed session is `app/(app)/history/[id]`, so the download action landed there (the issue's clear intent: download a completed cardio session from its detail view).

## How I tested
- `bash scripts/verify.sh --full` passed (lint + typecheck + unit + build + integration + E2E) - this is a complex change (new route + new surface), so the full tier ran before the PR.
- Round-trip test: `serializeTcx` -> `parseTcx` yields identical duration/distance/avgHr (one-lap and multi-lap). `xmlEscape` unit tests cover all five metacharacters and a markup-injection attempt. Integration tests pin ownership (404), cardio-only (400), missing-sessionId (400), and a round trip through the route.

This run's autonomy-log entry (covering #176/#177/#175) rides in this PR.

Closes #175