### PR TITLE
docs: write up batch 10 (GPX import, body measurements, max HR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   single field of the set logger to fill the weight, reps, and effort fields
   (RPE maps to the stored RIR). Deterministic parser in the user's display
   unit; the classic fields keep working unchanged.
+- Import a GPX file as a cardio session: bring a route export from Strava,
+  Komoot or Apple Fitness in as one cardio session (distance computed from
+  the GPS track, duration from the timestamps, heart rate from the track
+  extension) - the third file-import format, file-based and no-OAuth like the
+  rest. The parser does no XML entity decoding, so XXE and entity bombs are
+  impossible by construction.
+- Body-measurement tracking: log tape measurements (waist, arms, thighs, ...)
+  from a card on the progress page, with the latest value per site and a
+  trend, in your display unit. Stored alongside, and mirroring, bodyweight.
+- Maximum heart rate on cardio sets: the peak HR is stored, imported from and
+  exported to TCX, and shown next to the average; the CSV export gains
+  avg/max HR columns.
 - A free-text note to your coach: write a short note the AI coach reads -
   injuries, illness, life constraints - so its advice accounts for your own
   current context. It is the correctable half of "what your coach sees"; the

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -1347,3 +1347,18 @@ continuously, no per-change approval, self-challenge with subagents, keep a roll
 **Challenged.** Two parallel Opus reviews (one injection-lensed). Accepted-change rate: 4 merged / 0 abandoned this batch.
 
 **Deferred to human.** Nothing outstanding. Future: mobility session type (low confidence), Serwist migration (build-time advisories).
+
+---
+
+## 2026-06-15 - Batch 10 (#202/#203/#204): a maintainer tick died mid-run; resumed without loss
+
+**Context.** Tenth ideate batch (body measurements #202, cardio max HR #203, GPX import #204). The implementing tick (inherited Opus; Fable still unavailable) shipped #206 (#203) and #207 (#202), then DIED on a transient socket error mid-PR for #204, leaving a complete-but-uncommitted GPX implementation (parser + route + UI + 30 unit tests incl. the full hostile-input suite) on its branch. It had tagged the rollback baselines (autonomy-baseline-2026-06-14 / -14b) before its migrations.
+
+**Decided / shipped.**
+- Resumed the dead tick's GPX branch (socket-close is terminal, no zombie): verified the full gate was green on the uncommitted work, sanity-checked the parser's security posture, added the one missing piece (the E2E the issue required), re-gated, and shipped it as PR #208 on green full CI.
+- All three PRs then got the independent post-merge reviews the dead tick never reported: #206 CLEAN (max HR; Track subtree stripped before lap-max, bounds on all writers), #207 CLEAN (measurements; ownership, additive migration no drift), #208 CLEAN under a HOSTILE security review (21 adversarial cases - no entity table, billion-laughs <1ms, 5MB linear ~110ms, 200k-point cap, GPX name never read so no attacker text reaches DB/CSV/React). Zero REAL findings across the batch.
+- The product now imports four formats (Strong/Hevy CSV, TCX, GPX) plus full export - the file-based neutral ground the 2026-06-12 research identified.
+
+**Challenged.** Three parallel Opus reviews (one hostile-security). Accepted-change rate: 3 merged / 0 abandoned. The resilience pattern held: durable git/PR state meant the socket death cost no work; the mandatory review validated dead-tick code under attack.
+
+**Deferred to human.** Nothing. Future: FIT import (binary, needs a decoder), free-text AI set logging (LLM-shaped), mobility session type (low confidence), Serwist (build-time chore). #169 (Next 15) already done.

--- a/docs/loops/ideas-backlog.md
+++ b/docs/loops/ideas-backlog.md
@@ -46,6 +46,6 @@ research and the product wedge). See `docs/loops/08-ideation-loop.md` for how th
 - shipped - a free-text note to your coach (correctable AI memory) (issue #188, 2026-06-13, PR #194) - multi-lens review CLEAN incl. injection posture (note is JSON data, not instructions; contract byte-identical)
 - shipped - supersets slice 2: superset-aware rest timer (issue #189, 2026-06-13, PR #193) - review CLEAN, E2E proven live (short between members, full after group)
 - shipped - a Records board (all-time bests per exercise) (issue #190, 2026-06-13, PR #192 + fix #196) - review CLEAN; tie-break date made deterministic
-- proposed - body-measurement tracking (waist/arms/etc.) with a trend (issue #202, 2026-06-14) - additive BodyMeasurement table mirroring bodyweight #99; recomp/hypertrophy want
-- proposed - maximum heart rate on cardio sets (issue #203, 2026-06-14) - small additive completion of the HR story (avgHr exists); TCX carries MaximumHeartRateBpm
-- proposed - import a GPX file as a cardio session (issue #204, 2026-06-14) - third file-import format on the hardened no-entity-decode XML pipeline; haversine distance from the track; security-lens review mandatory
+- shipped - body-measurement tracking (waist/arms/etc.) with a trend (issue #202, 2026-06-14, PR #207) - additive BodyMeasurement table; multi-lens review CLEAN (ownership, bounds, migration drift)
+- shipped - maximum heart rate on cardio sets (issue #203, 2026-06-14, PR #206) - additive Set.maxHr; review CLEAN (bounds on all writers, Track subtree stripped before lap-max extraction)
+- shipped - import a GPX file as a cardio session (issue #204, 2026-06-15, PR #208) - third file format; hostile security review CLEAN (21 adversarial cases, no entity table, linear at 5MB, name never read)


### PR DESCRIPTION
Content-loop tail for batch 10 (#206 max HR, #207 body measurements, #208 GPX import).

- CHANGELOG: all three user-facing (GPX import headlined - the fourth import format extends the data-ownership wedge).
- Backlog: shipped with the three CLEAN review verdicts (the GPX parser cleared a 21-case hostile security review).
- Journal: records that the implementing tick died mid-run on a socket error and the GPX work was resumed from its uncommitted branch without loss, then independently reviewed - the resilience pattern in action.
- Media unchanged: the new surfaces (measurements card below the progress fold, GPX in settings import, max HR in session detail) are not among the four captured screenshots.

bash scripts/verify.sh - GREEN-GATE PASSED.

After merge: triggering deploy-demo (redeploying directly if the runner SSH egress is still flaky).

🤖 Generated with [Claude Code](https://claude.com/claude-code)