### PR TITLE
feat: import a GPX file as a cardio session (closes #204)

### DIFF
--- a/app/api/import/gpx/route.ts
+++ b/app/api/import/gpx/route.ts
@@ -1,0 +1,144 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { ApiError, handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
+import { rateLimit } from '@/lib/rate-limit';
+import { gpxImportInputSchema } from '@/lib/schemas/import';
+import { parseGpx, gpxExerciseName, GPX_MAX_BYTES } from '@/lib/import/gpx';
+
+// How close an existing session's start has to be to count as a likely
+// duplicate of the imported activity (the preview warns; confirm still works,
+// so re-importing on purpose stays possible). Same window as the TCX import.
+const DUPLICATE_WINDOW_MS = 2 * 60 * 1000;
+
+// POST /api/import/gpx: import a GPX track file as one cardio session (issue
+// #204). Mirrors the hardened TCX import route: streamed body cap, the SHARED
+// import rate bucket, dry-run preview, transactional confirm. The file is
+// untrusted XML; lib/import/gpx.ts refuses DTDs/entities by construction, caps
+// the trackpoint count, and bounds every persisted value.
+export async function POST(req: Request) {
+  try {
+    const userId = await requireApiUserId();
+
+    // Shared "import:" bucket: GPX shares the same per-user import budget as the
+    // CSV and TCX imports so a single user cannot fan out across formats.
+    const rl = rateLimit(`import:${userId}`, 10, 60_000);
+    if (!rl.ok) {
+      throw new ApiError(429, `Too many import requests. Retry in ${rl.retryAfterSec}s.`);
+    }
+
+    // Cheap early reject on a declared oversize. The header is advisory only;
+    // the real control is the streamed byte cap inside parseJsonBody below.
+    const contentLength = Number(req.headers.get('content-length') ?? 0);
+    if (contentLength > GPX_MAX_BYTES * 1.5) {
+      throw new ApiError(413, 'File too large: the limit is 5 MB.');
+    }
+
+    const data = await parseJsonBody(req, gpxImportInputSchema, {
+      // 1.5x leaves room for the JSON envelope and string escaping around the
+      // 5 MB XML payload itself (which the schema caps exactly).
+      maxBytes: GPX_MAX_BYTES * 1.5,
+    });
+
+    const parsed = parseGpx(data.gpx);
+    if (!parsed.ok || !parsed.activity) {
+      throw new ApiError(400, parsed.fatalError ?? 'Unreadable file.');
+    }
+    const activity = parsed.activity;
+    const exerciseName = gpxExerciseName(activity.sport);
+
+    // Near-duplicate warning: any session of this user starting within
+    // +/-2 minutes of the activity start.
+    const nearDuplicates = await db.session.findMany({
+      where: {
+        userId,
+        startedAt: {
+          gte: new Date(activity.startedAt.getTime() - DUPLICATE_WINDOW_MS),
+          lte: new Date(activity.startedAt.getTime() + DUPLICATE_WINDOW_MS),
+        },
+      },
+      select: { startedAt: true },
+      orderBy: { startedAt: 'asc' },
+    });
+
+    const summary = {
+      sport: activity.sport,
+      exerciseName,
+      startedAt: activity.startedAt.toISOString(),
+      durationSec: activity.durationSec,
+      distanceM: activity.distanceM,
+      avgHr: activity.avgHr,
+      duplicateSessions: nearDuplicates.map((s) => s.startedAt.toISOString()),
+    };
+
+    if (data.mode === 'preview') {
+      return NextResponse.json({ mode: 'preview', ...summary });
+    }
+
+    // Confirm: one transaction creates (or reuses, ownership-scoped) the cardio
+    // exercise, the session and its single cardio set.
+    const result = await db.$transaction(async (tx) => {
+      let exercise = await tx.exercise.findFirst({
+        where: { userId, name: exerciseName },
+        select: { id: true, category: true },
+      });
+      let createdExercise = false;
+      if (exercise && exercise.category !== 'CARDIO') {
+        // The user owns a non-cardio exercise with the default name: never
+        // write cardio fields onto it.
+        throw new ApiError(
+          409,
+          `You already have a non-cardio exercise named "${exerciseName}". Rename it and retry.`,
+        );
+      }
+      if (!exercise) {
+        exercise = await tx.exercise.create({
+          data: {
+            userId,
+            name: exerciseName,
+            muscleGroup: 'OTHER',
+            category: 'CARDIO',
+            notes: 'Created by the GPX import.',
+          },
+          select: { id: true, category: true },
+        });
+        createdExercise = true;
+      }
+
+      const finishedAt = new Date(activity.startedAt.getTime() + activity.durationSec * 1000);
+      const session = await tx.session.create({
+        data: {
+          userId,
+          startedAt: activity.startedAt,
+          finishedAt,
+          notes: `Imported from a GPX file (${activity.sport}).`,
+        },
+      });
+      await tx.set.create({
+        data: {
+          sessionId: session.id,
+          exerciseId: exercise.id,
+          setNumber: 1,
+          // Cardio sets store weight = 0 / reps = 1 by convention (#133).
+          weight: 0,
+          reps: 1,
+          durationSec: activity.durationSec,
+          distanceM: activity.distanceM,
+          avgHr: activity.avgHr,
+          completedAt: finishedAt,
+        },
+      });
+      return { sessionId: session.id, createdExercise };
+    });
+
+    return NextResponse.json({
+      mode: 'confirm',
+      createdSessions: 1,
+      createdSets: 1,
+      createdExercises: result.createdExercise ? 1 : 0,
+      sessionId: result.sessionId,
+      ...summary,
+    });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/components/settings/import-section.tsx
+++ b/components/settings/import-section.tsx
@@ -61,11 +61,12 @@ interface TcxPreview {
   duplicateSessions: string[];
 }
 
-type ImportFormat = 'STRONG' | 'HEVY' | 'TCX';
+type ImportFormat = 'STRONG' | 'HEVY' | 'TCX' | 'GPX';
 
 // Copy and endpoint per supported source app. Strong keeps its unit toggle
 // (its export follows the app's unit setting); Hevy always exports kg, so the
-// toggle is hidden for it. TCX is a single-activity cardio file (issue #152).
+// toggle is hidden for it. TCX (issue #152) and GPX (issue #204) are both
+// single-activity cardio files - they share the preview/confirm UI.
 const FORMAT_META: Record<
   ImportFormat,
   {
@@ -102,6 +103,15 @@ const FORMAT_META: Record<
     accept: '.tcx,application/vnd.garmin.tcx+xml,application/xml,text/xml',
     fileKind: 'TCX',
   },
+  GPX: {
+    label: 'GPX file',
+    endpoint: '/api/import/gpx',
+    exportHint:
+      'export the route as GPX from Strava, Komoot or Apple Fitness and it becomes one cardio session with duration, distance and heart rate',
+    hasUnitToggle: false,
+    accept: '.gpx,application/gpx+xml,application/xml,text/xml',
+    fileKind: 'GPX',
+  },
 };
 
 // CSV import from another tracker (issues #100/#113): pick the source app and
@@ -119,6 +129,10 @@ export function ImportSection() {
 
   const meta = FORMAT_META[format];
   const isTcx = format === 'TCX';
+  const isGpx = format === 'GPX';
+  // TCX and GPX are both single-activity cardio imports: same summary shape,
+  // same preview/confirm UI.
+  const isCardioActivity = isTcx || isGpx;
 
   function pickFile() {
     fileRef.current?.click();
@@ -154,14 +168,17 @@ export function ImportSection() {
     const res = await fetch(meta.endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      // Each route's Zod schema defines its exact body: TCX carries the file
-      // as xml; the CSV routes as csv (unit only where the app exports both).
+      // Each route's Zod schema defines its exact body: TCX carries the file as
+      // xml, GPX as gpx; the CSV routes as csv (unit only where the app exports
+      // both).
       body: JSON.stringify(
         isTcx
           ? { xml: fileText, mode }
-          : meta.hasUnitToggle
-            ? { csv: fileText, unit, mode }
-            : { csv: fileText, mode },
+          : isGpx
+            ? { gpx: fileText, mode }
+            : meta.hasUnitToggle
+              ? { csv: fileText, unit, mode }
+              : { csv: fileText, mode },
       ),
     });
     const json = (await res.json().catch(() => null)) as
@@ -183,7 +200,7 @@ export function ImportSection() {
     setBusy(true);
     try {
       const json = await callApi(fileText, 'preview');
-      if (json && isTcx) setTcxPreview(json);
+      if (json && isCardioActivity) setTcxPreview(json);
       else if (json) setPreview(json);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Preview failed.');
@@ -231,11 +248,11 @@ export function ImportSection() {
     <Card>
       <CardHeader className="pb-3">
         <h2 className="text-base font-semibold">
-          {isTcx ? 'Import a TCX activity' : `Import from ${meta.label}`}
+          {isCardioActivity ? `Import a ${meta.fileKind} activity` : `Import from ${meta.label}`}
         </h2>
         <p className="text-xs text-muted-foreground">
-          {isTcx
-            ? `Bring a cardio workout from your watch: ${meta.exportHint}. Preview it here, then confirm.`
+          {isCardioActivity
+            ? `Bring a cardio workout: ${meta.exportHint}. Preview it here, then confirm.`
             : `Bring your training history from the ${meta.label} app: ${meta.exportHint}, preview it here, then confirm.`}
         </p>
       </CardHeader>
@@ -254,6 +271,7 @@ export function ImportSection() {
                 <SelectItem value="STRONG">Strong</SelectItem>
                 <SelectItem value="HEVY">Hevy</SelectItem>
                 <SelectItem value="TCX">TCX file</SelectItem>
+                <SelectItem value="GPX">GPX file</SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -283,7 +301,9 @@ export function ImportSection() {
               <FileUp className="size-4" />
             )}
             <span className="ml-2">
-              {isTcx ? 'Choose a TCX file' : `Choose a ${meta.label} ${meta.fileKind} file`}
+              {isCardioActivity
+                ? `Choose a ${meta.fileKind} file`
+                : `Choose a ${meta.label} ${meta.fileKind} file`}
             </span>
           </Button>
         </div>

--- a/lib/import/gpx.test.ts
+++ b/lib/import/gpx.test.ts
@@ -1,0 +1,376 @@
+import { describe, it, expect } from 'vitest';
+import { parseGpx, gpxExerciseName, haversineMeters, GPX_MAX_BYTES } from './gpx';
+
+// ============================================================
+// Helpers
+// ============================================================
+
+// A minimal GPX wrapper around inner <trk> markup.
+const gpx = (inner: string) =>
+  `<?xml version="1.0" encoding="UTF-8"?>` +
+  `<gpx version="1.1" creator="test" xmlns="http://www.topografix.com/GPX/1/1">${inner}</gpx>`;
+
+// A trackpoint at lat/lon with an optional ISO time and HR.
+const pt = (lat: number, lon: number, time?: string, hr?: number) => {
+  const ext = hr != null ? `<extensions><gpxtpx:hr>${hr}</gpxtpx:hr></extensions>` : '';
+  const t = time ? `<time>${time}</time>` : '';
+  return `<trkpt lat="${lat}" lon="${lon}">${t}${ext}</trkpt>`;
+};
+
+// A realistic short run: 4 points along a line, 60 seconds apart.
+const RUN_GPX = gpx(
+  `<trk><name>Morning run</name><type>running</type><trkseg>` +
+    pt(48.8566, 2.3522, '2026-06-10T07:30:00.000Z', 150) +
+    pt(48.857, 2.3525, '2026-06-10T07:31:00.000Z', 152) +
+    pt(48.8575, 2.3528, '2026-06-10T07:32:00.000Z', 158) +
+    pt(48.858, 2.3531, '2026-06-10T07:33:00.000Z', 160) +
+    `</trkseg></trk>`,
+);
+
+// ============================================================
+// Happy paths
+// ============================================================
+
+describe('haversineMeters', () => {
+  it('is zero for identical points', () => {
+    expect(haversineMeters(48.85, 2.35, 48.85, 2.35)).toBe(0);
+  });
+
+  it('matches a known distance (Paris to London ~ 343 km)', () => {
+    const d = haversineMeters(48.8566, 2.3522, 51.5074, -0.1278);
+    expect(d / 1000).toBeGreaterThan(330);
+    expect(d / 1000).toBeLessThan(350);
+  });
+});
+
+describe('parseGpx (happy paths)', () => {
+  it('derives duration from timestamps and distance from trackpoints', () => {
+    const res = parseGpx(RUN_GPX);
+    expect(res.ok).toBe(true);
+    expect(res.activity!.startedAt).toEqual(new Date('2026-06-10T07:30:00.000Z'));
+    // 07:30:00 -> 07:33:00 = 180 s.
+    expect(res.activity!.durationSec).toBe(180);
+    // Four points a few meters apart -> a small positive distance.
+    expect(res.activity!.distanceM).toBeGreaterThan(0);
+    expect(res.activity!.distanceM!).toBeLessThan(1000);
+    // HR is the average of 150/152/158/160 = 155.
+    expect(res.activity!.avgHr).toBe(155);
+    expect(res.activity!.sport).toBe('Running');
+  });
+
+  it('maps <type> cycling to Biking and reads ns3:hr extension', () => {
+    const res = parseGpx(
+      gpx(
+        `<trk><type>cycling</type><trkseg>` +
+          `<trkpt lat="48.0" lon="2.0"><time>2026-06-10T07:30:00Z</time>` +
+          `<extensions><ns3:hr>120</ns3:hr></extensions></trkpt>` +
+          `<trkpt lat="48.01" lon="2.01"><time>2026-06-10T07:40:00Z</time>` +
+          `<extensions><ns3:hr>130</ns3:hr></extensions></trkpt>` +
+          `</trkseg></trk>`,
+      ),
+    );
+    expect(res.ok).toBe(true);
+    expect(res.activity!.sport).toBe('Biking');
+    expect(res.activity!.avgHr).toBe(125);
+  });
+
+  it('defaults to Other sport when <type> is missing', () => {
+    const res = parseGpx(
+      gpx(
+        `<trk><trkseg>` +
+          pt(48.0, 2.0, '2026-06-10T07:30:00Z') +
+          pt(48.01, 2.01, '2026-06-10T07:35:00Z') +
+          `</trkseg></trk>`,
+      ),
+    );
+    expect(res.ok).toBe(true);
+    expect(res.activity!.sport).toBe('Other');
+    expect(res.activity!.avgHr).toBeNull();
+  });
+
+  it('handles single-quoted lat/lon attributes', () => {
+    const res = parseGpx(
+      gpx(
+        `<trk><trkseg>` +
+          `<trkpt lat='48.0' lon='2.0'><time>2026-06-10T07:30:00Z</time></trkpt>` +
+          `<trkpt lat='48.01' lon='2.0'><time>2026-06-10T07:31:00Z</time></trkpt>` +
+          `</trkseg></trk>`,
+      ),
+    );
+    expect(res.ok).toBe(true);
+    expect(res.activity!.durationSec).toBe(60);
+  });
+
+  it('sums trackpoints across multiple segments and tracks', () => {
+    const res = parseGpx(
+      gpx(
+        `<trk><type>running</type><trkseg>` +
+          pt(48.0, 2.0, '2026-06-10T07:30:00Z') +
+          pt(48.001, 2.0, '2026-06-10T07:31:00Z') +
+          `</trkseg><trkseg>` +
+          pt(48.002, 2.0, '2026-06-10T07:32:00Z') +
+          `</trkseg></trk>`,
+      ),
+    );
+    expect(res.ok).toBe(true);
+    expect(res.activity!.durationSec).toBe(120);
+    expect(res.activity!.distanceM).toBeGreaterThan(0);
+  });
+
+  it('drops a trackpoint with out-of-range coordinates', () => {
+    const res = parseGpx(
+      gpx(
+        `<trk><trkseg>` +
+          pt(48.0, 2.0, '2026-06-10T07:30:00Z') +
+          `<trkpt lat="999" lon="2.0"><time>2026-06-10T07:31:00Z</time></trkpt>` +
+          pt(48.01, 2.0, '2026-06-10T07:32:00Z') +
+          `</trkseg></trk>`,
+      ),
+    );
+    expect(res.ok).toBe(true);
+    // 07:30 -> 07:32, the bad point in the middle contributed no time/distance.
+    expect(res.activity!.durationSec).toBe(120);
+  });
+
+  it('degrades an out-of-bounds heart rate to null instead of failing', () => {
+    const res = parseGpx(
+      gpx(
+        `<trk><trkseg>` +
+          pt(48.0, 2.0, '2026-06-10T07:30:00Z', 999) +
+          pt(48.01, 2.0, '2026-06-10T07:31:00Z', 999) +
+          `</trkseg></trk>`,
+      ),
+    );
+    expect(res.ok).toBe(true);
+    expect(res.activity!.avgHr).toBeNull();
+  });
+
+  it('maps sport to the default exercise name', () => {
+    expect(gpxExerciseName('Running')).toBe('Running');
+    expect(gpxExerciseName('Biking')).toBe('Cycling');
+    expect(gpxExerciseName('Other')).toBe('Cardio (imported)');
+  });
+});
+
+// ============================================================
+// Hostile fixtures (issue #204 SECURITY bar - same as #105/#108/#158)
+// ============================================================
+
+describe('parseGpx (hostile input)', () => {
+  it('rejects a file with an internal DTD outright', () => {
+    const res = parseGpx(
+      `<?xml version="1.0"?><!DOCTYPE gpx [<!ELEMENT gpx ANY>]>` +
+        gpx(`<trk><trkseg>${pt(48, 2, '2026-06-10T07:30:00Z')}</trkseg></trk>`),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toMatch(/DTD and entity declarations are not allowed/);
+  });
+
+  it('rejects an external entity (XXE) attempt outright', () => {
+    const res = parseGpx(
+      `<?xml version="1.0"?><!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>` +
+        `<gpx><trk><trkseg><trkpt lat="48" lon="2"><name>&xxe;</name>` +
+        `<time>2026-06-10T07:30:00Z</time></trkpt></trkseg></trk></gpx>`,
+    );
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toMatch(/not allowed/);
+  });
+
+  it('rejects a billion-laughs entity bomb outright (and fast)', () => {
+    const bomb =
+      `<?xml version="1.0"?><!DOCTYPE lolz [<!ENTITY lol "lol">` +
+      `<!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">` +
+      `<!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">` +
+      `<!ENTITY lol9 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">]>` +
+      `<gpx>&lol9;</gpx>`;
+    const start = Date.now();
+    const res = parseGpx(bomb);
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toMatch(/not allowed/);
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
+
+  it('never expands entity references even without a DTD (no entity table)', () => {
+    // An undeclared entity in a coordinate: it fails Number(), so the point is
+    // dropped - nothing is ever resolved or substituted.
+    const res = parseGpx(
+      gpx(
+        `<trk><trkseg><trkpt lat="&evil;" lon="2.0">` +
+          `<time>2026-06-10T07:30:00Z</time></trkpt></trkseg></trk>`,
+      ),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toMatch(/No usable trackpoints/);
+  });
+
+  it('ignores a <trk> smuggled inside an XML comment', () => {
+    const res = parseGpx(
+      gpx(
+        `<!-- <trk><type>cycling</type><trkseg>` +
+          pt(0, 0, '2000-01-01T00:00:00Z') +
+          pt(80, 80, '2020-01-01T00:00:00Z') +
+          `</trkseg></trk> -->` +
+          `<trk><type>running</type><trkseg>` +
+          pt(48.0, 2.0, '2026-06-10T07:30:00Z') +
+          pt(48.01, 2.0, '2026-06-10T07:31:00Z') +
+          `</trkseg></trk>`,
+      ),
+    );
+    expect(res.ok).toBe(true);
+    expect(res.activity!.sport).toBe('Running');
+    expect(res.activity!.durationSec).toBe(60);
+  });
+
+  it('accepts a file whose DTD is commented out (inert by construction)', () => {
+    const res = parseGpx(
+      `<?xml version="1.0"?><!-- <!DOCTYPE gpx SYSTEM "http://evil.example/x.dtd"> -->` +
+        gpx(
+          `<trk><trkseg>` +
+            pt(48.0, 2.0, '2026-06-10T07:30:00Z') +
+            pt(48.01, 2.0, '2026-06-10T07:31:00Z') +
+            `</trkseg></trk>`,
+        ),
+    );
+    expect(res.ok).toBe(true);
+    expect(res.activity!.durationSec).toBe(60);
+  });
+
+  it('drops everything after an unterminated comment', () => {
+    const res = parseGpx(
+      gpx(
+        `<!-- never closed <trk><trkseg>${pt(48, 2, '2026-06-10T07:30:00Z')}</trkseg></trk>`,
+      ),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toMatch(/No track found/);
+  });
+
+  it('rejects a null-byte-split <!DOCTYPE as a malformed markup declaration', () => {
+    const res = parseGpx(
+      `<?xml version="1.0"?><! DOCTYPE foo [<! ENTITY xxe SYSTEM "file:///etc/passwd">]>` +
+        gpx(`<trk><trkseg>${pt(48, 2, '2026-06-10T07:30:00Z')}</trkseg></trk>`),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toMatch(/malformed markup declaration/);
+  });
+
+  it('rejects CDATA sections (no real GPX export emits them in our fields)', () => {
+    const res = parseGpx(
+      gpx(
+        `<trk><trkseg><trkpt lat="48" lon="2">` +
+          `<time><![CDATA[2026-06-10T07:30:00Z]]></time></trkpt></trkseg></trk>`,
+      ),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toMatch(/malformed markup declaration/);
+  });
+
+  it('keeps huge-coordinate-count work linear and refuses an over-cap file', () => {
+    // Build a file just over the trackpoint cap (200000). It must not hang and
+    // must be refused as too large, not imported as a partial total.
+    // Minimal self-closing points (24 bytes each) so 200001 of them stay just
+    // under the 5 MB byte cap and we exercise the TRACKPOINT cap, not the bytes.
+    const big = gpx(`<trk><trkseg>${'<trkpt lat="1" lon="1"/>'.repeat(200_001)}</trkseg></trk>`);
+    expect(big.length).toBeLessThan(GPX_MAX_BYTES);
+    const start = Date.now();
+    const res = parseGpx(big);
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toMatch(/Too many trackpoints/);
+    // Linear scan: comfortably under a second even at the cap.
+    expect(Date.now() - start).toBeLessThan(2000);
+  });
+
+  it('treats a huge attribute value as absent (point dropped, not processed)', () => {
+    const huge = '9'.repeat(100_000);
+    const res = parseGpx(
+      gpx(
+        `<trk><trkseg><trkpt lat="${huge}" lon="2.0">` +
+          `<time>2026-06-10T07:30:00Z</time></trkpt>` +
+          pt(48.0, 2.0, '2026-06-10T07:30:00Z') +
+          pt(48.01, 2.0, '2026-06-10T07:31:00Z') +
+          `</trkseg></trk>`,
+      ),
+    );
+    // The huge-lat point is dropped; the two real points still parse.
+    expect(res.ok).toBe(true);
+    expect(res.activity!.durationSec).toBe(60);
+  });
+
+  it('handles a truncated file gracefully', () => {
+    const res = parseGpx(RUN_GPX.slice(0, Math.floor(RUN_GPX.length / 2)));
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toBeTruthy();
+  });
+
+  it('handles a truncated opening tag without hanging', () => {
+    const res = parseGpx(`<gpx><trk><trkseg><trkpt lat="48`);
+    expect(res.ok).toBe(false);
+  });
+
+  it('rejects a file over the shared byte cap', () => {
+    const res = parseGpx('a'.repeat(GPX_MAX_BYTES + 1));
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toMatch(/too large/i);
+  });
+
+  it('rejects non-GPX XML and empty input', () => {
+    expect(parseGpx('<html><body>hi</body></html>').ok).toBe(false);
+    expect(parseGpx('').ok).toBe(false);
+    expect(parseGpx('not xml at all').ok).toBe(false);
+  });
+
+  it('rejects a route-only GPX (no <trk>)', () => {
+    const res = parseGpx(
+      gpx(`<rte><rtept lat="48" lon="2"></rtept></rte>`),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toMatch(/No track found/);
+  });
+
+  it('rejects a track whose timestamps do not advance', () => {
+    const res = parseGpx(
+      gpx(
+        `<trk><trkseg>` +
+          pt(48.0, 2.0, '2026-06-10T07:30:00Z') +
+          pt(48.01, 2.0, '2026-06-10T07:30:00Z') +
+          `</trkseg></trk>`,
+      ),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toMatch(/duration is zero/);
+  });
+
+  it('rejects a track with no timestamps (cannot derive duration)', () => {
+    const res = parseGpx(
+      gpx(`<trk><trkseg><trkpt lat="48" lon="2"></trkpt><trkpt lat="48.01" lon="2"></trkpt></trkseg></trk>`),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toMatch(/no usable timestamps/i);
+  });
+
+  it('rejects a start time outside the sane window', () => {
+    const res = parseGpx(
+      gpx(
+        `<trk><trkseg>` +
+          pt(48.0, 2.0, '1980-01-01T00:00:00Z') +
+          pt(48.01, 2.0, '1980-01-01T00:10:00Z') +
+          `</trkseg></trk>`,
+      ),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toMatch(/out of range/);
+  });
+
+  it('rejects a duration over 24 hours (out of bounds)', () => {
+    const res = parseGpx(
+      gpx(
+        `<trk><trkseg>` +
+          pt(48.0, 2.0, '2026-06-10T00:00:00Z') +
+          pt(48.0001, 2.0, '2026-06-11T01:00:00Z') +
+          `</trkseg></trk>`,
+      ),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toMatch(/out of bounds/);
+  });
+});

--- a/lib/import/gpx.ts
+++ b/lib/import/gpx.ts
@@ -1,0 +1,471 @@
+import { z } from 'zod';
+import {
+  AVG_HR_MAX,
+  AVG_HR_MIN,
+  MAX_DISTANCE_M,
+  MAX_DURATION_SEC,
+} from '@/lib/cardio';
+import { IMPORT_CSV_MAX_BYTES } from '@/lib/import/csv';
+
+// ============================================================
+// GPX track file parser (issue #204) - pure, no DB
+// ============================================================
+// GPX (GPS Exchange) text in, ONE normalized cardio activity out. The file is
+// UNTRUSTED XML from an arbitrary platform export (Strava, Komoot, Apple).
+//
+// SECURITY - this mirrors lib/import/tcx.ts EXACTLY, deliberately: a general
+// XML parser is exactly the attack surface (XXE, external DTD fetches,
+// entity-expansion bombs) this import must not have, and the repo carries no
+// XML dependency. The GPX shape we need is tiny and rigid (trk > trkseg >
+// trkpt[@lat,@lon] with optional <time> and an HR extension), so this module
+// scans for those known tags with single-pass indexOf walks and validates
+// every extracted value with Zod. By construction:
+//   - NO entity resolution exists: there is no entity table and no decoding of
+//     any "&...;" sequence, so internal entities cannot expand (billion laughs)
+//     and external entities cannot be fetched (XXE).
+//   - XML comments are stripped before any scanning, so content smuggled inside
+//     "<!-- -->" (e.g. a fake <trk>) is never seen - matching a real XML
+//     parser. A DTD inside a comment is inert and accepted after stripping.
+//   - Any document containing "<!DOCTYPE" or "<!ENTITY" is rejected outright
+//     before extraction, so a DTD is never scanned past. After comments are
+//     stripped, any remaining "<!" not followed by a letter (a null-byte-split
+//     "<!\0DOCTYPE", "<![CDATA[", a bare "<!>") is rejected as a malformed
+//     markup declaration - none of these appear in a real export.
+//   - All scans are indexOf-based (no regex over attacker-sized input), so a
+//     huge attribute or a truncated tag cannot trigger pathological
+//     backtracking; unterminated structures simply stop matching.
+//   - The trackpoint count is hard-capped (MAX_TRACKPOINTS) so distance/HR work
+//     stays linear and bounded even under the byte cap; a hostile file with
+//     millions of <trkpt> simply stops being scanned past the cap.
+//   - The hard byte cap is re-checked here, independent of the route.
+// Output bounds are identical to the cardio set schema (lib/schemas/set.ts),
+// so an imported set satisfies the same contract as a manually logged one.
+//
+// OUT OF SCOPE (totals only, no track stored): elevation, pace splits, and the
+// full polyline. We persist duration / distance / optional avg HR.
+
+// Shared import cap (same 5 MB budget as the CSV/TCX importers).
+export const GPX_MAX_BYTES = IMPORT_CSV_MAX_BYTES;
+
+// GPX has no sport attribute; an optional <type> may carry one. We map the
+// common Strava/Garmin values and default to Other.
+export type GpxSport = 'Running' | 'Biking' | 'Other';
+
+export interface GpxActivity {
+  startedAt: Date;
+  durationSec: number; // last trkpt time - first trkpt time
+  distanceM: number | null; // haversine sum over consecutive trkpts; null if <2 points
+  avgHr: number | null; // average of trkpt HR extension values, when present
+  sport: GpxSport;
+}
+
+export interface GpxParseResult {
+  ok: boolean;
+  fatalError: string | null;
+  activity: GpxActivity | null;
+}
+
+const fatal = (msg: string): GpxParseResult => ({
+  ok: false,
+  fatalError: msg,
+  activity: null,
+});
+
+// Bounds identical to the cardio set contract (lib/schemas/set.ts).
+const activitySchema = z.object({
+  startedAt: z.date(),
+  durationSec: z.number().int().min(1).max(MAX_DURATION_SEC),
+  distanceM: z.number().min(0).max(MAX_DISTANCE_M).nullable(),
+  avgHr: z.number().int().min(AVG_HR_MIN).max(AVG_HR_MAX).nullable(),
+  sport: z.enum(['Running', 'Biking', 'Other']),
+});
+
+// Longest value we ever need (an ISO timestamp); anything longer is hostile or
+// garbage and is treated as absent.
+const MAX_VALUE_CHARS = 64;
+
+// Sane window for the activity start (same as TCX): nothing before consumer GPS
+// existed, nothing further out than tomorrow (small clock skew is fine).
+export const GPX_MIN_STARTED_AT = new Date('2000-01-01T00:00:00.000Z');
+const STARTED_AT_FUTURE_SLACK_MS = 24 * 60 * 60 * 1000;
+
+// Caps so a hostile file cannot make us accumulate unbounded work even under
+// the byte cap. A real ride/run is at most a few tens of thousands of points;
+// 200000 is generous while still bounding the haversine loop.
+const MAX_TRACKPOINTS = 200_000;
+const MAX_TRACKS = 50;
+
+// ------------------------------------------------------------
+// indexOf-based tag helpers, copied from the TCX parser's hardened layout. GPX
+// here is non-nested for the tags we read (a <trkpt> never contains another
+// <trkpt>); namespace prefixes on the HR extension are handled explicitly.
+// ------------------------------------------------------------
+
+// Locates `<tag` followed by whitespace, `>` or `/` and returns where its
+// content starts (after the closing `>` of the opening tag) plus the opening
+// tag's start. Self-closing tags return contentStart === the position after
+// "/>", with selfClosing flagged. Unterminated opening tags return null.
+function findOpenTag(
+  xml: string,
+  tag: string,
+  from: number,
+): { tagStart: number; contentStart: number; selfClosing: boolean } | null {
+  const needle = `<${tag}`;
+  let i = from;
+  for (;;) {
+    const at = xml.indexOf(needle, i);
+    if (at === -1) return null;
+    const after = xml[at + needle.length];
+    if (
+      after === '>' ||
+      after === ' ' ||
+      after === '\t' ||
+      after === '\n' ||
+      after === '\r' ||
+      after === '/'
+    ) {
+      const gt = xml.indexOf('>', at);
+      if (gt === -1) return null; // truncated opening tag
+      const selfClosing = xml[gt - 1] === '/';
+      return { tagStart: at, contentStart: gt + 1, selfClosing };
+    }
+    i = at + needle.length; // e.g. <trkseg vs <trkpt: keep looking
+  }
+}
+
+// Returns the inner text of each <tag ...>...</tag> block, in order, capped at
+// maxBlocks. Self-closing instances contribute an empty block.
+function extractBlocks(xml: string, tag: string, maxBlocks: number): string[] {
+  const blocks: string[] = [];
+  const close = `</${tag}>`;
+  let from = 0;
+  while (blocks.length < maxBlocks) {
+    const open = findOpenTag(xml, tag, from);
+    if (!open) break;
+    if (open.selfClosing) {
+      blocks.push('');
+      from = open.contentStart;
+      continue;
+    }
+    const end = xml.indexOf(close, open.contentStart);
+    if (end === -1) break; // truncated: ignore the unterminated block
+    blocks.push(xml.slice(open.contentStart, end));
+    from = end + close.length;
+  }
+  return blocks;
+}
+
+// First <tag>value</tag> inner text inside `xml`, trimmed, or null. Values
+// longer than MAX_VALUE_CHARS are treated as absent (hostile or garbage). A
+// self-closing tag has no text -> null.
+function firstTagText(xml: string, tag: string): string | null {
+  const open = findOpenTag(xml, tag, 0);
+  if (!open || open.selfClosing) return null;
+  const end = xml.indexOf(`</${tag}>`, open.contentStart);
+  if (end === -1 || end - open.contentStart > MAX_VALUE_CHARS) return null;
+  const value = xml.slice(open.contentStart, end).trim();
+  return value.length > 0 ? value : null;
+}
+
+// Reads attr="value" inside the opening tag that starts at tagStart. The scan
+// is capped at the end of the opening tag and the value at MAX_VALUE_CHARS, so
+// a huge attribute cannot blow anything up - it just reads as absent. Handles
+// both double and single quotes (GPX exporters use either).
+function attrValue(xml: string, tagStart: number, attr: string): string | null {
+  const gt = xml.indexOf('>', tagStart);
+  const tagEnd = gt === -1 ? Math.min(xml.length, tagStart + 512) : gt;
+  const openTag = xml.slice(tagStart, tagEnd);
+  for (const quote of ['"', "'"]) {
+    const needle = `${attr}=${quote}`;
+    const at = openTag.indexOf(needle);
+    if (at === -1) continue;
+    const start = at + needle.length;
+    const end = openTag.indexOf(quote, start);
+    if (end === -1 || end - start > MAX_VALUE_CHARS) return null;
+    return openTag.slice(start, end);
+  }
+  return null;
+}
+
+// Removes every "<!-- ... -->" comment, single pass, indexOf-based. An
+// unterminated comment drops the rest of the document, exactly like a real XML
+// parser refusing to see past it.
+function stripComments(xml: string): string {
+  const open = '<!--';
+  const close = '-->';
+  if (!xml.includes(open)) return xml;
+  let out = '';
+  let from = 0;
+  for (;;) {
+    const at = xml.indexOf(open, from);
+    if (at === -1) return out + xml.slice(from);
+    out += xml.slice(from, at);
+    const end = xml.indexOf(close, at + open.length);
+    if (end === -1) return out; // unterminated comment: drop the rest
+    from = end + close.length;
+  }
+}
+
+function asFiniteNumber(text: string | null): number | null {
+  if (text === null) return null;
+  const n = Number(text);
+  return Number.isFinite(n) ? n : null;
+}
+
+// ------------------------------------------------------------
+// Haversine distance between two lat/lon points, in meters. Pure arithmetic,
+// no dependency. Mean Earth radius 6371000 m.
+// ------------------------------------------------------------
+const EARTH_RADIUS_M = 6_371_000;
+
+export function haversineMeters(
+  lat1: number,
+  lon1: number,
+  lat2: number,
+  lon2: number,
+): number {
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return EARTH_RADIUS_M * c;
+}
+
+// A trackpoint with valid coordinates (latitude in [-90,90], longitude in
+// [-180,180]) and optional time / heart rate.
+interface Trkpt {
+  lat: number;
+  lon: number;
+  time: Date | null;
+  hr: number | null;
+}
+
+// Reads one trkpt's lat/lon attributes and its optional <time> / HR extension.
+// Returns null when lat or lon is missing or out of range (a hostile or broken
+// point is dropped, not fatal). The HR extension appears as <gpxtpx:hr>,
+// <ns3:hr> or a bare <hr>; we read whichever is present first.
+function parseTrkpt(xml: string, tagStart: number, content: string): Trkpt | null {
+  const latText = attrValue(xml, tagStart, 'lat');
+  const lonText = attrValue(xml, tagStart, 'lon');
+  const lat = asFiniteNumber(latText);
+  const lon = asFiniteNumber(lonText);
+  if (lat === null || lon === null) return null;
+  if (lat < -90 || lat > 90 || lon < -180 || lon > 180) return null;
+
+  const timeText = firstTagText(content, 'time');
+  const time = timeText ? new Date(timeText) : null;
+  const validTime = time && !Number.isNaN(time.getTime()) ? time : null;
+
+  // HR extension: try the namespaced forms first, then a bare <hr>.
+  let hr: number | null = null;
+  for (const tag of ['gpxtpx:hr', 'ns3:hr', 'hr']) {
+    const text = firstTagText(content, tag);
+    const n = asFiniteNumber(text);
+    if (n !== null) {
+      hr = n;
+      break;
+    }
+  }
+
+  return { lat, lon, time: validTime, hr };
+}
+
+// Maps an optional GPX <type> to our sport enum (case-insensitive). Strava
+// emits values like "running"/"cycling"/"9"; we map the obvious word forms and
+// default to Other.
+function sportForType(type: string | null): GpxSport {
+  if (!type) return 'Other';
+  const t = type.trim().toLowerCase();
+  if (t.includes('run')) return 'Running';
+  if (t.includes('bik') || t.includes('cycl') || t.includes('ride')) return 'Biking';
+  return 'Other';
+}
+
+// ------------------------------------------------------------
+// The parser
+// ------------------------------------------------------------
+
+export function parseGpx(input: string): GpxParseResult {
+  if (input.length > GPX_MAX_BYTES) {
+    return fatal('File too large: the limit is 5 MB.');
+  }
+
+  // Strip comments BEFORE any scanning so commented-out markup (a smuggled
+  // <trk>, an inert commented DTD) is never seen, matching a real XML parser.
+  const xml = stripComments(input);
+
+  // Reject any DTD or entity declaration outright (XXE / billion-laughs cannot
+  // happen by construction: we also never decode entities anywhere).
+  const upper = xml.toUpperCase();
+  if (upper.includes('<!DOCTYPE') || upper.includes('<!ENTITY')) {
+    return fatal('Invalid GPX file: DTD and entity declarations are not allowed.');
+  }
+
+  // With comments stripped, every remaining "<!" must open a normal markup
+  // declaration (a letter follows). Anything else - "<!\0DOCTYPE", "<![CDATA[",
+  // "<!>" - is malformed or evasive and no real export emits it.
+  {
+    let bang = xml.indexOf('<!');
+    while (bang !== -1) {
+      const next = xml[bang + 2];
+      const isLetter =
+        next !== undefined && ((next >= 'a' && next <= 'z') || (next >= 'A' && next <= 'Z'));
+      if (!isLetter) {
+        return fatal('Invalid GPX file: malformed markup declaration.');
+      }
+      bang = xml.indexOf('<!', bang + 2);
+    }
+  }
+
+  if (!xml.includes('<gpx')) {
+    return fatal('Not a GPX file: missing <gpx> root.');
+  }
+
+  // Collect <trk> blocks (capped). Each track is one segment-set; we read its
+  // optional <type> for the sport and all its trackpoints across <trkseg>.
+  const trackBlocks: Array<{ tagStart: number; content: string }> = [];
+  {
+    let from = 0;
+    while (trackBlocks.length < MAX_TRACKS) {
+      const open = findOpenTag(xml, 'trk', from);
+      if (!open) break;
+      if (open.selfClosing) {
+        from = open.contentStart;
+        continue;
+      }
+      const end = xml.indexOf('</trk>', open.contentStart);
+      if (end === -1) break; // truncated track: ignore it
+      trackBlocks.push({ tagStart: open.tagStart, content: xml.slice(open.contentStart, end) });
+      from = end + '</trk>'.length;
+    }
+  }
+  if (trackBlocks.length === 0) {
+    return fatal('No track found in the file (it may be a route/waypoint-only GPX or truncated).');
+  }
+
+  // Walk every trackpoint in document order, across all tracks and segments,
+  // up to the hard cap. Distance is the haversine sum between consecutive
+  // points; duration is last-time minus first-time; HR is averaged over points
+  // that carry it. The first track's <type> sets the sport.
+  let sport: GpxSport = 'Other';
+  let sportSet = false;
+  let pointCount = 0;
+  let prev: Trkpt | null = null;
+  let totalMeters = 0;
+  let firstTime: Date | null = null;
+  let lastTime: Date | null = null;
+  let hrSum = 0;
+  let hrCount = 0;
+  let capped = false;
+
+  for (const track of trackBlocks) {
+    if (!sportSet) {
+      // <type> is a direct child of <trk>; reading it from the track content
+      // (segments do not carry a <type>) is sufficient.
+      sport = sportForType(firstTagText(track.content, 'type'));
+      sportSet = true;
+    }
+
+    // Iterate <trkpt> within this track (segments are flat here: a trkpt is the
+    // same whether or not it sits inside a <trkseg>).
+    let from = 0;
+    while (pointCount < MAX_TRACKPOINTS) {
+      const open = findOpenTag(track.content, 'trkpt', from);
+      if (!open) break;
+      let content = '';
+      let nextFrom: number;
+      if (open.selfClosing) {
+        nextFrom = open.contentStart;
+      } else {
+        const end = track.content.indexOf('</trkpt>', open.contentStart);
+        if (end === -1) break; // truncated point: stop this track
+        content = track.content.slice(open.contentStart, end);
+        nextFrom = end + '</trkpt>'.length;
+      }
+      from = nextFrom;
+
+      const pt = parseTrkpt(track.content, open.tagStart, content);
+      if (pt) {
+        pointCount += 1;
+        if (prev) {
+          totalMeters += haversineMeters(prev.lat, prev.lon, pt.lat, pt.lon);
+        }
+        prev = pt;
+        if (pt.time) {
+          if (!firstTime || pt.time < firstTime) firstTime = pt.time;
+          if (!lastTime || pt.time > lastTime) lastTime = pt.time;
+        }
+        if (pt.hr !== null && pt.hr > 0) {
+          hrSum += pt.hr;
+          hrCount += 1;
+        }
+      }
+    }
+    if (pointCount >= MAX_TRACKPOINTS) {
+      capped = true;
+      break;
+    }
+  }
+
+  if (pointCount === 0) {
+    return fatal('No usable trackpoints found (missing or invalid lat/lon coordinates).');
+  }
+  if (capped) {
+    // A file at the cap is almost certainly hostile or corrupt; refuse rather
+    // than import a partial, misleading total.
+    return fatal('Too many trackpoints: the file exceeds the supported size.');
+  }
+  if (!firstTime || !lastTime) {
+    return fatal('No usable timestamps found: GPX trackpoints must carry <time> to derive duration.');
+  }
+
+  const durationMs = lastTime.getTime() - firstTime.getTime();
+  if (durationMs <= 0) {
+    return fatal('Track duration is zero: the trackpoint timestamps do not advance.');
+  }
+
+  if (
+    firstTime < GPX_MIN_STARTED_AT ||
+    firstTime.getTime() > Date.now() + STARTED_AT_FUTURE_SLACK_MS
+  ) {
+    return fatal('Activity start time out of range: it must be between 2000-01-01 and tomorrow.');
+  }
+
+  const durationSec = Math.round(durationMs / 1000);
+  const rawAvgHr = hrCount > 0 ? Math.round(hrSum / hrCount) : null;
+  const candidate: GpxActivity = {
+    startedAt: firstTime,
+    durationSec,
+    // A single valid point yields no distance; round to cm like TCX.
+    distanceM: pointCount >= 2 ? Math.round(totalMeters * 100) / 100 : null,
+    // Out-of-bounds heart rate (sensor glitch or hostile value) degrades to
+    // "no heart rate" instead of failing the import: it is optional data.
+    avgHr: rawAvgHr !== null && rawAvgHr >= AVG_HR_MIN && rawAvgHr <= AVG_HR_MAX ? rawAvgHr : null,
+    sport,
+  };
+
+  const checked = activitySchema.safeParse(candidate);
+  if (!checked.success) {
+    return fatal(
+      'Activity totals out of bounds: duration must be 1 second to 24 hours and distance at most 1000 km.',
+    );
+  }
+  return { ok: true, fatalError: null, activity: checked.data };
+}
+
+// Default exercise name per GPX sport, matching the TCX importer's mapping so a
+// GPX run and a TCX run land on the same exercise. Ownership-scoped
+// lookup/creation happens in the route.
+export function gpxExerciseName(sport: GpxSport): string {
+  switch (sport) {
+    case 'Running':
+      return 'Running';
+    case 'Biking':
+      return 'Cycling';
+    default:
+      return 'Cardio (imported)';
+  }
+}

--- a/lib/schemas/import.ts
+++ b/lib/schemas/import.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { STRONG_CSV_MAX_BYTES } from '@/lib/import/strong-csv';
 import { TCX_MAX_BYTES } from '@/lib/import/tcx';
+import { GPX_MAX_BYTES } from '@/lib/import/gpx';
 
 // Strong CSV import request (issue #100). The csv field carries the raw file
 // text (untrusted): the size cap is enforced here AND on the content-length
@@ -35,3 +36,14 @@ export const tcxImportInputSchema = z.object({
 });
 
 export type TcxImportInput = z.infer<typeof tcxImportInputSchema>;
+
+// GPX track import request (issue #204). The gpx field carries the raw file
+// text (untrusted XML - lib/import/gpx.ts refuses DTDs/entities by
+// construction, caps the trackpoint count, and the size cap is enforced here
+// AND on the streamed body read); same preview/confirm modes as the others.
+export const gpxImportInputSchema = z.object({
+  gpx: z.string().min(1).max(GPX_MAX_BYTES, 'File too large: the limit is 5 MB.'),
+  mode: z.enum(['preview', 'confirm']),
+});
+
+export type GpxImportInput = z.infer<typeof gpxImportInputSchema>;

--- a/tests/e2e/gpx-import.spec.ts
+++ b/tests/e2e/gpx-import.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test';
+
+// GPX cardio import (issue #204): switch the settings import section to GPX,
+// upload a route file, check the dry-run preview, confirm, and find the
+// imported cardio session with its heart rate in the history detail. Distance
+// is derived from the trackpoints (haversine), so it is not asserted exactly.
+
+const RUN_GPX = `<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="e2e" xmlns="http://www.topografix.com/GPX/1/1">
+  <trk>
+    <name>Evening run</name>
+    <type>running</type>
+    <trkseg>
+      <trkpt lat="48.8566" lon="2.3522"><time>2026-05-21T18:00:00.000Z</time><extensions><gpxtpx:hr>150</gpxtpx:hr></extensions></trkpt>
+      <trkpt lat="48.8576" lon="2.3532"><time>2026-05-21T18:01:00.000Z</time><extensions><gpxtpx:hr>152</gpxtpx:hr></extensions></trkpt>
+      <trkpt lat="48.8586" lon="2.3542"><time>2026-05-21T18:02:00.000Z</time><extensions><gpxtpx:hr>158</gpxtpx:hr></extensions></trkpt>
+      <trkpt lat="48.8596" lon="2.3552"><time>2026-05-21T18:03:00.000Z</time><extensions><gpxtpx:hr>160</gpxtpx:hr></extensions></trkpt>
+    </trkseg>
+  </trk>
+</gpx>`;
+
+test('a lifter can import a GPX activity as a cardio session', async ({ page }) => {
+  // Fresh user via the API; a unique X-Forwarded-For keeps this spec in its own
+  // register rate-limit bucket (the suite's parallel UI signups use the per-IP
+  // 5/min budget).
+  const registerRes = await page.request.post('/api/auth/register', {
+    headers: { 'x-forwarded-for': '10.111.0.4' },
+    data: {
+      displayName: 'GPX E2E',
+      email: `e2e-gpx-${Date.now()}@test.dev`,
+      password: 'supersecret',
+    },
+  });
+  expect(registerRes.ok()).toBeTruthy();
+
+  await page.goto('/settings');
+  await expect(page.getByText('Import from Strong')).toBeVisible();
+
+  // Switch the source to GPX: the copy flips to the cardio activity import.
+  await page.getByLabel('Source app').click();
+  await page.getByRole('option', { name: 'GPX file' }).click();
+  await expect(page.getByText('Import a GPX activity')).toBeVisible();
+
+  // Upload the file: the dry-run preview appears, nothing imported yet.
+  await page.locator('input[type="file"][accept^=".gpx"]').setInputFiles({
+    name: 'evening-run.gpx',
+    mimeType: 'application/gpx+xml',
+    buffer: Buffer.from(RUN_GPX, 'utf-8'),
+  });
+
+  const preview = page.getByTestId('import-preview');
+  await expect(preview).toBeVisible();
+  await expect(preview).toContainText('1 cardio session (Running)');
+  // HR averaged from 150/152/158/160 = 155; logged as Running. Distance is
+  // haversine-derived so it is not asserted exactly.
+  await expect(preview).toContainText('avg HR 155 bpm');
+  await expect(preview).toContainText('logged as Running');
+
+  // Confirm and find the imported session in the history.
+  await page.getByRole('button', { name: /confirm import/i }).click();
+  await expect(page.getByTestId('import-preview')).not.toBeVisible();
+
+  await page.goto('/history');
+  await expect(page.getByText('May 21, 2026')).toBeVisible();
+
+  // The session detail shows the cardio set with its average heart rate.
+  await page.getByRole('link', { name: /May 21, 2026/ }).click();
+  await expect(page.getByRole('heading', { name: 'Running' })).toBeVisible();
+  await expect(page.getByText('155 bpm')).toBeVisible();
+});


### PR DESCRIPTION
Closes #204 - the third file-import format (TCX shipped in #152), extending the file-based, no-OAuth data-ownership wedge.

- lib/import/gpx.ts: minimal no-entity-decode XML extractor mirroring tcx.ts EXACTLY - strips comments, rejects <!DOCTYPE/<!ENTITY (and null-byte-split variants), no entity table so XXE / billion-laughs are impossible by construction. Distance via haversine over the trackpoints (point count capped), duration from first/last <time>, average HR from the gpxtpx:hr extension. 30 unit tests including the full hostile-input suite (DTD, XXE, billion-laughs with a time bound, comment-smuggled track, commented-out DTD inert, unterminated comment, out-of-bounds duration).
- app/api/import/gpx/route.ts: ownership-scoped, streamed body cap (parseJsonBody maxBytes), shared import rate bucket, dry-run preview with near-duplicate warning, transactional confirm - same hardening as #105/#108/#158.
- Settings import section gains the GPX option (shares the TCX cardio preview UI).
- New E2E: upload a GPX -> preview -> confirm -> the cardio session appears in history with its averaged HR.

Provenance note: the parser/route/UI/unit-tests shipped from a maintainer tick that died on a transient socket error after completing them; I verified the full gate was green on the uncommitted work, added the missing E2E, and re-ran the full gate.

## How I tested
- bash scripts/verify.sh --full - GREEN-GATE PASSED (13 E2E incl. the new GPX one)

Per the issue, an independent SECURITY-lens post-merge review is mandatory (untrusted XML).

🤖 Generated with [Claude Code](https://claude.com/claude-code)