### PR TITLE
docs: write up batch 9 (coach note, superset rest, records board); seed a demo coach note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   single field of the set logger to fill the weight, reps, and effort fields
   (RPE maps to the stored RIR). Deterministic parser in the user's display
   unit; the classic fields keep working unchanged.
+- A free-text note to your coach: write a short note the AI coach reads -
+  injuries, illness, life constraints - so its advice accounts for your own
+  current context. It is the correctable half of "what your coach sees"; the
+  note is sent as data, never as instructions, and the output contract is
+  unchanged.
+- Records board: an all-time-bests section on the progress page showing your
+  heaviest set and best estimated 1RM for each lift, with dates.
+- Superset rest timer: in a paired (A1/A2) superset the rest is short between
+  the two exercises and full only after the group, instead of a full rest
+  after every set.
 - Export a cardio session as a TCX file: download a finished cardio session
   (duration, distance, average heart rate) as a standard .tcx you can import
   into Strava or any analysis tool - the outbound half of file-based data

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -1290,3 +1290,17 @@ continuously, no per-change approval, self-challenge with subagents, keep a roll
 **Verified (reinforced controls for a major bump).** verify.sh --full green (incl. 10 E2E); production Docker image built + probed locally (login 200, sw.js 200, no client error); CI docker-smoke re-validated the image; demo redeployed and the LIVE Next 15 instance confirmed healthy (login, full progress data, service worker, zero page errors). Lesson L13 records the approach.
 
 **Deferred to human.** None outstanding from #169. A Serwist migration (to clear the build-time workbox advisories) is a possible larger follow-up, not filed.
+
+---
+
+## 2026-06-13 (late) - Batch 9 shipped (#188/#189/#190); 3 CLEAN reviews + one tie-break fix
+
+**Context.** Ninth ideate batch implemented on Opus (Fable still unavailable to subagents): coach note (#188), superset-aware rest (#189), records board (#190).
+
+**Decided / shipped.**
+- #192/#193/#194 merged on green full CI; rollback baseline autonomy-baseline-2026-06-13b tagged before the #194 migration. Three independent Opus reviews: all CLEAN. The #188 review verified the coach note reaches the LLM as JSON DATA (not concatenated into instructions), the <adjustments> contract is byte-identical, and adversarial notes (</adjustments>, "ignore instructions", 501 chars, whitespace) are handled. The #193 timer was proven live via the superset E2E. The #190 review found one NIT (non-deterministic tie-break date, no orderBy) - promoted to fix #195/#196 (query ordered oldest-first; tests pin the contract).
+- The coach note is the correctable-memory differentiator the 2026-06-12 research identified; it pairs with the read-only transparency card (#154).
+
+**Challenged.** Two parallel Opus reviews (one injection-lensed). Accepted-change rate: 4 merged / 0 abandoned this batch.
+
+**Deferred to human.** Nothing outstanding. Future: mobility session type (low confidence), Serwist migration (build-time advisories).

--- a/docs/loops/ideas-backlog.md
+++ b/docs/loops/ideas-backlog.md
@@ -43,6 +43,6 @@ research and the product wedge). See `docs/loops/08-ideation-loop.md` for how th
 - shipped - export a cardio session as a TCX file (issue #175, 2026-06-13, PR #181 + hardening #182) - the outbound data-ownership half; hostile review CLEAN (escaping + ownership), round-trips through the parser
 - shipped - show last-time cardio performance in the session (issue #176, 2026-06-13, PR #179) - review CLEAN; ungated the cardio branch, HR averaged
 - shipped - cardio pace and speed (derived) on the session summary and history (issue #177, 2026-06-13, PR #180) - review CLEAN, math re-derived; warmup-totals inconsistency filed as #183
-- proposed - a free-text note to your coach (correctable AI memory) (issue #188, 2026-06-13) - research opp #3 (praised AI = correctable memory); additive User.coachNote, input-side payload, output contract unchanged
-- proposed - supersets slice 2: superset-aware rest timer (issue #189, 2026-06-13) - completes #146; short rest between A1/A2, full after the group; presentation/timer only, no logging change
-- proposed - a Records board (all-time bests per exercise) on the progress page (issue #190, 2026-06-13) - pure derivation over best1RM/max weight; the motivating PR board, display-only
+- shipped - a free-text note to your coach (correctable AI memory) (issue #188, 2026-06-13, PR #194) - multi-lens review CLEAN incl. injection posture (note is JSON data, not instructions; contract byte-identical)
+- shipped - supersets slice 2: superset-aware rest timer (issue #189, 2026-06-13, PR #193) - review CLEAN, E2E proven live (short between members, full after group)
+- shipped - a Records board (all-time bests per exercise) (issue #190, 2026-06-13, PR #192 + fix #196) - review CLEAN; tie-break date made deterministic

--- a/scripts/seed-demo-history.ts
+++ b/scripts/seed-demo-history.ts
@@ -197,12 +197,16 @@ async function main() {
   }
   await prisma.bodyweightEntry.createMany({ data: bodyweightEntries });
   const lastBodyweight = bodyweightEntries[bodyweightEntries.length - 1];
-  if (lastBodyweight) {
-    await prisma.user.update({
-      where: { id: user.id },
-      data: { bodyweight: lastBodyweight.weightKg },
-    });
-  }
+  await prisma.user.update({
+    where: { id: user.id },
+    data: {
+      ...(lastBodyweight ? { bodyweight: lastBodyweight.weightKg } : {}),
+      // A coach note (issue #188) so the demo shows the correctable-memory
+      // feature: the AI reads this when it advises.
+      coachNote:
+        'Left shoulder is a bit cranky lately - go easy on overhead pressing. Also travelling next week, so expect one or two missed sessions.',
+    },
+  });
 
   // One in-progress goal on the program's first compound lift.
   await prisma.exerciseGoal.deleteMany({ where: { userId: user.id } });


### PR DESCRIPTION
Content-loop tail for batch 9 (#188 coach note, #189 superset rest, #190 records board) + the #196 tie-break fix.

- CHANGELOG: all three user-facing (coach note headlined - the correctable-memory differentiator).
- Backlog: shipped with the three CLEAN review verdicts.
- Demo seed sets a coach note so the live demo shows the feature on the coach page.
- Screenshots intentionally unchanged: the Records card is below the captured viewport fold and the coach note is on the coach page (neither is a captured screenshot subject); the four captured pages are unchanged.

bash scripts/verify.sh - GREEN-GATE PASSED.

After merge: triggering deploy-demo so the live demo picks up the coach note + the new features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)