### PR TITLE
docs: log the ninth ideate batch (#188/#189/#190)

### DIFF
--- a/docs/loops/ideas-backlog.md
+++ b/docs/loops/ideas-backlog.md
@@ -43,3 +43,6 @@ research and the product wedge). See `docs/loops/08-ideation-loop.md` for how th
 - shipped - export a cardio session as a TCX file (issue #175, 2026-06-13, PR #181 + hardening #182) - the outbound data-ownership half; hostile review CLEAN (escaping + ownership), round-trips through the parser
 - shipped - show last-time cardio performance in the session (issue #176, 2026-06-13, PR #179) - review CLEAN; ungated the cardio branch, HR averaged
 - shipped - cardio pace and speed (derived) on the session summary and history (issue #177, 2026-06-13, PR #180) - review CLEAN, math re-derived; warmup-totals inconsistency filed as #183
+- proposed - a free-text note to your coach (correctable AI memory) (issue #188, 2026-06-13) - research opp #3 (praised AI = correctable memory); additive User.coachNote, input-side payload, output contract unchanged
+- proposed - supersets slice 2: superset-aware rest timer (issue #189, 2026-06-13) - completes #146; short rest between A1/A2, full after the group; presentation/timer only, no logging change
+- proposed - a Records board (all-time bests per exercise) on the progress page (issue #190, 2026-06-13) - pure derivation over best1RM/max weight; the motivating PR board, display-only


### PR DESCRIPTION
Records the 2026-06-13 ideate run (#188 coach note, #189 superset-aware rest, #190 Records board). Deliberately not filed: mobility session type (research low-confidence), soreness trend (lower value than the three filed), Serwist migration (build-time chore, not product). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)