### PR TITLE
fix: exclude warmup sets from the history cardio totals

### DIFF
--- a/app/(app)/history/[id]/page.tsx
+++ b/app/(app)/history/[id]/page.tsx
@@ -8,7 +8,7 @@ import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { MUSCLE_GROUP_LABELS } from '@/lib/schemas/exercise';
 import { applyBodyweight, best1RM, totalVolume } from '@/lib/stats';
-import { formatCardioSet, formatDistance, formatDuration, formatPace, formatSpeed } from '@/lib/cardio';
+import { formatCardioSet, formatDistance, formatDuration, formatPace, formatSpeed, sumCardioWorkingSets } from '@/lib/cardio';
 import { formatWeight } from '@/lib/units';
 import { DeleteSessionButton } from '@/components/history/delete-session-button';
 
@@ -193,17 +193,12 @@ export default async function HistorySessionPage(props: Params) {
               );
               const exoVolume = totalVolume(enrichedExoSets);
               const e1rm = best1RM(enrichedExoSets);
-              // Cardio recap (issue #133): totals across the logged sets, with
+              // Cardio recap (issue #133): totals across the WORKING sets, with
               // derived pace and speed (issue #177) appended when a distance was
-              // covered (omitted for duration-only cardio).
-              const cardioDurationTotal = entry.sets.reduce(
-                (acc, s) => acc + (s.durationSec ?? 0),
-                0,
-              );
-              const cardioDistanceTotal = entry.sets.reduce(
-                (acc, s) => acc + (s.distanceM ?? 0),
-                0,
-              );
+              // covered (omitted for duration-only cardio). Warmups are excluded
+              // (issue #183), matching the working-set convention used elsewhere.
+              const { durationSec: cardioDurationTotal, distanceM: cardioDistanceTotal } =
+                sumCardioWorkingSets(entry.sets);
               const cardioTotal = isCardio
                 ? [
                     formatCardioSet(cardioDurationTotal, cardioDistanceTotal),

--- a/lib/cardio.test.ts
+++ b/lib/cardio.test.ts
@@ -10,6 +10,7 @@ import {
   paceSecPerKm,
   parseDurationToSec,
   speedKmh,
+  sumCardioWorkingSets,
 } from './cardio';
 
 describe('isCardioSet', () => {
@@ -137,5 +138,25 @@ describe('formatSpeed', () => {
   it('returns null when there is no distance', () => {
     expect(formatSpeed(1800, 0, 'KG')).toBeNull();
     expect(formatSpeed(1800, null, 'LB')).toBeNull();
+  });
+});
+
+describe('sumCardioWorkingSets (issue #183)', () => {
+  it('excludes warmup sets from the duration and distance totals', () => {
+    const sets = [
+      { durationSec: 300, distanceM: 800, isWarmup: true }, // warmup, excluded
+      { durationSec: 1800, distanceM: 5000, isWarmup: false },
+      { durationSec: 600, distanceM: 2000, isWarmup: false },
+    ];
+    expect(sumCardioWorkingSets(sets)).toEqual({ durationSec: 2400, distanceM: 7000 });
+  });
+
+  it('treats absent duration/distance as 0 and handles an all-warmup list', () => {
+    expect(
+      sumCardioWorkingSets([{ durationSec: 1800, distanceM: null, isWarmup: false }]),
+    ).toEqual({ durationSec: 1800, distanceM: 0 });
+    expect(
+      sumCardioWorkingSets([{ durationSec: 300, distanceM: 800, isWarmup: true }]),
+    ).toEqual({ durationSec: 0, distanceM: 0 });
   });
 });

--- a/lib/cardio.ts
+++ b/lib/cardio.ts
@@ -27,6 +27,23 @@ export function isCardioSet(set: { durationSec?: number | null }): boolean {
   return set.durationSec != null;
 }
 
+// Sums duration and distance over the WORKING sets only (warmups excluded),
+// matching the working-set / last-performance convention used everywhere else
+// (issue #183). Used for the per-exercise cardio recap totals.
+export function sumCardioWorkingSets(
+  sets: { durationSec?: number | null; distanceM?: number | null; isWarmup: boolean }[],
+): { durationSec: number; distanceM: number } {
+  return sets
+    .filter((s) => !s.isWarmup)
+    .reduce(
+      (acc, s) => ({
+        durationSec: acc.durationSec + (s.durationSec ?? 0),
+        distanceM: acc.distanceM + (s.distanceM ?? 0),
+      }),
+      { durationSec: 0, distanceM: 0 },
+    );
+}
+
 // Parses a user-typed duration into seconds. Accepted formats:
 //   "mm:ss"    -> minutes and seconds (e.g. "12:30")
 //   "h:mm:ss"  -> hours, minutes, seconds (e.g. "1:05:00")


### PR DESCRIPTION
Closes #183 (pre-existing inconsistency found by the #179/#180 review). History cardio totals (and the derived pace/speed) now exclude warmup sets via a shared sumCardioWorkingSets helper, matching the working-set convention used everywhere else; unit test pins the exclusion.

bash scripts/verify.sh - GREEN-GATE PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)