### PR TITLE
chore: harden the TCX serializer and gate the export button on a finished session

### DIFF
--- a/app/(app)/history/[id]/page.tsx
+++ b/app/(app)/history/[id]/page.tsx
@@ -83,9 +83,11 @@ export default async function HistorySessionPage({ params }: Params) {
   );
   const volume = totalVolume(enrichedAllSets);
   const workingSetCount = session.sets.filter((s) => !s.isWarmup).length;
-  // TCX export (issue #175) is offered only when the session has cardio sets;
-  // the route 400s otherwise, so the button must mirror that condition.
-  const hasCardio = session.sets.some((s) => s.durationSec != null);
+  // TCX export (issue #175) is offered only for a FINISHED session that has
+  // cardio sets; the route 400s on a cardio-less session, and an in-progress
+  // session (reachable only by direct URL here) is not a complete export.
+  const hasCardio =
+    session.finishedAt != null && session.sets.some((s) => s.durationSec != null);
   const durationMin =
     session.finishedAt && session.startedAt
       ? Math.round((session.finishedAt.getTime() - session.startedAt.getTime()) / 60000)

--- a/lib/import/tcx-export.test.ts
+++ b/lib/import/tcx-export.test.ts
@@ -93,4 +93,20 @@ describe('serializeTcx round-trip', () => {
     expect(xml.toUpperCase()).not.toContain('<!DOCTYPE');
     expect(xml.toUpperCase()).not.toContain('<!ENTITY');
   });
+
+  it('never emits non-finite numbers or a zero HR (defensive)', () => {
+    const xml = serializeTcx({
+      startedAt: new Date('2026-06-10T07:30:00.000Z'),
+      sport: 'Running',
+      laps: [
+        { durationSec: Number.NaN, distanceM: Number.POSITIVE_INFINITY, avgHr: 0 },
+      ],
+    });
+    expect(xml).not.toContain('NaN');
+    expect(xml).not.toContain('Infinity');
+    // Distance is dropped (non-finite) and the HR block is omitted (avgHr 0).
+    expect(xml).not.toContain('DistanceMeters');
+    expect(xml).not.toContain('AverageHeartRateBpm');
+    expect(xml).toContain('<TotalTimeSeconds>0</TotalTimeSeconds>');
+  });
 });

--- a/lib/import/tcx-export.ts
+++ b/lib/import/tcx-export.ts
@@ -58,11 +58,18 @@ function lapXml(lap: TcxExportLap, startTime: string): string {
   // valid for strict consumers without inventing data.
   const lines: string[] = [];
   lines.push(`      <Lap StartTime="${xmlEscape(startTime)}">`);
-  lines.push(`        <TotalTimeSeconds>${lap.durationSec}</TotalTimeSeconds>`);
-  if (lap.distanceM != null && lap.distanceM > 0) {
+  // Defensive: only finite numbers reach the document, so a NaN/Infinity that
+  // ever slipped past the upstream write schema can never emit invalid TCX
+  // (the schemas already bound these; this keeps the serializer correct on
+  // its own).
+  const duration = Number.isFinite(lap.durationSec) ? lap.durationSec : 0;
+  lines.push(`        <TotalTimeSeconds>${duration}</TotalTimeSeconds>`);
+  if (lap.distanceM != null && Number.isFinite(lap.distanceM) && lap.distanceM > 0) {
     lines.push(`        <DistanceMeters>${lap.distanceM}</DistanceMeters>`);
   }
-  if (lap.avgHr != null) {
+  // A HeartRateBpm Value of 0 is invalid TCX; emit the block only for a real
+  // positive reading (symmetric with the distance gate above).
+  if (lap.avgHr != null && Number.isFinite(lap.avgHr) && lap.avgHr > 0) {
     lines.push('        <AverageHeartRateBpm>');
     lines.push(`          <Value>${lap.avgHr}</Value>`);
     lines.push('        </AverageHeartRateBpm>');


### PR DESCRIPTION
Tightens the three actionable NITs from the independent review of #181 (TCX export), all non-blocking and unreachable today but cheap correctness/robustness wins:
- serializer guards TotalTimeSeconds/DistanceMeters/avgHr with Number.isFinite (a NaN/Infinity that ever slipped the write schema can no longer emit invalid TCX)
- HR block emitted only for avgHr > 0 (a zero Value is invalid TCX; symmetric with the distance gate)
- history Download .tcx button now requires finishedAt, matching the documented finished-session contract
- defensive serializer test added

bash scripts/verify.sh - GREEN-GATE PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)