### PR TITLE
fix: make the records tie-break date deterministic (earliest on a tie)

### DIFF
--- a/app/(app)/progress/page.tsx
+++ b/app/(app)/progress/page.tsx
@@ -339,6 +339,11 @@ export default async function ProgressPage(
       session: { userId: auth.userId },
       exercise: { category: { not: 'CARDIO' } },
     },
+    // Oldest first so that on a tie (same load / e1RM) exerciseRecords keeps
+    // the EARLIEST date, matching its documented "first to reach it" behavior:
+    // the reducer keeps the first-seen row, which is only the earliest when the
+    // rows arrive chronologically.
+    orderBy: { session: { startedAt: 'asc' } },
     select: {
       weight: true,
       reps: true,

--- a/lib/records.test.ts
+++ b/lib/records.test.ts
@@ -112,13 +112,26 @@ describe('exerciseRecords', () => {
     });
   });
 
-  it('keeps the earlier date on a tie (strict comparison)', () => {
+  it('keeps the first-seen row on a tie - earliest date when fed oldest-first', () => {
+    // The function keeps the first matching row on a tie (strict comparison),
+    // so the caller must pass sets oldest-first to get the earliest date - the
+    // progress page orders the query by session.startedAt asc for exactly this.
     const records = exerciseRecords([
       rset('Bench', 80, 5, '2026-01-01'),
       rset('Bench', 80, 5, '2026-02-01'), // identical -> not a new record
     ]);
     expect(records[0]!.maxWeightDate).toBe('2026-01-01');
     expect(records[0]!.bestE1RMDate).toBe('2026-01-01');
+  });
+
+  it('is order-dependent on a tie (keeps the first element seen)', () => {
+    // Same two tied sets in REVERSE order: the function keeps the first one it
+    // sees, proving it relies on the caller ordering rows chronologically.
+    const records = exerciseRecords([
+      rset('Bench', 80, 5, '2026-02-01'),
+      rset('Bench', 80, 5, '2026-01-01'),
+    ]);
+    expect(records[0]!.maxWeightDate).toBe('2026-02-01');
   });
 
   it('excludes warm-up and cardio sets', () => {


### PR DESCRIPTION
Closes #195 (the one NIT from the independent review of #192, promoted to a quick fix since it makes a documented behavior actually true).

The records reducer keeps the first-seen row on a tie; the progress-page query had no orderBy, so on an exact tie the date label was non-deterministic. The query now orders by session.startedAt asc (earliest wins), and tests pin both the oldest-first contract and the function's order-dependence.

bash scripts/verify.sh - GREEN-GATE PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)