### PR TITLE
test: add validation coverage for the profile update schema

### DIFF
--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -6,6 +6,49 @@ by the charter in [`07-autonomy.md`](07-autonomy.md).
 
 ---
 
+## 2026-06-14 - Direct test coverage: CSV reader + profile schema (#198/#199)
+
+**Context.** Maintainer tick, two test-only coverage issues, strictly serialized (each PR MERGED
+before the next branch was cut). Both authored by JulienAu, trust-gated (login allowlist +
+collaborator check HTTP 204). Inherited model this cycle (Fable unavailable) - fine. Pure test
+additions, no production code touched, so a post-merge independent review was not required; the
+discipline instead was "read the source first, assert the REAL contract, never weaken a test, and
+STOP + file if a test surfaces a genuine bug". No bug surfaced - both modules behaved exactly as
+documented.
+
+**Decided / shipped.**
+- **#198 (PR #200, merged on green).** New `lib/import/csv.test.ts`: direct, adversarial coverage
+  for the shared quote-aware CSV reader (the untrusted-upload parsing core, previously exercised
+  only through the Strong/Hevy parser tests). 29 tests over `readCsvRecords` (quoted commas, quoted
+  newlines spanning lines, doubled-quote `""` escapes, trailing/empty fields, CRLF vs LF vs lone-CR,
+  blank trailing + mid-file lines, final record with no newline, 1-based `line` numbers), `asNumber`
+  (ints/decimals/whitespace/empty->0/garbage->NaN, exponent passes, and the `Number.isFinite` guard
+  so Infinity/NaN never leak a non-finite value), and `headerKey` normalization.
+  - *Contract clarified:* the caps `IMPORT_CSV_MAX_BYTES`/`IMPORT_CSV_MAX_ROWS` are exported
+    constants that `readCsvRecords` itself does NOT enforce - the format parsers do, against the
+    reader's output. The test asserts the constant values and documents that the reader reads a
+    row-cap-exceeding file in full (rejection is upstream), rather than asserting a cap the reader
+    does not own. Verified empirically against the source before writing.
+- **#199 (PR #<this>, merged on green).** New `lib/schemas/profile.test.ts` mirroring the existing
+  `lib/schemas/*.test.ts` style: 34 tests for `profileUpdateSchema` - bodyweight 20-300 (19.9/20/
+  300/300.1, decimals allowed), heightCm 100-250 (int-only), weeklyFrequency 1-14 (int-only), each
+  edge accepted / just-outside rejected; all native-enum values accepted + junk rejected (Sex/
+  TrainingGoal/WeightUnit), nullable-vs-optional split (unit is optional-not-nullable); coachNote at
+  vs over `COACH_NOTE_MAX_LEN` with length measured after trim; displayName trim + min-1 + max-80;
+  unknown keys stripped (default Zod object).
+  - *Contract clarified:* an all-whitespace `coachNote` trims to `""` at the schema level; the
+    null-coercion is the route's job (per the schema comment), so the test asserts `""` here, not
+    null. Verified empirically before asserting.
+
+**Challenged.** Test-only PRs with no production behavior change -> no subagent review per the run
+directive. The substitute discipline (read source, assert real contract empirically, never weaken)
+was applied; both green-gates passed (`bash scripts/verify.sh`: prisma generate + lint + typecheck
++ unit + build) and full CI was green (lint/type/unit, integration, build, E2E, docker-smoke).
+
+**Deferred.** Nothing. No production bug surfaced.
+
+---
+
 ## 2026-06-13 - Records board, superset rest timer, coach note (#190/#189/#188)
 
 **Context.** Maintainer tick, strictly serialized by ascending size (each PR MERGED before the

--- a/lib/schemas/profile.test.ts
+++ b/lib/schemas/profile.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest';
+import { Sex, TrainingGoal, WeightUnit } from '@prisma/client';
+import { profileUpdateSchema, COACH_NOTE_MAX_LEN } from './profile';
+
+// Validation coverage for the self-service profile update schema (issue #199).
+// Asserts the REAL implemented contract (verified against the source): every
+// field optional, nullable where the column clears, numeric bounds, int-only
+// fields, native enums, and the trimmed/bounded coach note (#188).
+
+describe('profileUpdateSchema', () => {
+  it('accepts an empty object (every field is optional)', () => {
+    expect(profileUpdateSchema.parse({})).toEqual({});
+  });
+
+  it('accepts a valid partial update', () => {
+    const parsed = profileUpdateSchema.parse({
+      bodyweight: 82.5,
+      heightCm: 180,
+      weeklyFrequency: 4,
+      sex: Sex.MALE,
+      goal: TrainingGoal.HYPERTROPHY,
+      unit: WeightUnit.KG,
+    });
+    expect(parsed.bodyweight).toBe(82.5);
+    expect(parsed.heightCm).toBe(180);
+    expect(parsed.weeklyFrequency).toBe(4);
+    expect(parsed.sex).toBe(Sex.MALE);
+  });
+
+  it('strips unknown keys rather than rejecting them', () => {
+    expect(profileUpdateSchema.parse({ bodyweight: 80, foo: 'bar' })).toEqual({
+      bodyweight: 80,
+    });
+  });
+
+  describe('bodyweight bound (20-300 kg, decimals allowed)', () => {
+    it('rejects just below the lower bound', () => {
+      expect(profileUpdateSchema.safeParse({ bodyweight: 19.9 }).success).toBe(false);
+    });
+    it('accepts the lower edge', () => {
+      expect(profileUpdateSchema.safeParse({ bodyweight: 20 }).success).toBe(true);
+    });
+    it('accepts the upper edge', () => {
+      expect(profileUpdateSchema.safeParse({ bodyweight: 300 }).success).toBe(true);
+    });
+    it('rejects just above the upper bound', () => {
+      expect(profileUpdateSchema.safeParse({ bodyweight: 300.1 }).success).toBe(false);
+    });
+    it('clears with null', () => {
+      expect(profileUpdateSchema.parse({ bodyweight: null }).bodyweight).toBeNull();
+    });
+  });
+
+  describe('heightCm bound (100-250, integer only)', () => {
+    it('rejects just below the lower bound', () => {
+      expect(profileUpdateSchema.safeParse({ heightCm: 99 }).success).toBe(false);
+    });
+    it('accepts the lower edge', () => {
+      expect(profileUpdateSchema.safeParse({ heightCm: 100 }).success).toBe(true);
+    });
+    it('accepts the upper edge', () => {
+      expect(profileUpdateSchema.safeParse({ heightCm: 250 }).success).toBe(true);
+    });
+    it('rejects just above the upper bound', () => {
+      expect(profileUpdateSchema.safeParse({ heightCm: 251 }).success).toBe(false);
+    });
+    it('rejects a non-integer height', () => {
+      expect(profileUpdateSchema.safeParse({ heightCm: 180.5 }).success).toBe(false);
+    });
+    it('clears with null', () => {
+      expect(profileUpdateSchema.parse({ heightCm: null }).heightCm).toBeNull();
+    });
+  });
+
+  describe('weeklyFrequency bound (1-14, integer only)', () => {
+    it('rejects 0 (below the lower bound)', () => {
+      expect(profileUpdateSchema.safeParse({ weeklyFrequency: 0 }).success).toBe(false);
+    });
+    it('accepts the lower edge', () => {
+      expect(profileUpdateSchema.safeParse({ weeklyFrequency: 1 }).success).toBe(true);
+    });
+    it('accepts the upper edge', () => {
+      expect(profileUpdateSchema.safeParse({ weeklyFrequency: 14 }).success).toBe(true);
+    });
+    it('rejects just above the upper bound', () => {
+      expect(profileUpdateSchema.safeParse({ weeklyFrequency: 15 }).success).toBe(false);
+    });
+    it('rejects a non-integer frequency', () => {
+      expect(profileUpdateSchema.safeParse({ weeklyFrequency: 3.5 }).success).toBe(false);
+    });
+  });
+
+  describe('native enums', () => {
+    it('accepts every valid Sex value and rejects junk', () => {
+      for (const v of Object.values(Sex)) {
+        expect(profileUpdateSchema.safeParse({ sex: v }).success).toBe(true);
+      }
+      expect(profileUpdateSchema.safeParse({ sex: 'martian' }).success).toBe(false);
+    });
+
+    it('accepts every valid TrainingGoal value and rejects junk', () => {
+      for (const v of Object.values(TrainingGoal)) {
+        expect(profileUpdateSchema.safeParse({ goal: v }).success).toBe(true);
+      }
+      expect(profileUpdateSchema.safeParse({ goal: 'BULK' }).success).toBe(false);
+    });
+
+    it('accepts every valid WeightUnit value and rejects junk', () => {
+      for (const v of Object.values(WeightUnit)) {
+        expect(profileUpdateSchema.safeParse({ unit: v }).success).toBe(true);
+      }
+      expect(profileUpdateSchema.safeParse({ unit: 'STONE' }).success).toBe(false);
+    });
+
+    it('allows clearing the nullable enums with null', () => {
+      expect(profileUpdateSchema.safeParse({ sex: null }).success).toBe(true);
+      expect(profileUpdateSchema.safeParse({ goal: null }).success).toBe(true);
+    });
+
+    it('does not allow null for unit (optional but not nullable)', () => {
+      expect(profileUpdateSchema.safeParse({ unit: null }).success).toBe(false);
+    });
+  });
+
+  describe('coachNote (#188: trimmed, bounded by COACH_NOTE_MAX_LEN)', () => {
+    it('accepts a note exactly at COACH_NOTE_MAX_LEN', () => {
+      expect(
+        profileUpdateSchema.safeParse({ coachNote: 'x'.repeat(COACH_NOTE_MAX_LEN) })
+          .success,
+      ).toBe(true);
+    });
+
+    it('rejects a note one character over COACH_NOTE_MAX_LEN', () => {
+      expect(
+        profileUpdateSchema.safeParse({ coachNote: 'x'.repeat(COACH_NOTE_MAX_LEN + 1) })
+          .success,
+      ).toBe(false);
+    });
+
+    it('measures length after trimming surrounding whitespace', () => {
+      // Padding is trimmed before the max-length check, so a max-length note
+      // with surrounding spaces still passes.
+      const padded = `  ${'x'.repeat(COACH_NOTE_MAX_LEN)}  `;
+      const parsed = profileUpdateSchema.parse({ coachNote: padded });
+      expect(parsed.coachNote).toBe('x'.repeat(COACH_NOTE_MAX_LEN));
+    });
+
+    it('trims a whitespace-only note to an empty string (the route then coerces to null)', () => {
+      // The schema itself yields "" for an all-whitespace note; null-coercion is
+      // the route's job, per the schema comment.
+      expect(profileUpdateSchema.parse({ coachNote: '   ' }).coachNote).toBe('');
+    });
+
+    it('clears the note with null', () => {
+      expect(profileUpdateSchema.parse({ coachNote: null }).coachNote).toBeNull();
+    });
+  });
+
+  describe('displayName (trimmed, 1-80 chars, nullable)', () => {
+    it('trims surrounding whitespace', () => {
+      expect(profileUpdateSchema.parse({ displayName: '  Bob  ' }).displayName).toBe('Bob');
+    });
+
+    it('rejects a whitespace-only name (empty after trim, below min 1)', () => {
+      expect(profileUpdateSchema.safeParse({ displayName: '   ' }).success).toBe(false);
+    });
+
+    it('rejects a name over 80 characters', () => {
+      expect(profileUpdateSchema.safeParse({ displayName: 'a'.repeat(81) }).success).toBe(false);
+    });
+
+    it('clears with null', () => {
+      expect(profileUpdateSchema.parse({ displayName: null }).displayName).toBeNull();
+    });
+  });
+
+  it('exposes COACH_NOTE_MAX_LEN as the shared 500-char limit', () => {
+    expect(COACH_NOTE_MAX_LEN).toBe(500);
+  });
+});


### PR DESCRIPTION
Adds validation coverage for `lib/schemas/profile.ts` (`profileUpdateSchema`, the Zod schema behind PATCH /api/profile), which previously had no colocated test despite carrying user-facing bounds the API relies on. Mirrors the existing `lib/schemas/*.test.ts` style.

Covers (asserting the REAL contract, verified against the source):
- Numeric bounds rejected just outside and accepted at the edge: bodyweight 19.9/20/300/300.1 (decimals allowed), heightCm 99/100/250/251 (int-only, 180.5 rejected), weeklyFrequency 0/1/14/15 (int-only).
- `nativeEnum` accepts every valid Sex/TrainingGoal/WeightUnit value and rejects junk; nullable enums (sex/goal) accept null; `unit` is optional-but-not-nullable.
- `coachNote` accepted at `COACH_NOTE_MAX_LEN` and rejected one over, with length measured after trim; an all-whitespace note trims to `""` at the schema level (the route coerces that to null, per the schema comment); null clears.
- `displayName` trim + min-1 (whitespace-only rejected) + max-80; null clears.
- Unknown keys are stripped (default Zod object), not rejected.

No production code changed; test-only addition. Also rides the autonomy-log run entry for #198/#199.

Closes #199

## How I tested
`bash scripts/verify.sh` -> GREEN-GATE PASSED (prisma generate + lint + typecheck + unit + build). New file: 34 tests passing.