### PR TITLE
feat: maximum heart rate on cardio sets (store, import, export, display)

### DIFF
--- a/app/(app)/history/[id]/page.tsx
+++ b/app/(app)/history/[id]/page.tsx
@@ -252,6 +252,7 @@ export default async function HistorySessionPage(props: Params) {
                               <th className="py-1.5 font-medium">Distance</th>
                               <th className="py-1.5 font-medium">Pace</th>
                               <th className="py-1.5 font-medium">Avg HR</th>
+                              <th className="py-1.5 font-medium">Max HR</th>
                             </tr>
                           </thead>
                           <tbody>
@@ -274,6 +275,9 @@ export default async function HistorySessionPage(props: Params) {
                                 <td className="py-1.5">{pace ?? '-'}</td>
                                 <td className="py-1.5">
                                   {s.avgHr != null ? `${s.avgHr} bpm` : '-'}
+                                </td>
+                                <td className="py-1.5">
+                                  {s.maxHr != null ? `${s.maxHr} bpm` : '-'}
                                 </td>
                               </tr>
                               );

--- a/app/api/backup/route.ts
+++ b/app/api/backup/route.ts
@@ -10,7 +10,14 @@ import {
 } from '@prisma/client';
 import { db } from '@/lib/db';
 import { ApiError, handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
-import { AVG_HR_MAX, AVG_HR_MIN, MAX_DISTANCE_M, MAX_DURATION_SEC } from '@/lib/cardio';
+import {
+  AVG_HR_MAX,
+  AVG_HR_MIN,
+  MAX_DISTANCE_M,
+  MAX_DURATION_SEC,
+  MAX_HR_MAX,
+  MAX_HR_MIN,
+} from '@/lib/cardio';
 import { MAX_SUPERSET_GROUP, MIN_SUPERSET_GROUP } from '@/lib/supersets';
 import { sorenessSchema } from '@/lib/schemas/readiness';
 
@@ -193,6 +200,7 @@ export async function GET() {
           durationSec: set.durationSec,
           distanceM: set.distanceM,
           avgHr: set.avgHr,
+          maxHr: set.maxHr,
           notes: set.notes,
           isWarmup: set.isWarmup,
           isDropSet: set.isDropSet,
@@ -366,6 +374,7 @@ const importSchema = z.object({
                 .optional(),
               distanceM: z.number().min(0).max(MAX_DISTANCE_M).nullable().optional(),
               avgHr: z.number().int().min(AVG_HR_MIN).max(AVG_HR_MAX).nullable().optional(),
+              maxHr: z.number().int().min(MAX_HR_MIN).max(MAX_HR_MAX).nullable().optional(),
               notes: z.string().max(2000).nullable().optional(),
               isWarmup: z.boolean(),
               isDropSet: z.boolean(),
@@ -613,6 +622,7 @@ export async function POST(req: Request) {
                 durationSec: set.durationSec ?? null,
                 distanceM: set.distanceM ?? null,
                 avgHr: set.avgHr ?? null,
+                maxHr: set.maxHr ?? null,
                 notes: set.notes ?? null,
                 isWarmup: set.isWarmup,
                 isDropSet: set.isDropSet,

--- a/app/api/cardio/tcx/route.ts
+++ b/app/api/cardio/tcx/route.ts
@@ -33,6 +33,7 @@ export async function GET(req: Request) {
             durationSec: true,
             distanceM: true,
             avgHr: true,
+            maxHr: true,
             exercise: { select: { name: true } },
           },
         },
@@ -57,6 +58,7 @@ export async function GET(req: Request) {
         durationSec: s.durationSec!,
         distanceM: s.distanceM,
         avgHr: s.avgHr,
+        maxHr: s.maxHr,
       })),
     };
 

--- a/app/api/history/csv/route.ts
+++ b/app/api/history/csv/route.ts
@@ -92,6 +92,10 @@ export async function GET(req: Request) {
           // Cardio columns (issue #144): raw storage units, empty on strength sets.
           set.durationSec != null ? String(set.durationSec) : '',
           set.distanceM != null ? String(set.distanceM) : '',
+          // Heart-rate columns (issue #203): bpm, empty on strength sets and on
+          // cardio logged without a heart-rate reading.
+          set.avgHr != null ? String(set.avgHr) : '',
+          set.maxHr != null ? String(set.maxHr) : '',
         ];
         lines.push(row.map(csvEscape).join(','));
       }

--- a/app/api/import/tcx/route.ts
+++ b/app/api/import/tcx/route.ts
@@ -66,6 +66,7 @@ export async function POST(req: Request) {
       durationSec: activity.durationSec,
       distanceM: activity.distanceM,
       avgHr: activity.avgHr,
+      maxHr: activity.maxHr,
       duplicateSessions: nearDuplicates.map((s) => s.startedAt.toISOString()),
     };
 
@@ -123,6 +124,7 @@ export async function POST(req: Request) {
           durationSec: activity.durationSec,
           distanceM: activity.distanceM,
           avgHr: activity.avgHr,
+          maxHr: activity.maxHr,
           completedAt: finishedAt,
         },
       });

--- a/app/api/sessions/[id]/sets/route.ts
+++ b/app/api/sessions/[id]/sets/route.ts
@@ -53,6 +53,7 @@ export async function POST(req: Request, props: Params) {
         durationSec: isCardio ? data.durationSec : null,
         distanceM: isCardio ? (data.distanceM ?? null) : null,
         avgHr: isCardio ? (data.avgHr ?? null) : null,
+        maxHr: isCardio ? (data.maxHr ?? null) : null,
         notes: data.notes ?? null,
         isWarmup: data.isWarmup ?? false,
         isDropSet: data.isDropSet ?? false,

--- a/components/settings/import-section.tsx
+++ b/components/settings/import-section.tsx
@@ -57,6 +57,7 @@ interface TcxPreview {
   durationSec: number;
   distanceM: number | null;
   avgHr: number | null;
+  maxHr: number | null;
   duplicateSessions: string[];
 }
 
@@ -312,7 +313,8 @@ export function ImportSection() {
               </li>
               <li>
                 {formatCardioSet(tcxPreview.durationSec, tcxPreview.distanceM)}
-                {tcxPreview.avgHr != null ? ` · avg HR ${tcxPreview.avgHr} bpm` : ''}{' '}
+                {tcxPreview.avgHr != null ? ` · avg HR ${tcxPreview.avgHr} bpm` : ''}
+                {tcxPreview.maxHr != null ? ` · max HR ${tcxPreview.maxHr} bpm` : ''}{' '}
                 logged as {tcxPreview.exerciseName}
               </li>
               {tcxPreview.duplicateSessions.length > 0 && (

--- a/lib/cardio.ts
+++ b/lib/cardio.ts
@@ -19,6 +19,13 @@ export const MAX_DISTANCE_M = 1000000;
 export const AVG_HR_MIN = 40;
 export const AVG_HR_MAX = 250;
 
+// Maximum heart rate bounds in bpm (issue #203): the peak heart-rate metric a
+// watch records, carried by the same TCX exports alongside the average. Same
+// 40..250 window as the average, enforced by every writer of Set.maxHr (the
+// set API schema and the TCX importer).
+export const MAX_HR_MIN = 40;
+export const MAX_HR_MAX = 250;
+
 // Statute mile in meters, for imports from imperial-unit exports.
 export const MILES_TO_METERS = 1609.34;
 

--- a/lib/csv.test.ts
+++ b/lib/csv.test.ts
@@ -28,6 +28,8 @@ describe('HISTORY_CSV_HEADERS', () => {
       'set_notes',
       'duration_sec',
       'distance_m',
+      'avg_hr',
+      'max_hr',
     ]);
   });
 });

--- a/lib/csv.ts
+++ b/lib/csv.ts
@@ -35,6 +35,8 @@ export const HISTORY_CSV_HEADERS = [
   'set_notes',
   'duration_sec', // cardio sets only (raw seconds); empty on strength sets
   'distance_m', // cardio sets only (raw meters); empty on strength sets
+  'avg_hr', // cardio sets only (bpm); empty on strength sets and cardio without HR
+  'max_hr', // cardio sets only (bpm); empty on strength sets and cardio without HR
 ] as const;
 
 export function csvEscape(value: string): string {

--- a/lib/import/tcx-export.test.ts
+++ b/lib/import/tcx-export.test.ts
@@ -36,7 +36,7 @@ describe('serializeTcx round-trip', () => {
     const activity: TcxExportActivity = {
       startedAt,
       sport: 'Running',
-      laps: [{ durationSec: 1800, distanceM: 5000, avgHr: 152 }],
+      laps: [{ durationSec: 1800, distanceM: 5000, avgHr: 152, maxHr: 181 }],
     };
 
     const xml = serializeTcx(activity);
@@ -47,8 +47,24 @@ describe('serializeTcx round-trip', () => {
     expect(parsed.activity!.durationSec).toBe(1800);
     expect(parsed.activity!.distanceM).toBe(5000);
     expect(parsed.activity!.avgHr).toBe(152);
+    // Max HR survives the round-trip unchanged (issue #203).
+    expect(parsed.activity!.maxHr).toBe(181);
     expect(parsed.activity!.sport).toBe('Running');
     expect(parsed.activity!.startedAt.toISOString()).toBe(startedAt.toISOString());
+  });
+
+  it('round-trips max HR as the max over laps', () => {
+    const activity: TcxExportActivity = {
+      startedAt: new Date('2026-06-10T07:30:00.000Z'),
+      sport: 'Running',
+      laps: [
+        { durationSec: 600, distanceM: 2000, avgHr: 150, maxHr: 170 },
+        { durationSec: 600, distanceM: 2000, avgHr: 150, maxHr: 188 },
+      ],
+    };
+    const parsed = parseTcx(serializeTcx(activity));
+    expect(parsed.ok).toBe(true);
+    expect(parsed.activity!.maxHr).toBe(188);
   });
 
   it('round-trips multiple laps, summing duration/distance (HR duration-weighted)', () => {
@@ -56,8 +72,8 @@ describe('serializeTcx round-trip', () => {
       startedAt: new Date('2026-06-10T07:30:00.000Z'),
       sport: 'Biking',
       laps: [
-        { durationSec: 1200, distanceM: 3000, avgHr: 150 },
-        { durationSec: 600, distanceM: 2000, avgHr: 150 },
+        { durationSec: 1200, distanceM: 3000, avgHr: 150, maxHr: null },
+        { durationSec: 600, distanceM: 2000, avgHr: 150, maxHr: null },
       ],
     };
     const parsed = parseTcx(serializeTcx(activity));
@@ -72,23 +88,25 @@ describe('serializeTcx round-trip', () => {
     const activity: TcxExportActivity = {
       startedAt: new Date('2026-06-10T07:30:00.000Z'),
       sport: 'Other',
-      laps: [{ durationSec: 900, distanceM: null, avgHr: null }],
+      laps: [{ durationSec: 900, distanceM: null, avgHr: null, maxHr: null }],
     };
     const xml = serializeTcx(activity);
     expect(xml).not.toContain('DistanceMeters');
     expect(xml).not.toContain('AverageHeartRateBpm');
+    expect(xml).not.toContain('MaximumHeartRateBpm');
     const parsed = parseTcx(xml);
     expect(parsed.ok).toBe(true);
     expect(parsed.activity!.durationSec).toBe(900);
     expect(parsed.activity!.distanceM).toBeNull();
     expect(parsed.activity!.avgHr).toBeNull();
+    expect(parsed.activity!.maxHr).toBeNull();
   });
 
   it('emits no DTD or entity declaration', () => {
     const xml = serializeTcx({
       startedAt: new Date('2026-06-10T07:30:00.000Z'),
       sport: 'Running',
-      laps: [{ durationSec: 60, distanceM: 100, avgHr: null }],
+      laps: [{ durationSec: 60, distanceM: 100, avgHr: null, maxHr: null }],
     });
     expect(xml.toUpperCase()).not.toContain('<!DOCTYPE');
     expect(xml.toUpperCase()).not.toContain('<!ENTITY');
@@ -99,14 +117,21 @@ describe('serializeTcx round-trip', () => {
       startedAt: new Date('2026-06-10T07:30:00.000Z'),
       sport: 'Running',
       laps: [
-        { durationSec: Number.NaN, distanceM: Number.POSITIVE_INFINITY, avgHr: 0 },
+        {
+          durationSec: Number.NaN,
+          distanceM: Number.POSITIVE_INFINITY,
+          avgHr: 0,
+          maxHr: Number.NaN,
+        },
       ],
     });
     expect(xml).not.toContain('NaN');
     expect(xml).not.toContain('Infinity');
-    // Distance is dropped (non-finite) and the HR block is omitted (avgHr 0).
+    // Distance is dropped (non-finite) and both HR blocks are omitted (avgHr 0,
+    // maxHr NaN).
     expect(xml).not.toContain('DistanceMeters');
     expect(xml).not.toContain('AverageHeartRateBpm');
+    expect(xml).not.toContain('MaximumHeartRateBpm');
     expect(xml).toContain('<TotalTimeSeconds>0</TotalTimeSeconds>');
   });
 });

--- a/lib/import/tcx-export.ts
+++ b/lib/import/tcx-export.ts
@@ -20,6 +20,7 @@ export interface TcxExportLap {
   durationSec: number;
   distanceM: number | null;
   avgHr: number | null;
+  maxHr: number | null;
 }
 
 export interface TcxExportActivity {
@@ -73,6 +74,14 @@ function lapXml(lap: TcxExportLap, startTime: string): string {
     lines.push('        <AverageHeartRateBpm>');
     lines.push(`          <Value>${lap.avgHr}</Value>`);
     lines.push('        </AverageHeartRateBpm>');
+  }
+  // Max HR (issue #203): same positive-finite gate as the average so a 0 or a
+  // NaN never emits an invalid HeartRateBpm block. The parser reads it back as
+  // MaximumHeartRateBpm, so a round-trip preserves the value.
+  if (lap.maxHr != null && Number.isFinite(lap.maxHr) && lap.maxHr > 0) {
+    lines.push('        <MaximumHeartRateBpm>');
+    lines.push(`          <Value>${lap.maxHr}</Value>`);
+    lines.push('        </MaximumHeartRateBpm>');
   }
   lines.push('        <Intensity>Active</Intensity>');
   lines.push('        <TriggerMethod>Manual</TriggerMethod>');

--- a/lib/import/tcx.test.ts
+++ b/lib/import/tcx.test.ts
@@ -61,6 +61,8 @@ describe('parseTcx (happy paths)', () => {
       distanceM: 3300,
       // Duration-weighted: (150*900 + 170*300) / 1200 = 155.
       avgHr: 155,
+      // Max-of-laps: lap 1 carries MaximumHeartRateBpm 165, lap 2 carries none.
+      maxHr: 165,
       sport: 'Running',
     });
   });
@@ -361,6 +363,47 @@ describe('parseTcx (bounds)', () => {
     );
     expect(res.ok).toBe(true);
     expect(res.activity?.avgHr).toBeNull();
+  });
+
+  it('reads MaximumHeartRateBpm as the max over laps (issue #203)', () => {
+    const res = parseTcx(
+      minimalTcx(
+        `<Activity Sport="Running"><Id>2026-06-08T07:00:00Z</Id>` +
+          `<Lap><TotalTimeSeconds>600</TotalTimeSeconds>` +
+          `<MaximumHeartRateBpm><Value>160</Value></MaximumHeartRateBpm></Lap>` +
+          `<Lap><TotalTimeSeconds>600</TotalTimeSeconds>` +
+          `<MaximumHeartRateBpm><Value>178</Value></MaximumHeartRateBpm></Lap></Activity>`,
+      ),
+    );
+    expect(res.ok).toBe(true);
+    expect(res.activity?.maxHr).toBe(178);
+  });
+
+  it('does not let a Trackpoint MaximumHeartRateBpm leak into the lap max', () => {
+    // Lap total carries no MaximumHeartRateBpm; only a per-second Track sample
+    // does. The Track is stripped before extraction, so maxHr stays null.
+    const res = parseTcx(
+      minimalTcx(
+        `<Activity Sport="Running"><Id>2026-06-08T07:00:00Z</Id>` +
+          `<Lap><TotalTimeSeconds>600</TotalTimeSeconds><Track><Trackpoint>` +
+          `<MaximumHeartRateBpm><Value>200</Value></MaximumHeartRateBpm>` +
+          `</Trackpoint></Track></Lap></Activity>`,
+      ),
+    );
+    expect(res.ok).toBe(true);
+    expect(res.activity?.maxHr).toBeNull();
+  });
+
+  it('drops an out-of-bounds max heart rate instead of failing the import', () => {
+    const res = parseTcx(
+      minimalTcx(
+        `<Activity Sport="Running"><Id>2026-06-08T07:00:00Z</Id>` +
+          `<Lap><TotalTimeSeconds>600</TotalTimeSeconds>` +
+          `<MaximumHeartRateBpm><Value>999</Value></MaximumHeartRateBpm></Lap></Activity>`,
+      ),
+    );
+    expect(res.ok).toBe(true);
+    expect(res.activity?.maxHr).toBeNull();
   });
 
   // Number() accepts exponent and hex notation; lock in that both stay

--- a/lib/import/tcx.ts
+++ b/lib/import/tcx.ts
@@ -1,5 +1,12 @@
 import { z } from 'zod';
-import { AVG_HR_MAX, AVG_HR_MIN, MAX_DISTANCE_M, MAX_DURATION_SEC } from '@/lib/cardio';
+import {
+  AVG_HR_MAX,
+  AVG_HR_MIN,
+  MAX_DISTANCE_M,
+  MAX_DURATION_SEC,
+  MAX_HR_MAX,
+  MAX_HR_MIN,
+} from '@/lib/cardio';
 import { IMPORT_CSV_MAX_BYTES } from '@/lib/import/csv';
 
 // ============================================================
@@ -48,6 +55,7 @@ export interface TcxActivity {
   durationSec: number; // whole seconds, summed over laps
   distanceM: number | null; // summed over laps; null when no lap carries one
   avgHr: number | null; // duration-weighted average of lap averages
+  maxHr: number | null; // max of the per-lap MaximumHeartRateBpm values
   sport: TcxSport;
 }
 
@@ -69,6 +77,7 @@ const activitySchema = z.object({
   durationSec: z.number().int().min(1).max(MAX_DURATION_SEC),
   distanceM: z.number().min(0).max(MAX_DISTANCE_M).nullable(),
   avgHr: z.number().int().min(AVG_HR_MIN).max(AVG_HR_MAX).nullable(),
+  maxHr: z.number().int().min(MAX_HR_MIN).max(MAX_HR_MAX).nullable(),
   sport: z.enum(['Running', 'Biking', 'Other']),
 });
 
@@ -278,6 +287,9 @@ export function parseTcx(input: string): TcxParseResult {
   let sawDistance = false;
   let hrWeightedSum = 0;
   let hrSeconds = 0;
+  // Max HR is a peak, so it is the max over the per-lap MaximumHeartRateBpm
+  // values (not a sum or an average), matching issue #203's documented choice.
+  let maxHrSeen: number | null = null;
   let earliestStart: Date | null = null;
   let sport: TcxSport = 'Other';
   let sportSet = false;
@@ -317,6 +329,13 @@ export function parseTcx(input: string): TcxParseResult {
         hrWeightedSum += hr * seconds;
         hrSeconds += seconds;
       }
+
+      const maxHrBlock = extractBlocks(lapTotals, 'MaximumHeartRateBpm', 1)[0];
+      const lapMaxHr =
+        maxHrBlock === undefined ? null : asFiniteNumber(firstTagText(maxHrBlock, 'Value'));
+      if (lapMaxHr !== null && lapMaxHr > 0) {
+        maxHrSeen = maxHrSeen === null ? lapMaxHr : Math.max(maxHrSeen, lapMaxHr);
+      }
     }
 
     // Fall back to the first lap's StartTime when <Id> is missing/invalid.
@@ -345,6 +364,7 @@ export function parseTcx(input: string): TcxParseResult {
 
   const durationSec = Math.round(totalSeconds);
   const rawAvgHr = hrSeconds > 0 ? Math.round(hrWeightedSum / hrSeconds) : null;
+  const rawMaxHr = maxHrSeen !== null ? Math.round(maxHrSeen) : null;
   const candidate: TcxActivity = {
     startedAt: earliestStart,
     durationSec,
@@ -352,6 +372,8 @@ export function parseTcx(input: string): TcxParseResult {
     // Out-of-bounds heart rate (sensor glitch or hostile value) degrades to
     // "no heart rate" instead of failing the import: it is optional data.
     avgHr: rawAvgHr !== null && rawAvgHr >= AVG_HR_MIN && rawAvgHr <= AVG_HR_MAX ? rawAvgHr : null,
+    // Same degrade-to-null on an out-of-bounds peak (issue #203).
+    maxHr: rawMaxHr !== null && rawMaxHr >= MAX_HR_MIN && rawMaxHr <= MAX_HR_MAX ? rawMaxHr : null,
     sport,
   };
 

--- a/lib/schemas/set.test.ts
+++ b/lib/schemas/set.test.ts
@@ -66,6 +66,18 @@ describe('setInputSchema', () => {
     expect(setInputSchema.safeParse({ ...valid, distanceM: -1 }).success).toBe(false);
     expect(setInputSchema.safeParse({ ...valid, distanceM: 1000001 }).success).toBe(false);
   });
+
+  it('accepts in-range avg/max HR and coerces numeric strings', () => {
+    const parsed = setInputSchema.parse({ ...valid, avgHr: '150', maxHr: '178' });
+    expect(parsed.avgHr).toBe(150);
+    expect(parsed.maxHr).toBe(178);
+  });
+
+  it('rejects out-of-range or non-integer max HR (issue #203)', () => {
+    expect(setInputSchema.safeParse({ ...valid, maxHr: 39 }).success).toBe(false);
+    expect(setInputSchema.safeParse({ ...valid, maxHr: 251 }).success).toBe(false);
+    expect(setInputSchema.safeParse({ ...valid, maxHr: 150.5 }).success).toBe(false);
+  });
 });
 
 describe('validateSetForCategory', () => {
@@ -77,6 +89,10 @@ describe('validateSetForCategory', () => {
   it('rejects duration or distance on non-cardio exercises', () => {
     expect(validateSetForCategory('COMPOUND', { durationSec: 600 })).toMatch(/cardio/i);
     expect(validateSetForCategory('ISOLATION', { distanceM: 1000 })).toMatch(/cardio/i);
+  });
+
+  it('rejects a max HR on non-cardio exercises (issue #203)', () => {
+    expect(validateSetForCategory('COMPOUND', { maxHr: 170 })).toMatch(/cardio/i);
   });
 
   it('requires a duration on cardio exercises', () => {

--- a/lib/schemas/set.ts
+++ b/lib/schemas/set.ts
@@ -1,6 +1,13 @@
 import { z } from 'zod';
 import type { ExerciseCategory } from '@prisma/client';
-import { AVG_HR_MAX, AVG_HR_MIN, MAX_DISTANCE_M, MAX_DURATION_SEC } from '@/lib/cardio';
+import {
+  AVG_HR_MAX,
+  AVG_HR_MIN,
+  MAX_DISTANCE_M,
+  MAX_DURATION_SEC,
+  MAX_HR_MAX,
+  MAX_HR_MIN,
+} from '@/lib/cardio';
 
 export const setInputSchema = z.object({
   exerciseId: z.string().min(1),
@@ -26,6 +33,12 @@ export const setInputSchema = z.object({
     .union([z.coerce.number().int().min(AVG_HR_MIN).max(AVG_HR_MAX), z.null()])
     .optional()
     .nullable(),
+  // Maximum (peak) heart rate in bpm (issue #203): cardio-only like avgHr,
+  // mainly written by the TCX import. 40..250 when present.
+  maxHr: z
+    .union([z.coerce.number().int().min(MAX_HR_MIN).max(MAX_HR_MAX), z.null()])
+    .optional()
+    .nullable(),
   notes: z.string().trim().max(500).optional().nullable(),
   isWarmup: z.boolean().optional().default(false),
   isDropSet: z.boolean().optional().default(false),
@@ -38,7 +51,7 @@ export type SetInput = z.infer<typeof setInputSchema>;
 // cardio set requires a duration. Returns an error message or null when valid.
 export function validateSetForCategory(
   category: ExerciseCategory,
-  data: Pick<SetInput, 'durationSec' | 'distanceM' | 'avgHr'>,
+  data: Pick<SetInput, 'durationSec' | 'distanceM' | 'avgHr' | 'maxHr'>,
 ): string | null {
   if (category === 'CARDIO') {
     if (data.durationSec == null) {
@@ -46,7 +59,12 @@ export function validateSetForCategory(
     }
     return null;
   }
-  if (data.durationSec != null || data.distanceM != null || data.avgHr != null) {
+  if (
+    data.durationSec != null ||
+    data.distanceM != null ||
+    data.avgHr != null ||
+    data.maxHr != null
+  ) {
     return 'Duration, distance and heart rate are only valid on cardio exercises.';
   }
   return null;

--- a/prisma/migrations/20260614120000_add_set_max_hr/migration.sql
+++ b/prisma/migrations/20260614120000_add_set_max_hr/migration.sql
@@ -1,0 +1,4 @@
+-- Additive (issue #203): maximum (peak) heart rate on a cardio set, imported
+-- from a TCX file alongside the average. NULL on every existing row and on
+-- manually logged sets.
+ALTER TABLE "Set" ADD COLUMN "maxHr" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -231,6 +231,11 @@ model Set {
   // file import carries over manual logging. 40..250 when present (enforced
   // by every writer), NULL on strength sets and on cardio logged without it.
   avgHr       Int?
+  // Maximum (peak) heart rate in bpm (issue #203, additive): the companion HR
+  // metric watches record, carried in the same TCX exports. 40..250 when
+  // present (enforced by every writer), NULL on strength sets and on cardio
+  // logged without it.
+  maxHr       Int?
   notes       String?
   isWarmup    Boolean  @default(false)
   isDropSet   Boolean  @default(false)

--- a/tests/integration/backup-route.test.ts
+++ b/tests/integration/backup-route.test.ts
@@ -153,6 +153,7 @@ async function seedFullUser(email: string) {
             durationSec: 1800,
             distanceM: 5000,
             avgHr: 152,
+            maxHr: 181,
             completedAt: new Date('2026-06-01T10:50:00.000Z'),
           },
         ],
@@ -272,7 +273,7 @@ describe('GET /api/backup - export completeness (issue #168)', () => {
 
     const sets = dump.sessions[0].sets as Array<Record<string, unknown>>;
     const cardio = sets.find((s) => s.exerciseName === 'Running');
-    expect(cardio).toMatchObject({ durationSec: 1800, distanceM: 5000, avgHr: 152 });
+    expect(cardio).toMatchObject({ durationSec: 1800, distanceM: 5000, avgHr: 152, maxHr: 181 });
 
     const peGroups = dump.programs[0].workouts[0].exercises.map(
       (pe: { supersetGroup: number | null }) => pe.supersetGroup,
@@ -440,6 +441,7 @@ describe('POST /api/backup - restore round trip (issue #168)', () => {
     const set = await db.set.findFirst({ where: { session: { userId: user.id } } });
     expect(set?.durationSec).toBeNull();
     expect(set?.avgHr).toBeNull();
+    expect(set?.maxHr).toBeNull();
 
     // No profile in a v1 file: the account's profile is left alone.
     const profile = await db.user.findUnique({ where: { id: user.id } });
@@ -459,6 +461,18 @@ describe('POST /api/backup - malformed and oversized input (issue #168)', () => 
     expect(res.status).toBe(400);
 
     // Validation failed before the transaction: nothing was deleted.
+    expect(await countsFor(user.id)).toEqual(before);
+  });
+
+  it('rejects an out-of-bounds max HR without touching existing data (issue #203)', async () => {
+    const user = await seedFullUser('victim-maxhr@test.dev');
+    actAs(user.id);
+    const before = await countsFor(user.id);
+    const dump = await (await getBackup()).json();
+
+    dump.sessions[0].sets[0].maxHr = 999; // out of the 40..250 range
+    const res = await postBackup(jsonReq({ payload: dump, confirmReplace: true }));
+    expect(res.status).toBe(400);
     expect(await countsFor(user.id)).toEqual(before);
   });
 

--- a/tests/integration/cardio-tcx-route.test.ts
+++ b/tests/integration/cardio-tcx-route.test.ts
@@ -53,6 +53,7 @@ describe('GET /api/cardio/tcx (issue #175)', () => {
         durationSec: 1800,
         distanceM: 5000,
         avgHr: 152,
+        maxHr: 181,
       },
     });
 
@@ -66,6 +67,7 @@ describe('GET /api/cardio/tcx (issue #175)', () => {
     expect(parsed.activity!.durationSec).toBe(1800);
     expect(parsed.activity!.distanceM).toBe(5000);
     expect(parsed.activity!.avgHr).toBe(152);
+    expect(parsed.activity!.maxHr).toBe(181);
     expect(parsed.activity!.sport).toBe('Running');
   });
 

--- a/tests/integration/history-csv-route.test.ts
+++ b/tests/integration/history-csv-route.test.ts
@@ -51,6 +51,8 @@ async function seedMixedSession() {
       reps: 1,
       durationSec: 1800,
       distanceM: 5000,
+      avgHr: 152,
+      maxHr: 181,
     },
   });
   return { user, session };
@@ -71,7 +73,7 @@ beforeEach(() => {
 });
 
 describe('GET /api/history/csv - cardio columns (issue #144)', () => {
-  it('appends duration_sec and distance_m, populated only on cardio rows', async () => {
+  it('appends cardio columns (duration/distance/HR), populated only on cardio rows', async () => {
     const { user } = await seedMixedSession();
     actAs(user.id);
 
@@ -80,8 +82,13 @@ describe('GET /api/history/csv - cardio columns (issue #144)', () => {
 
     const durationIdx = header.indexOf('duration_sec');
     const distanceIdx = header.indexOf('distance_m');
-    expect(durationIdx).toBe(header.length - 2);
-    expect(distanceIdx).toBe(header.length - 1);
+    const avgHrIdx = header.indexOf('avg_hr');
+    const maxHrIdx = header.indexOf('max_hr');
+    // The four cardio columns are pinned at the end in this order.
+    expect(durationIdx).toBe(header.length - 4);
+    expect(distanceIdx).toBe(header.length - 3);
+    expect(avgHrIdx).toBe(header.length - 2);
+    expect(maxHrIdx).toBe(header.length - 1);
 
     const exerciseIdx = header.indexOf('exercise');
     const strengthRow = rows.find((r) => r[exerciseIdx] === 'Bench');
@@ -92,12 +99,16 @@ describe('GET /api/history/csv - cardio columns (issue #144)', () => {
     // Cardio row: raw storage units, stored row shape (weight 0 / reps 1).
     expect(cardioRow![durationIdx]).toBe('1800');
     expect(cardioRow![distanceIdx]).toBe('5000');
+    expect(cardioRow![avgHrIdx]).toBe('152');
+    expect(cardioRow![maxHrIdx]).toBe('181');
     expect(cardioRow![header.indexOf('external_load_kg')]).toBe('0');
     expect(cardioRow![header.indexOf('reps')]).toBe('1');
 
     // Strength row: cardio columns empty, lifting cells unchanged.
     expect(strengthRow![durationIdx]).toBe('');
     expect(strengthRow![distanceIdx]).toBe('');
+    expect(strengthRow![avgHrIdx]).toBe('');
+    expect(strengthRow![maxHrIdx]).toBe('');
     expect(strengthRow![header.indexOf('external_load_kg')]).toBe('100');
     expect(strengthRow![header.indexOf('reps')]).toBe('5');
     expect(strengthRow![header.indexOf('volume_kg')]).toBe('500');

--- a/tests/integration/tcx-import-route.test.ts
+++ b/tests/integration/tcx-import-route.test.ts
@@ -28,6 +28,7 @@ const RUN_TCX = `<?xml version="1.0" encoding="UTF-8"?>
         <TotalTimeSeconds>1800</TotalTimeSeconds>
         <DistanceMeters>5000</DistanceMeters>
         <AverageHeartRateBpm><Value>152</Value></AverageHeartRateBpm>
+        <MaximumHeartRateBpm><Value>181</Value></MaximumHeartRateBpm>
       </Lap>
     </Activity>
   </Activities>
@@ -56,6 +57,7 @@ describe('POST /api/import/tcx (preview)', () => {
       durationSec: 1800,
       distanceM: 5000,
       avgHr: 152,
+      maxHr: 181,
       duplicateSessions: [],
     });
 
@@ -138,6 +140,7 @@ describe('POST /api/import/tcx (confirm)', () => {
       durationSec: 1800,
       distanceM: 5000,
       avgHr: 152,
+      maxHr: 181,
     });
     expect(set?.exercise).toMatchObject({
       name: 'Running',


### PR DESCRIPTION
Adds maximum (peak) heart rate to cardio sets, completing the HR story alongside avgHr (#152).

## What changed
- **Schema (additive)**: `Set.maxHr Int?` + migration `20260614120000_add_set_max_hr`. Validated on the test DB: `prisma migrate reset` applies all 15 migrations cleanly and `migrate diff` reports no drift. Rollback baseline `autonomy-baseline-2026-06-14` tagged on main before the migration.
- **Bounds (40..250)**: `MAX_HR_MIN/MAX` in `lib/cardio.ts`; enforced in the set Zod schema, the TCX importer, and the backup-restore schema.
- **TCX import**: reads `MaximumHeartRateBpm` as the **max over laps** (documented as the right reduction for a peak metric); Track samples stripped so per-second values never leak; out-of-bounds peaks degrade to null.
- **TCX export**: emits `MaximumHeartRateBpm` behind the same positive-finite gate as the average; round-trips to the same value.
- **Display / export**: Max HR column on the session-detail cardio table; import preview line; history CSV gains `avg_hr` + `max_hr` (existing columns pinned); backup export/restore carry `maxHr`.

## How I tested
`bash scripts/verify.sh --full` passes: lint + typecheck + 139 unit/integration + production build + 11 E2E (incl. the TCX import flow). New tests: schema bounds, TCX max-of-laps / Track-leak / out-of-bounds / round-trip, CSV header+columns, and the import/export/backup/csv integration routes.

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)