### PR TITLE
feat: give the AI coach your all-time records (#212)

### DIFF
--- a/lib/coach-context.test.ts
+++ b/lib/coach-context.test.ts
@@ -35,6 +35,7 @@ function emptyPayload(): CoachPayload {
       days: [],
       weeklyTargetMin: 150,
     },
+    records: [],
     recentProgress: [],
   };
 }

--- a/lib/coach.ts
+++ b/lib/coach.ts
@@ -22,6 +22,7 @@ import {
   recommendDeload,
 } from '@/lib/deload';
 import { COACH_SYSTEM_PROMPT } from '@/lib/prompts/coach-system-prompt';
+import { exerciseRecords, type ExerciseRecord } from '@/lib/records';
 import { getLlmProvider } from '@/lib/llm';
 
 // ============================================================
@@ -76,6 +77,15 @@ export interface CoachPayload {
   // chat is opened from the session runner with a session the user owns.
   // Additive and input-side only; the output contract is unchanged.
   currentSession?: CurrentSessionContext;
+  // All-time personal records per strength exercise (issue #212), via the SAME
+  // lib/records.ts exerciseRecords derivation the progress page's records board
+  // uses: heaviest working set ever (weight x reps) and best estimated 1RM ever,
+  // on effective load (bodyweight included), cardio and warm-ups excluded. This
+  // lets the debrief acknowledge a fresh PR and anchor advice on the user's
+  // bests without inventing records. Compact: capped to the most recently
+  // trained exercises (see COACH_RECORDS_CAP). Input signal only; the output
+  // contract (the <adjustments> block) is unchanged.
+  records: RecordSummary[];
   // For each program exercise: the progression over the last 8 weeks
   // (max loads + 1RM per session, effective values with bodyweight included).
   recentProgress: Array<{
@@ -93,6 +103,17 @@ export interface CoachPayload {
       estimated1RM: number;
     }>;
   }>;
+}
+
+// A compact all-time record for one exercise (issue #212). Mirrors the fields
+// the spec asks the coach to see: heaviest working set (weight x reps) and best
+// estimated 1RM ever. The dates exerciseRecords also computes are dropped to
+// keep the payload compact - the coach references the bests, not their history.
+interface RecordSummary {
+  exerciseName: string;
+  maxWeight: number;
+  maxWeightReps: number;
+  bestE1RM: number;
 }
 
 interface ConditioningWeek {
@@ -246,6 +267,11 @@ interface ProgramSummary {
 // Building the payload
 // ============================================================
 
+// Cap on the all-time records list (issue #212): keep the payload compact by
+// sending at most this many records, ordered by how recently the exercise was
+// trained, so the coach sees the bests for the lifts the user actually works.
+const COACH_RECORDS_CAP = 20;
+
 export async function buildCoachPayload(userId: string): Promise<CoachPayload> {
   const now = new Date();
   const currentWeekStart = isoWeekStart(now);
@@ -278,6 +304,7 @@ export async function buildCoachPayload(userId: string): Promise<CoachPayload> {
     latestReadiness,
     goals,
     fatigue,
+    records,
     recentSets,
   ] = await Promise.all([
     weekSummary(userId, currentWeekStart, addDays(currentWeekStart, 7), bodyweight),
@@ -286,6 +313,7 @@ export async function buildCoachPayload(userId: string): Promise<CoachPayload> {
     fetchLatestReadiness(userId, now),
     fetchGoalsSummary(userId, bodyweight),
     fetchFatigueSummary(userId, bodyweight, now),
+    fetchRecordsSummary(userId, bodyweight),
     db.set.findMany({
       where: {
         isWarmup: false,
@@ -440,6 +468,7 @@ export async function buildCoachPayload(userId: string): Promise<CoachPayload> {
       deloadActive: isDeloadActive(user?.deloadUntil ?? null, now),
     },
     conditioning,
+    records,
     recentProgress: recentProgress.sort((a, b) =>
       a.exerciseName.localeCompare(b.exerciseName),
     ),
@@ -633,6 +662,71 @@ async function fetchGoalsSummary(
       achieved: goal.achievedAt != null,
     };
   });
+}
+
+// All-time records summary for the coach (issue #212). Reuses the EXACT
+// exerciseRecords derivation the progress page's records board uses: full set
+// history, cardio excluded at the query (category != CARDIO), warm-ups excluded
+// both here and in the derivation, effective load applied so a bodyweight
+// movement reads on the load actually moved. The list is then trimmed to the
+// most recently trained exercises and the per-record dates are dropped to keep
+// the payload compact. Input signal only; the output contract is unchanged.
+async function fetchRecordsSummary(
+  userId: string,
+  bodyweight: number | null,
+): Promise<RecordSummary[]> {
+  const recordSetsRaw = await db.set.findMany({
+    where: {
+      isWarmup: false,
+      session: { userId },
+      exercise: { category: { not: 'CARDIO' } },
+    },
+    // Oldest first so a tie (same load / e1RM) keeps the EARLIEST date in
+    // exerciseRecords, matching the records board's "first to reach it".
+    orderBy: { session: { startedAt: 'asc' } },
+    select: {
+      weight: true,
+      reps: true,
+      isWarmup: true,
+      durationSec: true,
+      exercise: { select: { name: true, usesBodyweight: true } },
+      session: { select: { startedAt: true } },
+    },
+  });
+
+  const records = exerciseRecords(
+    recordSetsRaw.map((s) => ({
+      weight: effectiveWeight(s.weight, s.exercise.usesBodyweight, bodyweight),
+      reps: s.reps,
+      isWarmup: s.isWarmup,
+      durationSec: s.durationSec,
+      exerciseName: s.exercise.name,
+      sessionStartedAt: s.session.startedAt,
+    })),
+  );
+
+  // Most-recently-trained exercises first, so a capped list keeps the lifts the
+  // user actually works. The latest qualifying set per exercise dates recency;
+  // rows arrive oldest-first, so the last seen per name is the most recent.
+  const lastTrained = new Map<string, number>();
+  for (const s of recordSetsRaw) {
+    if (s.isWarmup || s.durationSec != null || s.weight <= 0 || s.reps <= 0) continue;
+    lastTrained.set(s.exercise.name, s.session.startedAt.getTime());
+  }
+
+  return records
+    .slice()
+    .sort(
+      (a, b) =>
+        (lastTrained.get(b.exerciseName) ?? 0) - (lastTrained.get(a.exerciseName) ?? 0),
+    )
+    .slice(0, COACH_RECORDS_CAP)
+    .map((r: ExerciseRecord) => ({
+      exerciseName: r.exerciseName,
+      maxWeight: r.maxWeight,
+      maxWeightReps: r.maxWeightReps,
+      bestE1RM: r.bestE1RM,
+    }));
 }
 
 // The same window the progress page judges stalls over (last 12 weeks).

--- a/lib/llm/demo.test.ts
+++ b/lib/llm/demo.test.ts
@@ -30,6 +30,9 @@ describe('demo provider', () => {
     expect(debrief.text).toMatch(/of the way to your .* target/i);
     expect(debrief.text).toMatch(/stalled/i);
     expect(debrief.text).toMatch(/deload/i);
+    // Issue #212: the canned debrief references an all-time record so the no-key
+    // flow exercises the records payload field.
+    expect(debrief.text).toMatch(/personal record|PR|all-time best/i);
 
     const program = await p.complete({
       system: 'Respond with a SINGLE JSON object and nothing else.',

--- a/lib/llm/demo.ts
+++ b/lib/llm/demo.ts
@@ -22,6 +22,9 @@ Solid week: 3 sessions logged, total working volume up about 4% versus last week
 - Barbell bench press: 70 kg x 8 at RIR 2 on the top set, estimated 1RM up again.
 - Pronated pull-ups: clean reps across all sets, ready for added load.
 
+**Personal records**
+- New PR on Barbell bench press: 70 kg x 8 edged your all-time best estimated 1RM. Nice work - that is the strongest this lift has read.
+
 **Goal check**
 - Barbell bench press: 92% of the way to your 80 kg x 8 target on the estimated-1RM scale. One more clean progression and it should fall.
 

--- a/lib/prompts/coach-system-prompt.test.ts
+++ b/lib/prompts/coach-system-prompt.test.ts
@@ -65,6 +65,17 @@ describe('coach system prompt positioning', () => {
     expect(COACH_SYSTEM_PROMPT).toMatch(/do not\s+recommend starting a deload then/i);
   });
 
+  // Issue #212: all-time records are INPUT-side context only - reference and
+  // celebrate them, never invent one; records do not change the output format.
+  it('tells the coach to reference records and forbids inventing a PR', () => {
+    expect(COACH_SYSTEM_PROMPT).toMatch(/"records": the user's all-time bests/i);
+    expect(COACH_SYSTEM_PROMPT).toMatch(/acknowledge the personal record/i);
+    expect(COACH_SYSTEM_PROMPT).toMatch(/NEVER invent\s+a record/i);
+    expect(COACH_SYSTEM_PROMPT).toMatch(
+      /records never go in the <adjustments> block/i,
+    );
+  });
+
   // Issue #145: conditioning is an INPUT-side signal; the output contract
   // (the <adjustments> block) stays about the lifting program.
   it('tells the coach to factor conditioning into recovery, without medical advice', () => {

--- a/lib/prompts/coach-system-prompt.ts
+++ b/lib/prompts/coach-system-prompt.ts
@@ -60,6 +60,18 @@ week (the app is stepping their suggested loads down about 10%): do not
 recommend starting a deload then - support executing the one underway and frame
 suggestions around returning to normal loads when it ends.
 
+The payload also carries "records": the user's all-time bests per strength
+exercise (exerciseName, maxWeight with its maxWeightReps, and bestE1RM on the
+estimated-1RM scale), computed over their full logged history on effective load.
+Use them to celebrate and to anchor advice: when a set in the current week
+matches or beats one of these bests, acknowledge the personal record in plain
+words; when you suggest a load or rep target, relate it to the user's best for
+that lift so the advice is grounded in what they have actually done. NEVER invent
+a record, claim a PR that the data does not support, or cite a best for an
+exercise that is not in "records". This is context to reference, not a new output
+section: records never go in the <adjustments> block and do not change your
+output format.
+
 The "conditioning" section summarizes the user's cardio training, which is
 deliberately kept out of the strength signals above: conditioning.weekCurrent
 and conditioning.weekPrevious give total minutes, km and cardio session counts

--- a/tests/integration/core.test.ts
+++ b/tests/integration/core.test.ts
@@ -609,3 +609,81 @@ describe('buildCoachPayload fatigue (issue #101)', () => {
     expect(payload.fatigue.stalledExercises).toEqual([]);
   });
 });
+
+describe('buildCoachPayload records (issue #212)', () => {
+  // Logs three working sets on distinct days; the heaviest set and the best
+  // estimated 1RM may sit on different sets, exactly like the records board.
+  async function seedLift(
+    userId: string,
+    name: string,
+    sets: Array<{ weight: number; reps: number; daysAgo: number; isWarmup?: boolean }>,
+    opts: { usesBodyweight?: boolean; category?: 'COMPOUND' | 'CARDIO' } = {},
+  ) {
+    const exercise = await db.exercise.create({
+      data: {
+        userId,
+        name,
+        muscleGroup: 'CHEST',
+        category: opts.category ?? 'COMPOUND',
+        usesBodyweight: opts.usesBodyweight ?? false,
+      },
+    });
+    for (const s of sets) {
+      const startedAt = new Date(Date.now() - s.daysAgo * 24 * 60 * 60 * 1000);
+      const session = await db.session.create({
+        data: { userId, startedAt, finishedAt: startedAt },
+      });
+      await db.set.create({
+        data: {
+          sessionId: session.id,
+          exerciseId: exercise.id,
+          setNumber: 1,
+          weight: s.weight,
+          reps: s.reps,
+          isWarmup: s.isWarmup ?? false,
+          completedAt: startedAt,
+        },
+      });
+    }
+    return exercise;
+  }
+
+  it('pins all-time bests per lift from the full set history', async () => {
+    const user = await makeUser('records-bests@test.dev');
+    // Heaviest set: 110x3; best e1RM: 100x8 (Epley 100*(1+8/30)=126.7 > 110*1.1=121).
+    await seedLift(user.id, 'Bench', [
+      { weight: 100, reps: 8, daysAgo: 30 },
+      { weight: 110, reps: 3, daysAgo: 10 },
+      { weight: 60, reps: 10, daysAgo: 40, isWarmup: true },
+    ]);
+
+    const payload = await buildCoachPayload(user.id);
+    const bench = payload.records.find((r) => r.exerciseName === 'Bench');
+    expect(bench).toEqual({
+      exerciseName: 'Bench',
+      maxWeight: 110,
+      maxWeightReps: 3,
+      bestE1RM: 126.7,
+    });
+  });
+
+  it('excludes cardio and reports nothing for a fresh user', async () => {
+    const user = await makeUser('records-fresh@test.dev');
+    await seedLift(user.id, 'Running', [{ weight: 0, reps: 1, daysAgo: 2 }], {
+      category: 'CARDIO',
+    });
+
+    const payload = await buildCoachPayload(user.id);
+    expect(payload.records).toEqual([]);
+  });
+
+  it("does not leak another user's records", async () => {
+    const userA = await makeUser('records-a@test.dev');
+    const userB = await makeUser('records-b@test.dev');
+    await seedLift(userB.id, 'B Bench', [{ weight: 200, reps: 5, daysAgo: 3 }]);
+
+    const payload = await buildCoachPayload(userA.id);
+    expect(payload.records.map((r) => r.exerciseName)).not.toContain('B Bench');
+    expect(payload.records).toEqual([]);
+  });
+});


### PR DESCRIPTION
Feeds the records board (#190) into the coach payload so the weekly debrief can acknowledge a fresh PR and anchor advice on the user's bests. Input-side only - the `<adjustments>` output contract is unchanged.

## What changed
- `CoachPayload.records`: compact `{ exerciseName, maxWeight, maxWeightReps, bestE1RM }` per strength exercise, computed via the SAME `lib/records.ts` `exerciseRecords` derivation the progress page uses (effective load with bodyweight, cardio excluded at the query, warm-ups excluded). Capped to the most-recently-trained exercises (`COACH_RECORDS_CAP = 20`) and dates dropped to stay compact.
- `coach-system-prompt.ts`: input-side guidance telling the coach to reference and celebrate a PR and anchor targets on the user's bests, and to NEVER invent a record. Records never go in `<adjustments>`; the output format is unchanged.
- Demo provider: the canned debrief now references an all-time record so the no-key flow exercises the field.

## Reinforced controls
- Existing `<adjustments>` contract tests pass UNMODIFIED.
- Integration tests pin records (seeded bests with heaviest-set vs best-e1RM on different sets; cardio excluded; cross-user isolation; empty for a fresh user); prompt + demo-provider assertions added.

## How I tested
`bash scripts/verify.sh --full`: lint, typecheck, build, unit (714), integration (153, incl. new records tests), and E2E (13) all pass. One unit flake (`readiness-checkin` 5s timeout under parallel load, an untouched test) reproduced only under full-suite load and passes in isolation and on a clean unit re-run - not a regression.

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)