### PR TITLE
feat: body-measurement tracking with a progress-page trend card

### DIFF
--- a/app/(app)/progress/page.tsx
+++ b/app/(app)/progress/page.tsx
@@ -29,6 +29,7 @@ import { ProgressDashboard } from '@/components/progress/progress-dashboard';
 import { ConsistencyCard } from '@/components/progress/consistency-card';
 import { DeloadBanner } from '@/components/progress/deload-banner';
 import { BodyweightCard } from '@/components/progress/bodyweight-card';
+import { MeasurementsCard } from '@/components/progress/measurements-card';
 import { ConditioningCard } from '@/components/progress/conditioning-card';
 import { RecordsCard } from '@/components/progress/records-card';
 
@@ -303,6 +304,15 @@ export default async function ProgressPage(
     select: { id: true, weightKg: true, measuredAt: true },
   });
 
+  // Body measurements (issue #202): entries of the same 12-week window, newest
+  // first, across every site. The card slices per site client-side. Like the
+  // bodyweight card, it renders on the empty state too.
+  const bodyMeasurements = await db.bodyMeasurement.findMany({
+    where: { userId: auth.userId, measuredAt: { gte: since } },
+    orderBy: { measuredAt: 'desc' },
+    select: { id: true, site: true, valueCm: true, measuredAt: true },
+  });
+
   // Conditioning card (issue #135, display-only): weekly cardio minutes /
   // distance / sessions over the last 8 weeks, derived from the cardio sets
   // already fetched for the window. The card stays hidden until the user has
@@ -388,6 +398,16 @@ export default async function ProgressPage(
           entries={bodyweightEntries.map((e) => ({
             id: e.id,
             weightKg: e.weightKg,
+            measuredAt: e.measuredAt.toISOString(),
+          }))}
+          unit={unit}
+        />
+
+        <MeasurementsCard
+          entries={bodyMeasurements.map((e) => ({
+            id: e.id,
+            site: e.site,
+            valueCm: e.valueCm,
             measuredAt: e.measuredAt.toISOString(),
           }))}
           unit={unit}

--- a/app/api/measurements/[id]/route.ts
+++ b/app/api/measurements/[id]/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { ApiError, handleApiError, requireApiUserId } from '@/lib/api';
+
+interface Params {
+  params: Promise<{ id: string }>;
+}
+
+// DELETE /api/measurements/[id] : remove one measurement. Ownership-scoped - a
+// row belonging to another user (or a missing id) returns 404 and is never
+// deleted, identical to the bodyweight route.
+export async function DELETE(_req: Request, props: Params) {
+  const params = await props.params;
+  try {
+    const userId = await requireApiUserId();
+    const entry = await db.bodyMeasurement.findUnique({ where: { id: params.id } });
+    if (!entry || entry.userId !== userId) {
+      throw new ApiError(404, 'Measurement not found.');
+    }
+    await db.bodyMeasurement.delete({ where: { id: params.id } });
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/app/api/measurements/route.ts
+++ b/app/api/measurements/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import {
+  bodyMeasurementInputSchema,
+  bodyMeasurementListQuerySchema,
+} from '@/lib/schemas/measurement';
+import { handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
+
+// GET /api/measurements?site=WAIST : the user's measurement history, newest
+// first. The optional site filter narrows to one site; an invalid site value
+// is ignored (all sites) rather than rejected.
+export async function GET(req: Request) {
+  try {
+    const userId = await requireApiUserId();
+    const url = new URL(req.url);
+    const parsed = bodyMeasurementListQuerySchema.safeParse({
+      site: url.searchParams.get('site') ?? undefined,
+    });
+    const site = parsed.success ? parsed.data.site : undefined;
+
+    const entries = await db.bodyMeasurement.findMany({
+      where: { userId, ...(site ? { site } : {}) },
+      orderBy: { measuredAt: 'desc' },
+    });
+    return NextResponse.json(entries);
+  } catch (err) {
+    return handleApiError(err);
+  }
+}
+
+// POST /api/measurements : log one measurement. Ownership-scoped: the row is
+// always created under the authenticated user, so a payload can never write
+// another user's data. Value is stored in cm (the client converts).
+export async function POST(req: Request) {
+  try {
+    const userId = await requireApiUserId();
+    const data = await parseJsonBody(req, bodyMeasurementInputSchema);
+
+    const entry = await db.bodyMeasurement.create({
+      data: {
+        userId,
+        site: data.site,
+        valueCm: data.valueCm,
+        note: data.note ?? null,
+      },
+    });
+    return NextResponse.json(entry, { status: 201 });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/components/progress/measurements-card.test.tsx
+++ b/components/progress/measurements-card.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MeasurementsCard, type BodyMeasurementView } from './measurements-card';
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const refresh = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh }),
+}));
+
+function lastFetchCall(fetchMock: ReturnType<typeof vi.fn>) {
+  return fetchMock.mock.calls.at(-1) as [string, RequestInit | undefined];
+}
+
+const entries: BodyMeasurementView[] = [
+  { id: 'm3', site: 'WAIST', valueCm: 82, measuredAt: '2026-06-08T08:00:00Z' },
+  { id: 'm2', site: 'WAIST', valueCm: 84, measuredAt: '2026-06-01T08:00:00Z' },
+  { id: 'm1', site: 'HIPS', valueCm: 95, measuredAt: '2026-06-01T08:00:00Z' },
+];
+
+describe('MeasurementsCard', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('shows the latest value per site', () => {
+    render(<MeasurementsCard entries={entries} unit="KG" />);
+    // Latest waist (newest entry m3 = 82) appears in the latest-per-site grid
+    // and the selected-site list, so it shows at least once.
+    expect(screen.getAllByText('82 cm').length).toBeGreaterThanOrEqual(1);
+    // Hips (95) is only in the grid (waist is the selected site for the list).
+    expect(screen.getByText('95 cm')).toBeInTheDocument();
+    // The older waist value (84) shows in the list but never as a "latest".
+    expect(screen.getByText('84 cm')).toBeInTheDocument();
+  });
+
+  it('shows an empty-state trend message for a site with no data', () => {
+    render(<MeasurementsCard entries={[]} unit="KG" />);
+    expect(screen.getByText(/no waist measurement yet/i)).toBeInTheDocument();
+  });
+
+  it('posts the value in cm for the selected site (metric)', async () => {
+    const user = userEvent.setup();
+    render(<MeasurementsCard entries={[]} unit="KG" />);
+
+    await user.type(screen.getByLabelText(/value \(cm\)/i), '82.5');
+    await user.click(screen.getByRole('button', { name: 'Log' }));
+
+    const [url, init] = lastFetchCall(fetchMock);
+    expect(url).toBe('/api/measurements');
+    const body = JSON.parse(init?.body as string) as { site: string; valueCm: number };
+    expect(body.site).toBe('WAIST');
+    expect(body.valueCm).toBeCloseTo(82.5, 6);
+    expect(refresh).toHaveBeenCalled();
+  });
+
+  it('converts inches to cm before posting (imperial)', async () => {
+    const user = userEvent.setup();
+    render(<MeasurementsCard entries={[]} unit="LB" />);
+
+    await user.type(screen.getByLabelText(/value \(in\)/i), '32');
+    await user.click(screen.getByRole('button', { name: 'Log' }));
+
+    const [, init] = lastFetchCall(fetchMock);
+    const body = JSON.parse(init?.body as string) as { valueCm: number };
+    // 32 in = 81.28 cm.
+    expect(body.valueCm).toBeCloseTo(81.28, 2);
+  });
+
+  it('rejects an empty value without calling the API', async () => {
+    const user = userEvent.setup();
+    render(<MeasurementsCard entries={[]} unit="KG" />);
+    await user.click(screen.getByRole('button', { name: 'Log' }));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('deletes the selected-site entry through the API', async () => {
+    const user = userEvent.setup();
+    render(<MeasurementsCard entries={entries} unit="KG" />);
+    // Default site is WAIST; the first deletable row is the newest waist (m3).
+    await user.click(
+      screen.getAllByRole('button', { name: /delete waist measurement/i })[0] as HTMLElement,
+    );
+    const [url, init] = lastFetchCall(fetchMock);
+    expect(url).toBe('/api/measurements/m3');
+    expect(init?.method).toBe('DELETE');
+    expect(refresh).toHaveBeenCalled();
+  });
+
+  it('switches the trend and list to the chosen site', async () => {
+    const user = userEvent.setup();
+    render(<MeasurementsCard entries={entries} unit="KG" />);
+    await user.selectOptions(screen.getByLabelText(/^site$/i), 'HIPS');
+    // Hips has a single entry -> the "log a second" trend message appears.
+    expect(screen.getByText(/log a second hips measurement/i)).toBeInTheDocument();
+  });
+});

--- a/components/progress/measurements-card.tsx
+++ b/components/progress/measurements-card.tsx
@@ -1,0 +1,269 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { Ruler, Trash2 } from 'lucide-react';
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { BodyMeasurementSite, WeightUnit } from '@prisma/client';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  formatLength,
+  fromDisplayLength,
+  MEASUREMENT_SITES,
+  measurementSiteLabel,
+  roundLength,
+  toDisplayLength,
+} from '@/lib/measurement';
+
+// One body measurement, as serialized at the Server Component boundary.
+export interface BodyMeasurementView {
+  id: string;
+  site: BodyMeasurementSite;
+  valueCm: number;
+  measuredAt: string; // ISO
+}
+
+interface Props {
+  // All measurements of the trend window, newest first, across every site.
+  entries: BodyMeasurementView[];
+  unit: WeightUnit;
+  // How many recent entries (for the selected site) get a list row.
+  listLimit?: number;
+}
+
+function shortDate(iso: string) {
+  return new Intl.DateTimeFormat('en-US', {
+    day: '2-digit',
+    month: '2-digit',
+  }).format(new Date(iso));
+}
+
+// Body-measurement card (issue #202), mirroring the bodyweight card (#99):
+// pick a site, quick-add a value in the display unit (cm in metric, inches in
+// imperial), see the latest value per site and a trend for the selected site,
+// delete bad entries. Storage is always cm; the unit only affects display.
+export function MeasurementsCard({ entries, unit, listLimit = 5 }: Props) {
+  const router = useRouter();
+  const metric = unit !== 'LB';
+  const unitSuffix = metric ? 'cm' : 'in';
+
+  const [site, setSite] = useState<BodyMeasurementSite>('WAIST');
+  const [valueField, setValueField] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  // Newest entry per site, for the "latest per site" summary grid.
+  const latestPerSite = useMemo(() => {
+    const map = new Map<BodyMeasurementSite, BodyMeasurementView>();
+    // entries are newest-first, so the first one seen per site is the latest.
+    for (const e of entries) {
+      if (!map.has(e.site)) map.set(e.site, e);
+    }
+    return map;
+  }, [entries]);
+
+  // Entries for the selected site, newest first.
+  const siteEntries = useMemo(
+    () => entries.filter((e) => e.site === site),
+    [entries, site],
+  );
+
+  // Chart data for the selected site, oldest to newest, in the display unit.
+  const chartData = useMemo(
+    () =>
+      [...siteEntries]
+        .reverse()
+        .map((e) => ({
+          label: shortDate(e.measuredAt),
+          value: roundLength(toDisplayLength(e.valueCm, metric)),
+        })),
+    [siteEntries, metric],
+  );
+
+  async function addEntry() {
+    const value = parseFloat(valueField);
+    if (!Number.isFinite(value) || value <= 0) {
+      toast.error('Enter a positive measurement.');
+      return;
+    }
+    setBusy(true);
+    try {
+      const res = await fetch('/api/measurements', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ site, valueCm: fromDisplayLength(value, metric) }),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as { error?: string } | null;
+        toast.error(data?.error ?? 'Could not log the measurement.');
+        return;
+      }
+      toast.success('Measurement logged.');
+      setValueField('');
+      router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function deleteEntry(id: string) {
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/measurements/${id}`, { method: 'DELETE' });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as { error?: string } | null;
+        toast.error(data?.error ?? 'Could not delete the measurement.');
+        return;
+      }
+      toast.success('Measurement deleted.');
+      router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h2 className="flex items-center gap-2 text-base font-semibold">
+            <Ruler className="size-4" />
+            Measurements
+          </h2>
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {/* Site selector + quick add, in the display unit */}
+        <form
+          className="flex flex-wrap items-end gap-2"
+          onSubmit={(e) => {
+            e.preventDefault();
+            void addEntry();
+          }}
+        >
+          <div className="flex-1 space-y-1">
+            <Label htmlFor="measurement-site">Site</Label>
+            <select
+              id="measurement-site"
+              className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              value={site}
+              onChange={(e) => setSite(e.target.value as BodyMeasurementSite)}
+            >
+              {MEASUREMENT_SITES.map((s) => (
+                <option key={s} value={s}>
+                  {measurementSiteLabel(s)}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex-1 space-y-1">
+            <Label htmlFor="measurement-value">Value ({unitSuffix})</Label>
+            <Input
+              id="measurement-value"
+              type="number"
+              inputMode="decimal"
+              step="0.1"
+              min="0"
+              value={valueField}
+              onChange={(e) => setValueField(e.target.value)}
+            />
+          </div>
+          <Button type="submit" disabled={busy}>
+            {busy ? 'Saving...' : 'Log'}
+          </Button>
+        </form>
+
+        {/* Latest value per site */}
+        {latestPerSite.size > 0 && (
+          <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm sm:grid-cols-3">
+            {MEASUREMENT_SITES.filter((s) => latestPerSite.has(s)).map((s) => (
+              <div key={s} className="flex items-center justify-between gap-2">
+                <span className="text-muted-foreground">{measurementSiteLabel(s)}</span>
+                <span className="font-medium">
+                  {formatLength(latestPerSite.get(s)!.valueCm, metric)}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Trend for the selected site */}
+        {chartData.length < 2 ? (
+          <p className="text-sm text-muted-foreground">
+            {chartData.length === 0
+              ? `No ${measurementSiteLabel(site).toLowerCase()} measurement yet. Log one to start the trend.`
+              : `Log a second ${measurementSiteLabel(site).toLowerCase()} measurement to see the trend.`}
+          </p>
+        ) : (
+          <div className="h-48 w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={chartData} margin={{ top: 5, right: 10, bottom: 0, left: -10 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+                <XAxis dataKey="label" tick={{ fontSize: 11 }} />
+                <YAxis
+                  tick={{ fontSize: 11 }}
+                  domain={['auto', 'auto']}
+                  tickFormatter={(v: number) => String(v)}
+                />
+                <Tooltip
+                  contentStyle={{
+                    background: 'hsl(var(--popover))',
+                    border: '1px solid hsl(var(--border))',
+                    borderRadius: 6,
+                    fontSize: 12,
+                  }}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="value"
+                  name={`${measurementSiteLabel(site)} (${unitSuffix})`}
+                  stroke="hsl(var(--primary))"
+                  strokeWidth={2}
+                  dot={{ r: 3 }}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+
+        {/* Recent entries for the selected site, deletable */}
+        {siteEntries.length > 0 && (
+          <ul className="flex flex-col gap-1">
+            {siteEntries.slice(0, listLimit).map((e) => (
+              <li
+                key={e.id}
+                className="flex items-center justify-between gap-3 text-sm"
+              >
+                <span>
+                  <span className="font-medium">{formatLength(e.valueCm, metric)}</span>{' '}
+                  <span className="text-muted-foreground">on {shortDate(e.measuredAt)}</span>
+                </span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label={`Delete ${measurementSiteLabel(e.site)} measurement of ${shortDate(e.measuredAt)}`}
+                  onClick={() => void deleteEntry(e.id)}
+                  disabled={busy}
+                >
+                  <Trash2 className="size-4" />
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/lib/measurement.test.ts
+++ b/lib/measurement.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CM_PER_INCH,
+  formatLength,
+  fromDisplayLength,
+  MEASUREMENT_SITES,
+  measurementSiteLabel,
+  roundLength,
+  toDisplayLength,
+} from './measurement';
+
+describe('MEASUREMENT_SITES', () => {
+  it('lists all 13 enum sites with no duplicates', () => {
+    expect(MEASUREMENT_SITES).toHaveLength(13);
+    expect(new Set(MEASUREMENT_SITES).size).toBe(13);
+  });
+
+  it('has a human label for every site', () => {
+    for (const site of MEASUREMENT_SITES) {
+      expect(measurementSiteLabel(site)).toBeTruthy();
+    }
+    expect(measurementSiteLabel('ARM_LEFT')).toBe('Arm (left)');
+  });
+});
+
+describe('length unit conversion', () => {
+  it('is identity in metric', () => {
+    expect(toDisplayLength(82.5, true)).toBe(82.5);
+    expect(fromDisplayLength(82.5, true)).toBe(82.5);
+  });
+
+  it('converts cm <-> inches in imperial', () => {
+    expect(toDisplayLength(CM_PER_INCH, false)).toBeCloseTo(1, 6);
+    expect(fromDisplayLength(1, false)).toBeCloseTo(CM_PER_INCH, 6);
+  });
+
+  it('round-trips a stored value through the display unit', () => {
+    const cm = 91.4;
+    expect(fromDisplayLength(toDisplayLength(cm, false), false)).toBeCloseTo(cm, 6);
+  });
+});
+
+describe('formatLength', () => {
+  it('renders cm in metric and inches in imperial', () => {
+    expect(formatLength(82.5, true)).toBe('82.5 cm');
+    // 82.5 cm = 32.48 in -> rounded to 1 decimal.
+    expect(formatLength(82.5, false)).toBe('32.5 in');
+  });
+
+  it('trims trailing zeros via roundLength', () => {
+    expect(roundLength(80.0)).toBe(80);
+    expect(formatLength(80, true)).toBe('80 cm');
+  });
+});

--- a/lib/measurement.ts
+++ b/lib/measurement.ts
@@ -1,0 +1,75 @@
+import { BodyMeasurementSite } from '@prisma/client';
+
+// ============================================================
+// Body measurements (issue #202) - pure display helpers
+// ============================================================
+// Tape-measure tracking, stored always in cm (BodyMeasurement.valueCm). These
+// helpers keep the site ordering and human labels in one place so the card,
+// the API and any future consumer agree.
+
+// Centimeters per inch, for the imperial display path.
+export const CM_PER_INCH = 2.54;
+
+// The sites in the order they appear in the selector (top-down, left/right
+// paired). The enum is the source of truth for validity; this is the source of
+// truth for presentation order.
+export const MEASUREMENT_SITES: BodyMeasurementSite[] = [
+  'NECK',
+  'SHOULDERS',
+  'CHEST',
+  'WAIST',
+  'HIPS',
+  'ARM_LEFT',
+  'ARM_RIGHT',
+  'FOREARM_LEFT',
+  'FOREARM_RIGHT',
+  'THIGH_LEFT',
+  'THIGH_RIGHT',
+  'CALF_LEFT',
+  'CALF_RIGHT',
+];
+
+// Human-readable label per site, for the selector and the list rows.
+const SITE_LABELS: Record<BodyMeasurementSite, string> = {
+  WAIST: 'Waist',
+  HIPS: 'Hips',
+  CHEST: 'Chest',
+  SHOULDERS: 'Shoulders',
+  NECK: 'Neck',
+  ARM_LEFT: 'Arm (left)',
+  ARM_RIGHT: 'Arm (right)',
+  FOREARM_LEFT: 'Forearm (left)',
+  FOREARM_RIGHT: 'Forearm (right)',
+  THIGH_LEFT: 'Thigh (left)',
+  THIGH_RIGHT: 'Thigh (right)',
+  CALF_LEFT: 'Calf (left)',
+  CALF_RIGHT: 'Calf (right)',
+};
+
+export function measurementSiteLabel(site: BodyMeasurementSite): string {
+  return SITE_LABELS[site];
+}
+
+// Converts a stored cm value to the display unit. The app's weight unit doubles
+// as the length unit: KG -> metric (cm), LB -> imperial (inches), matching how
+// bodyweight already keys off User.unit.
+export function toDisplayLength(valueCm: number, metric: boolean): number {
+  return metric ? valueCm : valueCm / CM_PER_INCH;
+}
+
+// Inverse of toDisplayLength: a value typed in the display unit back to cm for
+// storage.
+export function fromDisplayLength(value: number, metric: boolean): number {
+  return metric ? value : value * CM_PER_INCH;
+}
+
+// Rounds a length to one decimal for display, trimming trailing zeros.
+export function roundLength(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+// Formats a stored cm value for display: "82.5 cm" or "32.5 in".
+export function formatLength(valueCm: number, metric: boolean): string {
+  const shown = roundLength(toDisplayLength(valueCm, metric));
+  return metric ? `${shown} cm` : `${shown} in`;
+}

--- a/lib/schemas/measurement.test.ts
+++ b/lib/schemas/measurement.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import {
+  bodyMeasurementInputSchema,
+  bodyMeasurementListQuerySchema,
+  MEASUREMENT_MAX_CM,
+  MEASUREMENT_MIN_CM,
+} from './measurement';
+
+describe('bodyMeasurementInputSchema', () => {
+  it('accepts a valid measurement and coerces a numeric string', () => {
+    const parsed = bodyMeasurementInputSchema.parse({ site: 'WAIST', valueCm: '82.5' });
+    expect(parsed.site).toBe('WAIST');
+    expect(parsed.valueCm).toBe(82.5);
+  });
+
+  it('accepts an optional note', () => {
+    const parsed = bodyMeasurementInputSchema.parse({
+      site: 'ARM_LEFT',
+      valueCm: 36,
+      note: 'flexed',
+    });
+    expect(parsed.note).toBe('flexed');
+  });
+
+  it('rejects an unknown site', () => {
+    expect(
+      bodyMeasurementInputSchema.safeParse({ site: 'EARLOBE', valueCm: 10 }).success,
+    ).toBe(false);
+  });
+
+  it('rejects out-of-range values', () => {
+    expect(
+      bodyMeasurementInputSchema.safeParse({ site: 'WAIST', valueCm: MEASUREMENT_MIN_CM - 1 })
+        .success,
+    ).toBe(false);
+    expect(
+      bodyMeasurementInputSchema.safeParse({ site: 'WAIST', valueCm: MEASUREMENT_MAX_CM + 1 })
+        .success,
+    ).toBe(false);
+    expect(bodyMeasurementInputSchema.safeParse({ site: 'WAIST', valueCm: 0 }).success).toBe(
+      false,
+    );
+    expect(bodyMeasurementInputSchema.safeParse({ site: 'WAIST', valueCm: -5 }).success).toBe(
+      false,
+    );
+  });
+
+  it('rejects a missing site', () => {
+    expect(bodyMeasurementInputSchema.safeParse({ valueCm: 80 }).success).toBe(false);
+  });
+});
+
+describe('bodyMeasurementListQuerySchema', () => {
+  it('accepts a valid site filter', () => {
+    expect(bodyMeasurementListQuerySchema.parse({ site: 'HIPS' }).site).toBe('HIPS');
+  });
+
+  it('treats an absent site as "all sites"', () => {
+    expect(bodyMeasurementListQuerySchema.parse({}).site).toBeUndefined();
+  });
+
+  it('rejects an invalid site (caller falls back to all sites)', () => {
+    expect(bodyMeasurementListQuerySchema.safeParse({ site: 'NOPE' }).success).toBe(false);
+  });
+});

--- a/lib/schemas/measurement.ts
+++ b/lib/schemas/measurement.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+import { BodyMeasurementSite } from '@prisma/client';
+
+// Body-measurement input (issue #202), mirroring the bodyweight schema (#99).
+// The value arrives in cm (the client converts from the display unit before
+// posting). Bounds are deliberately wide so any real tape-measure reading
+// fits: 1 cm guards against zero/negative, 300 cm is far beyond any human
+// girth. The site must be one of the enum values; an unknown site is rejected.
+export const MEASUREMENT_MIN_CM = 1;
+export const MEASUREMENT_MAX_CM = 300;
+
+export const bodyMeasurementInputSchema = z.object({
+  site: z.nativeEnum(BodyMeasurementSite),
+  valueCm: z.coerce.number().min(MEASUREMENT_MIN_CM).max(MEASUREMENT_MAX_CM),
+  note: z.string().max(500).optional(),
+});
+
+export type BodyMeasurementInput = z.infer<typeof bodyMeasurementInputSchema>;
+
+// Query schema for the list endpoint: an optional site filter. Anything not a
+// valid site is ignored (treated as "all sites") rather than rejected, so a
+// stale or hand-edited query string degrades gracefully.
+export const bodyMeasurementListQuerySchema = z.object({
+  site: z.nativeEnum(BodyMeasurementSite).optional(),
+});

--- a/prisma/migrations/20260614202637_add_body_measurement/migration.sql
+++ b/prisma/migrations/20260614202637_add_body_measurement/migration.sql
@@ -1,0 +1,24 @@
+-- Additive migration (issue #202): tape-measure body-measurement history,
+-- mirroring BodyweightEntry (#99). New enum + table + index only; no change to
+-- existing tables and nothing else in the app reads it.
+
+-- CreateEnum
+CREATE TYPE "BodyMeasurementSite" AS ENUM ('WAIST', 'HIPS', 'CHEST', 'SHOULDERS', 'NECK', 'ARM_LEFT', 'ARM_RIGHT', 'FOREARM_LEFT', 'FOREARM_RIGHT', 'THIGH_LEFT', 'THIGH_RIGHT', 'CALF_LEFT', 'CALF_RIGHT');
+
+-- CreateTable
+CREATE TABLE "BodyMeasurement" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "site" "BodyMeasurementSite" NOT NULL,
+    "valueCm" DOUBLE PRECISION NOT NULL,
+    "measuredAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "note" TEXT,
+
+    CONSTRAINT "BodyMeasurement_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "BodyMeasurement_userId_site_measuredAt_idx" ON "BodyMeasurement"("userId", "site", "measuredAt");
+
+-- AddForeignKey
+ALTER TABLE "BodyMeasurement" ADD CONSTRAINT "BodyMeasurement_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,6 +46,7 @@ model User {
   readinessCheckins ReadinessCheckin[]
   exerciseGoals ExerciseGoal[]
   bodyweightEntries BodyweightEntry[]
+  bodyMeasurements BodyMeasurement[]
 }
 
 enum Sex {
@@ -282,6 +283,39 @@ model BodyweightEntry {
   note       String?
 
   @@index([userId, measuredAt])
+}
+
+// Tape-measure body measurements (issue #202, additive): the recomp/hypertrophy
+// companion to bodyweight tracking. Stored always in cm; the client converts
+// from the display unit. One row per (site, time) measurement; nothing else in
+// the app reads it, so the table is fully additive.
+model BodyMeasurement {
+  id         String              @id @default(cuid())
+  userId     String
+  user       User                @relation(fields: [userId], references: [id], onDelete: Cascade)
+  site       BodyMeasurementSite
+  // Stored in centimeters; the client converts from cm/inches at the edge.
+  valueCm    Float
+  measuredAt DateTime            @default(now())
+  note       String?
+
+  @@index([userId, site, measuredAt])
+}
+
+enum BodyMeasurementSite {
+  WAIST
+  HIPS
+  CHEST
+  SHOULDERS
+  NECK
+  ARM_LEFT
+  ARM_RIGHT
+  FOREARM_LEFT
+  FOREARM_RIGHT
+  THIGH_LEFT
+  THIGH_RIGHT
+  CALF_LEFT
+  CALF_RIGHT
 }
 
 model CoachSession {

--- a/tests/e2e/bodyweight.spec.ts
+++ b/tests/e2e/bodyweight.spec.ts
@@ -16,19 +16,24 @@ test('a lifter can log and delete a bodyweight entry on the progress page', asyn
   await expect(page).toHaveURL('/');
 
   await page.goto('/progress');
-  await expect(page.getByText('Bodyweight', { exact: true })).toBeVisible();
-  await expect(page.getByText(/no bodyweight logged yet/i)).toBeVisible();
+  // Scope to the Bodyweight card (the page also has a Measurements card whose
+  // own "Log" button would otherwise be ambiguous).
+  const card = page
+    .locator('div.rounded-xl', { has: page.getByRole('heading', { name: 'Bodyweight' }) })
+    .first();
+  await expect(card.getByRole('heading', { name: 'Bodyweight' })).toBeVisible();
+  await expect(card.getByText(/no bodyweight logged yet/i)).toBeVisible();
 
   // Quick-add 82.5 kg.
-  await page.getByLabel(/bodyweight \(kg\)/i).fill('82.5');
-  await page.getByRole('button', { name: 'Log', exact: true }).click();
+  await card.getByLabel(/bodyweight \(kg\)/i).fill('82.5');
+  await card.getByRole('button', { name: 'Log', exact: true }).click();
 
-  await expect(page.getByText(/current: 82.5 kg/i)).toBeVisible();
+  await expect(card.getByText(/current: 82.5 kg/i)).toBeVisible();
   // The entry shows in the recent list with a delete button.
-  const deleteButton = page.getByRole('button', { name: /delete entry/i }).first();
+  const deleteButton = card.getByRole('button', { name: /delete entry/i }).first();
   await expect(deleteButton).toBeVisible();
 
   // Delete it again: back to the empty state.
   await deleteButton.click();
-  await expect(page.getByText(/no bodyweight logged yet/i)).toBeVisible();
+  await expect(card.getByText(/no bodyweight logged yet/i)).toBeVisible();
 });

--- a/tests/e2e/measurements.spec.ts
+++ b/tests/e2e/measurements.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+
+// Body-measurement tracking (issue #202): pick a site, quick-add a value on the
+// progress page, see it as the latest-per-site value, then delete it. The card
+// renders even with no training data, so a fresh user is enough.
+
+test('a lifter can log and delete a body measurement on the progress page', async ({
+  page,
+}) => {
+  // Register through the API with a unique X-Forwarded-For so this spec keeps
+  // its own per-IP register rate-limit bucket (the suite's parallel signups
+  // otherwise exhaust the 5/min budget), mirroring the import specs.
+  const registerRes = await page.request.post('/api/auth/register', {
+    headers: { 'x-forwarded-for': '10.111.0.7' },
+    data: {
+      displayName: 'Measurement E2E',
+      email: `e2e-measure-${Date.now()}@test.dev`,
+      password: 'supersecret',
+    },
+  });
+  expect(registerRes.ok()).toBeTruthy();
+
+  await page.goto('/progress');
+  // Scope to the Measurements card (the page also has a Bodyweight card).
+  const card = page
+    .locator('div.rounded-xl', { has: page.getByRole('heading', { name: 'Measurements' }) })
+    .first();
+  await expect(card.getByRole('heading', { name: 'Measurements' })).toBeVisible();
+  await expect(card.getByText(/no waist measurement yet/i)).toBeVisible();
+
+  // Default site is Waist; quick-add 82.5 cm.
+  await card.getByLabel(/value \(cm\)/i).fill('82.5');
+  await card.getByRole('button', { name: 'Log', exact: true }).click();
+
+  // Latest-per-site shows the value, and a deletable row appears.
+  await expect(card.getByText('82.5 cm').first()).toBeVisible();
+  const deleteButton = card
+    .getByRole('button', { name: /delete waist measurement/i })
+    .first();
+  await expect(deleteButton).toBeVisible();
+
+  // Delete it: back to the empty trend state for waist.
+  await deleteButton.click();
+  await expect(card.getByText(/no waist measurement yet/i)).toBeVisible();
+});

--- a/tests/integration/measurements-route.test.ts
+++ b/tests/integration/measurements-route.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { db } from '@/lib/db';
+import { getCurrentUserId } from '@/lib/auth';
+
+// Auth is read through getCurrentUserId (via requireApiUserId in @/lib/api).
+vi.mock('@/lib/auth', () => ({ getCurrentUserId: vi.fn() }));
+const mockUserId = vi.mocked(getCurrentUserId);
+
+import { GET as listEntries, POST as postEntry } from '@/app/api/measurements/route';
+import { DELETE as deleteEntry } from '@/app/api/measurements/[id]/route';
+
+function actAs(userId: string) {
+  mockUserId.mockResolvedValue(userId);
+}
+
+function jsonReq(method: string, body: unknown): Request {
+  return new Request('http://test.local/api/measurements', {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function listReq(query = ''): Request {
+  return new Request(`http://test.local/api/measurements${query}`, { method: 'GET' });
+}
+
+async function seed() {
+  const [a, b] = await Promise.all([
+    db.user.create({ data: { email: 'owner@test.dev', passwordHash: 'x' } }),
+    db.user.create({ data: { email: 'stranger@test.dev', passwordHash: 'x' } }),
+  ]);
+  return { a, b };
+}
+
+beforeEach(() => {
+  mockUserId.mockReset();
+});
+
+describe('POST /api/measurements', () => {
+  it('creates a measurement scoped to the authenticated user', async () => {
+    const { a } = await seed();
+    actAs(a.id);
+    const res = await postEntry(jsonReq('POST', { site: 'WAIST', valueCm: 82.5 }));
+    expect(res.status).toBe(201);
+    const entry = await res.json();
+    expect(entry.site).toBe('WAIST');
+    expect(entry.valueCm).toBe(82.5);
+    expect(entry.userId).toBe(a.id);
+    expect(await db.bodyMeasurement.count({ where: { userId: a.id } })).toBe(1);
+  });
+
+  it('stores the optional note', async () => {
+    const { a } = await seed();
+    actAs(a.id);
+    const res = await postEntry(
+      jsonReq('POST', { site: 'ARM_LEFT', valueCm: 36, note: 'flexed' }),
+    );
+    expect(res.status).toBe(201);
+    expect((await res.json()).note).toBe('flexed');
+  });
+
+  it('rejects an out-of-bounds value (Zod) and writes nothing', async () => {
+    const { a } = await seed();
+    actAs(a.id);
+    const res = await postEntry(jsonReq('POST', { site: 'WAIST', valueCm: 500 }));
+    expect(res.status).toBe(400);
+    expect(await db.bodyMeasurement.count()).toBe(0);
+  });
+
+  it('rejects an unknown site (Zod) and writes nothing', async () => {
+    const { a } = await seed();
+    actAs(a.id);
+    const res = await postEntry(jsonReq('POST', { site: 'EARLOBE', valueCm: 10 }));
+    expect(res.status).toBe(400);
+    expect(await db.bodyMeasurement.count()).toBe(0);
+  });
+
+  it('requires auth', async () => {
+    await seed();
+    mockUserId.mockResolvedValue(null);
+    const res = await postEntry(jsonReq('POST', { site: 'WAIST', valueCm: 80 }));
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /api/measurements', () => {
+  it("lists only the user's own entries, newest first", async () => {
+    const { a, b } = await seed();
+    actAs(a.id);
+    await postEntry(jsonReq('POST', { site: 'WAIST', valueCm: 84 }));
+    await postEntry(jsonReq('POST', { site: 'WAIST', valueCm: 82 }));
+
+    actAs(b.id);
+    expect(await (await listEntries(listReq())).json()).toEqual([]);
+
+    actAs(a.id);
+    const own = await (await listEntries(listReq())).json();
+    expect(own).toHaveLength(2);
+    // Newest first (the second POST is newer).
+    expect(own[0].valueCm).toBe(82);
+    expect(own[1].valueCm).toBe(84);
+  });
+
+  it('filters by site when a valid site is given', async () => {
+    const { a } = await seed();
+    actAs(a.id);
+    await postEntry(jsonReq('POST', { site: 'WAIST', valueCm: 82 }));
+    await postEntry(jsonReq('POST', { site: 'HIPS', valueCm: 95 }));
+
+    const waist = await (await listEntries(listReq('?site=WAIST'))).json();
+    expect(waist).toHaveLength(1);
+    expect(waist[0].site).toBe('WAIST');
+  });
+
+  it('falls back to all sites for an invalid site filter', async () => {
+    const { a } = await seed();
+    actAs(a.id);
+    await postEntry(jsonReq('POST', { site: 'WAIST', valueCm: 82 }));
+    await postEntry(jsonReq('POST', { site: 'HIPS', valueCm: 95 }));
+
+    const all = await (await listEntries(listReq('?site=NOPE'))).json();
+    expect(all).toHaveLength(2);
+  });
+});
+
+describe('DELETE /api/measurements/[id]', () => {
+  it('deletes the user\'s own measurement', async () => {
+    const { a } = await seed();
+    actAs(a.id);
+    const created = await (
+      await postEntry(jsonReq('POST', { site: 'CHEST', valueCm: 102 }))
+    ).json();
+
+    const res = await deleteEntry(new Request('http://t/api', { method: 'DELETE' }), {
+      params: Promise.resolve({ id: created.id }),
+    });
+    expect(res.status).toBe(200);
+    expect(await db.bodyMeasurement.count({ where: { userId: a.id } })).toBe(0);
+  });
+
+  it("returns 404 and keeps the entry when a stranger tries to delete it", async () => {
+    const { a, b } = await seed();
+    actAs(a.id);
+    const created = await (
+      await postEntry(jsonReq('POST', { site: 'CHEST', valueCm: 102 }))
+    ).json();
+
+    actAs(b.id);
+    const res = await deleteEntry(new Request('http://t/api', { method: 'DELETE' }), {
+      params: Promise.resolve({ id: created.id }),
+    });
+    expect(res.status).toBe(404);
+    expect(await db.bodyMeasurement.count()).toBe(1);
+  });
+
+  it('returns 404 for a missing id', async () => {
+    const { a } = await seed();
+    actAs(a.id);
+    const res = await deleteEntry(new Request('http://t/api', { method: 'DELETE' }), {
+      params: Promise.resolve({ id: 'does-not-exist' }),
+    });
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
Adds tape-measure body-measurement tracking (waist, arms, etc.), the recomp/hypertrophy companion to bodyweight tracking (#99), reusing its exact additive pattern.

## What changed
- **Schema (additive)**: `BodyMeasurement` model + `BodyMeasurementSite` enum (13 sites) + index on `(userId, site, measuredAt)`; migration `20260614202637_add_body_measurement`. Validated on the test DB: `migrate reset` applies all migrations cleanly and `migrate diff` reports no drift. Fresh rollback baseline `autonomy-baseline-2026-06-14b` tagged before merge. Stored always in cm; the client converts.
- **API**: `POST`/`GET`/`DELETE /api/measurements`, ownership-scoped exactly like `/api/bodyweight`. `GET` takes an optional `site` filter (an invalid site degrades to all sites). `valueCm` bounded 1..300; `site` validated against the enum.
- **UI**: a Measurements card on the progress page - site selector, quick-add in the display unit (cm metric / inches imperial, keyed off the existing weight-unit preference), latest-per-site grid, trend line for the selected site, deletable rows.

## How I tested
`bash scripts/verify.sh --full` passes: lint + typecheck + unit/integration + build + 12 E2E. New tests: schema bounds + site validation, length-unit helpers, route integration (ownership + cross-user isolation, bounds, list-by-site), a component test, and an E2E (add -> latest-per-site -> delete). The E2E registers via the API with a dedicated `X-Forwarded-For` to keep its own register rate-limit bucket; the bodyweight E2E is now scoped to its card since the progress page has two "Log" buttons.

Out of scope (noted): backup/restore of measurements (bodyweight gained that in a separate slice, #168) - can follow as its own issue.

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)