### PR TITLE
docs: write up the cardio-axis batch (TCX export, last-time, pace/speed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   single field of the set logger to fill the weight, reps, and effort fields
   (RPE maps to the stored RIR). Deterministic parser in the user's display
   unit; the classic fields keep working unchanged.
+- Export a cardio session as a TCX file: download a finished cardio session
+  (duration, distance, average heart rate) as a standard .tcx you can import
+  into Strava or any analysis tool - the outbound half of file-based data
+  ownership, no cloud account or OAuth. It round-trips back through the
+  importer to the same numbers.
+- Cardio "last time" in the session: starting a cardio exercise now shows
+  your last session's duration, distance, and average heart rate - the
+  cardio counterpart of the strength last-performance reference (it was
+  previously hidden for cardio).
+- Pace and speed on cardio: the session summary and history now show derived
+  pace (min/km or /mi) and speed (km/h or mph) for cardio sets with a
+  distance, in your unit.
 - Complete backup export/restore: the JSON backup now round-trips every
   piece of your data - cardio duration/distance/heart rate, supersets,
   per-exercise goals, bodyweight history, readiness check-ins, and coach

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -1206,3 +1206,17 @@ continuously, no per-change approval, self-challenge with subagents, keep a roll
 
 **Next.** Merge #9 once green; then work the backlog (#4 seed catalog, #5 empty states,
 #1 imperial units), each subagent-challenged before merge per the protocol.
+
+---
+
+## 2026-06-13 - Cardio axis closed out (#175/#176/#177); model note + three CLEAN reviews
+
+**Context.** Eighth ideate batch (#175 TCX export, #176 cardio last-time, #177 pace/speed) implemented and shipped. Operator switched the default model to Opus 4.8; the Fable model then became unavailable to subagents, so this cycle's dev tick ran on the inherited Opus (the Fable-for-dev routing is moot while Fable is inaccessible) - noted so a future run does not treat the routing as broken.
+
+**Decided / shipped.**
+- #179/#180/#181 merged on green full CI; all three independent Opus reviews CLEAN (the #181 TCX-export review attacked escaping/ownership/2000-lap perf and the round trip - all held; the #180 pace/speed math was re-derived independently). Three NITs on #181 (unreachable non-finite/zero-HR emission, finished-session button gate) hardened in #182; one pre-existing cross-cutting NIT (history cardio totals include warmups) filed as #183.
+- The cardio axis is now closed in and out: TCX/CSV import -> first-class cardio logging with a last-time reference -> pace/speed + conditioning analytics -> TCX/CSV export. This is the file-based neutral ground the 2026-06-12 research identified as the hybrid-athlete white space.
+
+**Challenged.** Two parallel Opus reviews (one security-lensed). Accepted-change rate: 4 merged / 0 abandoned (+ docs).
+
+**Deferred to human.** #169 (Next.js 14->15 major bump) still stop-for-human, untouched. Future: #183 (warmup totals), supersets slice 2, coach-context annotation.

--- a/docs/loops/ideas-backlog.md
+++ b/docs/loops/ideas-backlog.md
@@ -40,6 +40,6 @@ research and the product wedge). See `docs/loops/08-ideation-loop.md` for how th
 - shipped - per-day conditioning + interference guidance (issue #153, 2026-06-12, PR #157) - review CLEAN; daily window aligned to the strength week at the UTC instant
 - shipped - 'What your coach sees' transparency card (issue #154, 2026-06-12, PR #156 + fix #162) - review found the footer overclaimed privacy; reworded to the truth same-day
 - rejected - OAuth cloud integrations (Garmin/Strava/Apple Health), watch companion / rep auto-counting, black-box auto-push program generator, nutrition/macro tracking, real-time GPS recorder (2026-06-12 research anti-recommendations) - recorded so future runs never propose them
-- proposed - export a cardio session as a TCX file (issue #175, 2026-06-13) - the outbound half of the data-ownership wedge (research opp #4); pure serializer, round-trips through the tcx.ts parser
-- proposed - show last-time cardio performance in the session (issue #176, 2026-06-13) - cardio counterpart of the loved strength last-performance, currently gated off by !isCardio; display-only
-- proposed - cardio pace and speed (derived) on the session summary and history (issue #177, 2026-06-13) - pure lib/cardio.ts derivation, the number runners actually train on; display-only, unit-aware
+- shipped - export a cardio session as a TCX file (issue #175, 2026-06-13, PR #181 + hardening #182) - the outbound data-ownership half; hostile review CLEAN (escaping + ownership), round-trips through the parser
+- shipped - show last-time cardio performance in the session (issue #176, 2026-06-13, PR #179) - review CLEAN; ungated the cardio branch, HR averaged
+- shipped - cardio pace and speed (derived) on the session summary and history (issue #177, 2026-06-13, PR #180) - review CLEAN, math re-derived; warmup-totals inconsistency filed as #183


### PR DESCRIPTION
Content-loop tail for the cardio-axis batch (#175 TCX export, #176 cardio last-time, #177 pace/speed) and the #182 hardening.

- CHANGELOG: all three are user-facing (TCX export headlined as the outbound data-ownership half).
- Backlog: shipped with the three CLEAN independent review verdicts; #183 (pre-existing warmup-totals inconsistency) recorded.
- Journal: notes the cardio axis is now closed in and out, plus that Fable became unavailable to subagents so the dev tick ran on inherited Opus.
- Media untouched: the session/history pages that changed are not among the four captured screenshots, and no recorded clip exercises cardio.

bash scripts/verify.sh - GREEN-GATE PASSED.

After merge: triggering deploy-demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)