### PR TITLE
feat: a Records board - all-time bests per exercise on the progress page

### DIFF
--- a/app/(app)/progress/page.tsx
+++ b/app/(app)/progress/page.tsx
@@ -7,6 +7,7 @@ import {
   applyBodyweight,
   best1RM,
   classifyWeeklySets,
+  effectiveWeight,
   exerciseProgress,
   isStalled,
   isoWeekKey,
@@ -23,11 +24,13 @@ import {
   isDeloadActive,
   recommendDeload,
 } from '@/lib/deload';
+import { exerciseRecords } from '@/lib/records';
 import { ProgressDashboard } from '@/components/progress/progress-dashboard';
 import { ConsistencyCard } from '@/components/progress/consistency-card';
 import { DeloadBanner } from '@/components/progress/deload-banner';
 import { BodyweightCard } from '@/components/progress/bodyweight-card';
 import { ConditioningCard } from '@/components/progress/conditioning-card';
+import { RecordsCard } from '@/components/progress/records-card';
 
 interface SearchParams {
   exerciseId?: string;
@@ -324,6 +327,38 @@ export default async function ProgressPage(
       )
     : null;
 
+  // Records board (issue #190, display-only): all-time bests per strength
+  // exercise over the user's full set history (not just the 12-week window).
+  // Cardio is excluded at the query (category != CARDIO); warm-ups are excluded
+  // both here and in the derivation. Bodyweight-effective load is applied so a
+  // bodyweight movement's records read on the load actually moved, consistent
+  // with every other load aggregation on this page.
+  const recordSetsRaw = await db.set.findMany({
+    where: {
+      isWarmup: false,
+      session: { userId: auth.userId },
+      exercise: { category: { not: 'CARDIO' } },
+    },
+    select: {
+      weight: true,
+      reps: true,
+      isWarmup: true,
+      durationSec: true,
+      exercise: { select: { name: true, usesBodyweight: true } },
+      session: { select: { startedAt: true } },
+    },
+  });
+  const records = exerciseRecords(
+    recordSetsRaw.map((s) => ({
+      weight: effectiveWeight(s.weight, s.exercise.usesBodyweight, bodyweight),
+      reps: s.reps,
+      isWarmup: s.isWarmup,
+      durationSec: s.durationSec,
+      exerciseName: s.exercise.name,
+      sessionStartedAt: s.session.startedAt,
+    })),
+  );
+
   const deload = recommendDeload({
     stalledExerciseNames: recap
       .filter((r) => r.stalled)
@@ -412,6 +447,9 @@ export default async function ProgressPage(
               selectedBestE1RM={selectedBestE1RM}
               selectedUsesBodyweight={selectedUsesBodyweight}
             />
+            {records.length > 0 && (
+              <RecordsCard records={records} unit={unit} />
+            )}
           </>
         )}
       </div>

--- a/components/progress/records-card.tsx
+++ b/components/progress/records-card.tsx
@@ -1,0 +1,85 @@
+import { Trophy } from 'lucide-react';
+import type { WeightUnit } from '@prisma/client';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { formatWeight } from '@/lib/units';
+
+// One exercise's all-time bests, serialized at the Server Component boundary.
+// Weights are stored in kg (bodyweight-effective load already applied upstream)
+// and formatted into the user's unit here. Dates are ISO day strings.
+export interface ExerciseRecordView {
+  exerciseName: string;
+  maxWeight: number;
+  maxWeightReps: number;
+  maxWeightDate: string;
+  bestE1RM: number;
+  bestE1RMDate: string;
+}
+
+interface Props {
+  records: ExerciseRecordView[];
+  unit: WeightUnit;
+}
+
+function formatDay(iso: string): string {
+  // "2026-02-01" -> "Feb 1, 2026". Parsed as UTC so the day never shifts.
+  return new Intl.DateTimeFormat('en-US', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(`${iso}T00:00:00.000Z`));
+}
+
+// Records board (issue #190, display-only): per strength exercise, the heaviest
+// working set ever and the best estimated 1RM ever, each with the date it was
+// reached. Pure derivation from existing set history (lib/records
+// exerciseRecords) - no schema, API, or prompt change. Cardio and warm-ups are
+// excluded upstream. Hidden by the parent until there is at least one record.
+export function RecordsCard({ records, unit }: Props) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center gap-2">
+          <Trophy className="size-4 text-amber-500" />
+          <h2 className="text-base font-semibold">Records</h2>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          All-time bests per exercise: heaviest working set and best estimated
+          1RM (Epley).
+        </p>
+      </CardHeader>
+      <CardContent>
+        <ul className="flex flex-col divide-y divide-border" role="list">
+          {records.map((r) => (
+            <li
+              key={r.exerciseName}
+              className="flex flex-col gap-1 py-3 first:pt-0 last:pb-0"
+            >
+              <span className="text-sm font-semibold">{r.exerciseName}</span>
+              <div className="flex flex-wrap gap-x-6 gap-y-1 text-xs text-muted-foreground">
+                <span>
+                  Heaviest:{' '}
+                  <span className="font-medium text-foreground tabular-nums">
+                    {formatWeight(r.maxWeight, unit)} x {r.maxWeightReps}
+                  </span>{' '}
+                  <span className="text-muted-foreground">
+                    ({formatDay(r.maxWeightDate)})
+                  </span>
+                </span>
+                <span>
+                  Best 1RM:{' '}
+                  <span className="font-medium text-foreground tabular-nums">
+                    {formatWeight(r.bestE1RM, unit)}
+                  </span>{' '}
+                  <span className="text-muted-foreground">
+                    ({formatDay(r.bestE1RMDate)})
+                  </span>
+                </span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/lib/records.test.ts
+++ b/lib/records.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { detectPRs, isPR } from './records';
+import { detectPRs, isPR, exerciseRecords } from './records';
 
 // Minimal set factory: only the fields the PR detector reads.
 function set(weight: number, reps: number, isWarmup = false) {
@@ -71,6 +71,92 @@ describe('detectPRs - cardio exclusion', () => {
   it('ignores a normalized cardio candidate (weight 0, reps 1)', () => {
     expect(
       detectPRs({ weight: 0, reps: 1, isWarmup: false, durationSec: 750 }, []),
+    ).toEqual([]);
+  });
+});
+
+// Records board (issue #190): all-time bests per exercise.
+describe('exerciseRecords', () => {
+  // Builds a record set; date defaults are spaced so order is unambiguous.
+  function rset(
+    exerciseName: string,
+    weight: number,
+    reps: number,
+    date: string,
+    opts: { isWarmup?: boolean; durationSec?: number | null } = {},
+  ) {
+    return {
+      exerciseName,
+      weight,
+      reps,
+      isWarmup: opts.isWarmup ?? false,
+      durationSec: opts.durationSec ?? null,
+      sessionStartedAt: new Date(`${date}T10:00:00.000Z`),
+    };
+  }
+
+  it('returns the heaviest set and the best e1RM with their dates', () => {
+    const records = exerciseRecords([
+      rset('Squat', 100, 5, '2026-01-01'),
+      rset('Squat', 110, 3, '2026-02-01'), // heaviest load
+      rset('Squat', 95, 10, '2026-03-01'), // best e1RM (~126.7)
+    ]);
+    expect(records).toHaveLength(1);
+    expect(records[0]).toEqual({
+      exerciseName: 'Squat',
+      maxWeight: 110,
+      maxWeightReps: 3,
+      maxWeightDate: '2026-02-01',
+      bestE1RM: +(95 * (1 + 10 / 30)).toFixed(1),
+      bestE1RMDate: '2026-03-01',
+    });
+  });
+
+  it('keeps the earlier date on a tie (strict comparison)', () => {
+    const records = exerciseRecords([
+      rset('Bench', 80, 5, '2026-01-01'),
+      rset('Bench', 80, 5, '2026-02-01'), // identical -> not a new record
+    ]);
+    expect(records[0]!.maxWeightDate).toBe('2026-01-01');
+    expect(records[0]!.bestE1RMDate).toBe('2026-01-01');
+  });
+
+  it('excludes warm-up and cardio sets', () => {
+    const records = exerciseRecords([
+      rset('Deadlift', 200, 1, '2026-01-01', { isWarmup: true }),
+      rset('Deadlift', 60, 5, '2026-01-02'), // only working set
+      rset('Row', 0, 1, '2026-01-03', { durationSec: 600 }), // cardio
+    ]);
+    expect(records).toHaveLength(1);
+    expect(records[0]!.exerciseName).toBe('Deadlift');
+    expect(records[0]!.maxWeight).toBe(60);
+  });
+
+  it('uses the bodyweight-effective load passed by the caller', () => {
+    // The caller has already added bodyweight (e.g. pull-up at +0 -> 80 kg
+    // effective). The record reads that effective load directly.
+    const records = exerciseRecords([rset('Pull-up', 80, 8, '2026-01-01')]);
+    expect(records[0]!.maxWeight).toBe(80);
+    expect(records[0]!.maxWeightReps).toBe(8);
+  });
+
+  it('groups multiple exercises and sorts alphabetically', () => {
+    const records = exerciseRecords([
+      rset('Squat', 140, 3, '2026-01-01'),
+      rset('Bench', 100, 5, '2026-01-01'),
+      rset('Deadlift', 180, 2, '2026-01-01'),
+    ]);
+    expect(records.map((r) => r.exerciseName)).toEqual([
+      'Bench',
+      'Deadlift',
+      'Squat',
+    ]);
+  });
+
+  it('returns an empty board when there is no qualifying set', () => {
+    expect(exerciseRecords([])).toEqual([]);
+    expect(
+      exerciseRecords([rset('Squat', 100, 5, '2026-01-01', { isWarmup: true })]),
     ).toEqual([]);
   });
 });

--- a/lib/records.ts
+++ b/lib/records.ts
@@ -69,3 +69,88 @@ export function detectPRs(candidate: SetLike, history: SetLike[]): PRType[] {
 export function isPR(candidate: SetLike, history: SetLike[]): boolean {
   return detectPRs(candidate, history).length > 0;
 }
+
+// ============================================================
+// Records board (issue #190) - all-time bests per exercise
+// ============================================================
+// A pure derivation over a user's working-set history: for each strength
+// exercise, the heaviest working set ever (weight x reps and its date) and the
+// best estimated 1RM ever (Epley, with its date). Display-only - there is no
+// records table. Cardio sets and warm-ups carry no lifting record and are
+// excluded, consistent with `best1RM` / `setVolume` in lib/stats and the PR
+// detector above.
+//
+// Bodyweight exercises: the caller passes the effective load (entered weight +
+// bodyweight) in `weight`, the same `applyBodyweight` adjustment the progress
+// page uses everywhere else, so a bodyweight movement's records read on the
+// load actually moved rather than the added plates alone.
+
+// A working set decorated with its exercise name and session date. The caller
+// builds these from the rows it already loads for the progress page.
+type RecordSet = Pick<Set, 'weight' | 'reps' | 'isWarmup'> & {
+  durationSec?: number | null;
+  exerciseName: string;
+  sessionStartedAt: Date;
+};
+
+// The all-time bests for one exercise.
+export interface ExerciseRecord {
+  exerciseName: string;
+  maxWeight: number;
+  maxWeightReps: number; // reps of the heaviest set
+  maxWeightDate: string; // ISO date (YYYY-MM-DD) the heaviest set was logged
+  bestE1RM: number; // rounded to 1 decimal, like exerciseProgress
+  bestE1RMDate: string; // ISO date of the set with the best estimated 1RM
+}
+
+function isoDay(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+// Given a flat list of (bodyweight-adjusted) working sets across exercises,
+// returns one record per strength exercise, sorted alphabetically by exercise
+// name (stable and predictable for a board the user scans by lift). Warm-ups,
+// cardio sets, and sets with a non-positive load or reps are ignored; an
+// exercise with no qualifying set yields no row. Ties keep the earliest set
+// (the date the record was first reached).
+export function exerciseRecords(sets: RecordSet[]): ExerciseRecord[] {
+  const byExercise = new Map<string, ExerciseRecord>();
+
+  for (const s of sets) {
+    if (s.isWarmup || s.durationSec != null || s.weight <= 0 || s.reps <= 0) {
+      continue;
+    }
+
+    const e1rm = +estimate1RM(s.weight, s.reps).toFixed(1);
+    const day = isoDay(s.sessionStartedAt);
+    const current = byExercise.get(s.exerciseName);
+
+    if (!current) {
+      byExercise.set(s.exerciseName, {
+        exerciseName: s.exerciseName,
+        maxWeight: s.weight,
+        maxWeightReps: s.reps,
+        maxWeightDate: day,
+        bestE1RM: e1rm,
+        bestE1RMDate: day,
+      });
+      continue;
+    }
+
+    // Strictly heavier load wins the weight record; a tie keeps the earlier
+    // date already stored (we only overwrite on a strict improvement).
+    if (s.weight > current.maxWeight) {
+      current.maxWeight = s.weight;
+      current.maxWeightReps = s.reps;
+      current.maxWeightDate = day;
+    }
+    if (e1rm > current.bestE1RM) {
+      current.bestE1RM = e1rm;
+      current.bestE1RMDate = day;
+    }
+  }
+
+  return [...byExercise.values()].sort((a, b) =>
+    a.exerciseName.localeCompare(b.exerciseName),
+  );
+}


### PR DESCRIPTION
## Summary

Adds a display-only **Records** board to the progress page: per strength exercise, the heaviest working set ever (weight x reps and the date) and the best estimated 1RM ever (Epley, with the date).

- New `exerciseRecords` derivation in `lib/records.ts` (pure, colocated unit tests). One row per strength exercise; warm-ups, cardio, and non-positive load/reps excluded - consistent with the PR/stats exclusion contract.
- Bodyweight exercises use the same effective-load (`effectiveWeight`) semantics as the rest of the page (the caller applies it before grouping).
- Sorted alphabetically; ties keep the earlier date. The card hides until there is at least one record (empty state already handled by the page's overall empty state).
- No schema, API, or prompt change; one bounded extra query over the user's full set history.

Closes #190

## How I tested

- `bash scripts/verify.sh`: prisma generate, lint, typecheck all pass; build passes (`/progress` compiles). The full unit suite passes except `components/session/readiness-checkin.test.tsx > submits a partial soreness map...`, which is a pre-existing local-environment flake (a `userEvent.type` 5s timeout under WSL2): it fails identically on clean `main` with no change applied, and is green in CI on `main`. It does not touch the records code.
- New tests: `lib/records.test.ts` exerciseRecords (17 tests total in the file) - heaviest set, best e1RM, ties, bodyweight effective load, warmup/cardio exclusion, alphabetical grouping, empty board.
- `npx vitest run --exclude '**/readiness-checkin.test.tsx'`: 578 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)