### PR TITLE
feat: user-settable weekly volume targets (personal MEV/MRV per muscle) (#211)

### DIFF
--- a/app/(app)/progress/page.tsx
+++ b/app/(app)/progress/page.tsx
@@ -15,6 +15,7 @@ import {
   weeklyConditioning,
   weeklySetsByMuscleGroup,
   weeklyVolumeByMuscleGroup,
+  resolveVolumeBand,
   WEEKLY_SETS_MEV,
   WEEKLY_SETS_MRV,
 } from '@/lib/stats';
@@ -79,6 +80,18 @@ export default async function ProgressPage(
   ]);
   const bodyweight = user?.bodyweight ?? null;
   const unit = user?.unit ?? 'KG';
+
+  // The user's per-muscle volume targets (issue #211): personal MEV/MRV bands
+  // that override the global defaults for the volume-landmark card. Absent
+  // groups fall back to the defaults via resolveVolumeBand.
+  const volumeTargetRows = await db.volumeTarget.findMany({
+    where: { userId: auth.userId },
+    select: { muscleGroup: true, mev: true, mrv: true },
+  });
+  const volumeTargets: Record<string, { mev: number; mrv: number }> =
+    Object.fromEntries(
+      volumeTargetRows.map((t) => [t.muscleGroup, { mev: t.mev, mrv: t.mrv }]),
+    );
   const usesBodyweightById = new Map(
     exercisesWithSets.map((e) => [e.id, e.usesBodyweight]),
   );
@@ -210,14 +223,25 @@ export default async function ProgressPage(
   const volumeLandmarks = latestCompletedWeek
     ? {
         weekKey: latestCompletedWeek.weekKey,
+        // Default band, shown as the card-level reference; each row also
+        // carries its own resolved band (custom or default).
         mev: WEEKLY_SETS_MEV,
         mrv: WEEKLY_SETS_MRV,
         byMuscleGroup: Object.fromEntries(
           Object.entries(latestCompletedWeek.byMuscleGroup).map(
-            ([group, sets]) => [
-              group,
-              { sets, zone: classifyWeeklySets(sets) },
-            ],
+            ([group, sets]) => {
+              const band = resolveVolumeBand(group, volumeTargets);
+              return [
+                group,
+                {
+                  sets,
+                  zone: classifyWeeklySets(sets, band.mev, band.mrv),
+                  mev: band.mev,
+                  mrv: band.mrv,
+                  custom: band.custom,
+                },
+              ];
+            },
           ),
         ),
       }
@@ -457,6 +481,8 @@ export default async function ProgressPage(
                 total: w.total,
               }))}
               volumeLandmarks={volumeLandmarks}
+              volumeTargets={volumeTargets}
+              defaultBand={{ mev: WEEKLY_SETS_MEV, mrv: WEEKLY_SETS_MRV }}
               recap={recap}
               unit={unit}
               selectedGoal={

--- a/app/api/volume-targets/route.ts
+++ b/app/api/volume-targets/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
+import {
+  volumeTargetInputSchema,
+  volumeTargetClearSchema,
+} from '@/lib/schemas/volume-target';
+
+// Per-muscle weekly volume targets (issue #211). Every handler operates strictly
+// on the authenticated user's own rows (requireApiUserId + a userId-scoped
+// where/unique), so ownership is enforced by construction - there is no way to
+// address or clobber another user's target.
+
+// GET /api/volume-targets: the user's saved per-muscle bands.
+export async function GET() {
+  try {
+    const userId = await requireApiUserId();
+    const targets = await db.volumeTarget.findMany({
+      where: { userId },
+      select: { muscleGroup: true, mev: true, mrv: true },
+    });
+    return NextResponse.json(targets);
+  } catch (err) {
+    return handleApiError(err);
+  }
+}
+
+// POST /api/volume-targets: set (upsert) the band for one muscle group. The Zod
+// schema bounds mev/mrv (1..40) and enforces mrv > mev; one row per
+// (userId, muscleGroup) via the unique constraint.
+export async function POST(req: Request) {
+  try {
+    const userId = await requireApiUserId();
+    const data = await parseJsonBody(req, volumeTargetInputSchema);
+    const target = await db.volumeTarget.upsert({
+      where: {
+        userId_muscleGroup: { userId, muscleGroup: data.muscleGroup },
+      },
+      create: {
+        userId,
+        muscleGroup: data.muscleGroup,
+        mev: data.mev,
+        mrv: data.mrv,
+      },
+      update: { mev: data.mev, mrv: data.mrv },
+      select: { muscleGroup: true, mev: true, mrv: true },
+    });
+    return NextResponse.json(target, { status: 201 });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}
+
+// DELETE /api/volume-targets: clear (reset to default) the band for one muscle
+// group. Idempotent - deleting an absent target is a no-op success, so the
+// group falls back to the global defaults.
+export async function DELETE(req: Request) {
+  try {
+    const userId = await requireApiUserId();
+    const data = await parseJsonBody(req, volumeTargetClearSchema);
+    await db.volumeTarget.deleteMany({
+      where: { userId, muscleGroup: data.muscleGroup },
+    });
+    return NextResponse.json({ muscleGroup: data.muscleGroup, cleared: true });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/components/progress/progress-dashboard.tsx
+++ b/components/progress/progress-dashboard.tsx
@@ -32,6 +32,7 @@ import {
 } from '@/lib/stats';
 import { roundWeight, toDisplayWeight, unitLabel } from '@/lib/units';
 import { ExerciseGoalCard, type GoalView } from '@/components/progress/exercise-goal-card';
+import { VolumeTargetEditor } from '@/components/progress/volume-target-editor';
 
 interface RecapRow {
   exerciseId: string;
@@ -62,7 +63,18 @@ interface VolumeLandmarks {
   weekKey: string;
   mev: number;
   mrv: number;
-  byMuscleGroup: Record<string, { sets: number; zone: VolumeLandmarkZone }>;
+  byMuscleGroup: Record<
+    string,
+    {
+      sets: number;
+      zone: VolumeLandmarkZone;
+      // Issue #211: the band actually applied to this group (the user's custom
+      // target when set, else the defaults).
+      mev: number;
+      mrv: number;
+      custom: boolean;
+    }
+  >;
 }
 
 interface Props {
@@ -71,6 +83,10 @@ interface Props {
   exercisePoints: ExerciseChartPoint[];
   weeklyPoints: SerializedWeeklyPoint[];
   volumeLandmarks: VolumeLandmarks | null;
+  // Issue #211: the user's saved per-muscle targets (muscleGroup -> band) and
+  // the global defaults, for the inline editor.
+  volumeTargets: Record<string, { mev: number; mrv: number }>;
+  defaultBand: { mev: number; mrv: number };
   recap: RecapRow[];
   unit: WeightUnit;
   // Target goal for the selected exercise (issue #90), with the
@@ -128,6 +144,8 @@ export function ProgressDashboard({
   exercisePoints,
   weeklyPoints,
   volumeLandmarks,
+  volumeTargets,
+  defaultBand,
   recap,
   unit,
   selectedGoal,
@@ -366,9 +384,9 @@ export function ProgressDashboard({
             <h2 className="text-base font-semibold">Volume landmarks</h2>
             <p className="text-xs text-muted-foreground">
               Working sets in {shortLabelFromWeekKey(volumeLandmarks.weekKey)}{' '}
-              vs a reference band of {volumeLandmarks.mev}-{volumeLandmarks.mrv}{' '}
-              sets/week per muscle group (MEV-MRV). General hypertrophy
-              defaults, not a prescription.
+              vs your reference band (MEV-MRV) per muscle group. Defaults to{' '}
+              {defaultBand.mev}-{defaultBand.mrv} sets/week; edit a group to set
+              your own. General hypertrophy heuristic, not a prescription.
             </p>
           </CardHeader>
           <CardContent>
@@ -380,14 +398,29 @@ export function ProgressDashboard({
                     key={row.group}
                     className="flex items-center justify-between gap-3 text-sm"
                   >
-                    <span className="font-medium">
-                      {muscleGroupLabel(row.group)}
+                    <span className="flex items-center gap-2">
+                      <span className="font-medium">
+                        {muscleGroupLabel(row.group)}
+                      </span>
+                      <span className="text-xs text-muted-foreground">
+                        {row.mev}-{row.mrv}
+                        {row.custom ? ' (custom)' : ' (default)'}
+                      </span>
                     </span>
                     <span className="flex items-center gap-2">
                       <span className="text-muted-foreground">
                         {row.sets} {row.sets === 1 ? 'set' : 'sets'}
                       </span>
                       <Badge variant={meta.variant}>{meta.label}</Badge>
+                      <VolumeTargetEditor
+                        muscleGroup={row.group}
+                        label={muscleGroupLabel(row.group)}
+                        mev={row.mev}
+                        mrv={row.mrv}
+                        custom={row.custom}
+                        defaultMev={defaultBand.mev}
+                        defaultMrv={defaultBand.mrv}
+                      />
                     </span>
                   </li>
                 );

--- a/components/progress/volume-target-editor.test.tsx
+++ b/components/progress/volume-target-editor.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { VolumeTargetEditor } from './volume-target-editor';
+
+const refresh = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh }),
+}));
+
+function lastFetchCall(fetchMock: ReturnType<typeof vi.fn>) {
+  return fetchMock.mock.calls.at(-1) as [string, RequestInit | undefined];
+}
+
+function renderEditor(over: Partial<Parameters<typeof VolumeTargetEditor>[0]> = {}) {
+  return render(
+    <VolumeTargetEditor
+      muscleGroup="CHEST"
+      label="Chest"
+      mev={10}
+      mrv={20}
+      custom={false}
+      defaultMev={10}
+      defaultMrv={20}
+      {...over}
+    />,
+  );
+}
+
+describe('VolumeTargetEditor (issue #211)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('saves a valid band as a POST and refreshes', async () => {
+    const user = userEvent.setup();
+    renderEditor();
+
+    await user.click(screen.getByRole('button', { name: 'Edit' }));
+    const mev = screen.getByLabelText(/MEV/i);
+    const mrv = screen.getByLabelText(/MRV/i);
+    await user.clear(mev);
+    await user.type(mev, '12');
+    await user.clear(mrv);
+    await user.type(mrv, '22');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    const [url, init] = lastFetchCall(fetchMock);
+    expect(url).toBe('/api/volume-targets');
+    expect(init?.method).toBe('POST');
+    const body = JSON.parse(init?.body as string);
+    expect(body).toEqual({ muscleGroup: 'CHEST', mev: 12, mrv: 22 });
+    expect(refresh).toHaveBeenCalled();
+  });
+
+  it('blocks save and shows an error when mrv <= mev (no fetch)', async () => {
+    const user = userEvent.setup();
+    renderEditor();
+
+    await user.click(screen.getByRole('button', { name: 'Edit' }));
+    const mev = screen.getByLabelText(/MEV/i);
+    const mrv = screen.getByLabelText(/MRV/i);
+    await user.clear(mev);
+    await user.type(mev, '18');
+    await user.clear(mrv);
+    await user.type(mrv, '10');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(screen.getByText(/MRV must be greater than MEV/i)).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('offers reset-to-default only on a custom band and DELETEs it', async () => {
+    const user = userEvent.setup();
+    renderEditor({ custom: true, mev: 12, mrv: 22 });
+
+    await user.click(screen.getByRole('button', { name: 'Edit' }));
+    await user.click(screen.getByRole('button', { name: /reset to default/i }));
+
+    const [url, init] = lastFetchCall(fetchMock);
+    expect(url).toBe('/api/volume-targets');
+    expect(init?.method).toBe('DELETE');
+    expect(JSON.parse(init?.body as string)).toEqual({ muscleGroup: 'CHEST' });
+    expect(refresh).toHaveBeenCalled();
+  });
+
+  it('hides reset-to-default when the band is the default', async () => {
+    const user = userEvent.setup();
+    renderEditor({ custom: false });
+
+    await user.click(screen.getByRole('button', { name: 'Edit' }));
+    expect(
+      screen.queryByRole('button', { name: /reset to default/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/components/progress/volume-target-editor.tsx
+++ b/components/progress/volume-target-editor.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { VOLUME_TARGET_MAX } from '@/lib/schemas/volume-target';
+
+interface Props {
+  // The Prisma MuscleGroup enum value (e.g. "CHEST").
+  muscleGroup: string;
+  // Human-readable label for the muscle group.
+  label: string;
+  // The band currently applied to this group, and whether it is the user's
+  // custom target (vs the global defaults).
+  mev: number;
+  mrv: number;
+  custom: boolean;
+  // The global defaults, shown as the reset target.
+  defaultMev: number;
+  defaultMrv: number;
+}
+
+// Inline editor (issue #211) for one muscle group's weekly volume target. Opens
+// a dialog with mev/mrv inputs, saves via POST /api/volume-targets, and clears
+// (reset to default) via DELETE. Client-side validation mirrors the Zod bounds
+// (1..MAX, mrv > mev); the server re-validates regardless.
+export function VolumeTargetEditor({
+  muscleGroup,
+  label,
+  mev,
+  mrv,
+  custom,
+  defaultMev,
+  defaultMrv,
+}: Props) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [mevValue, setMevValue] = useState(String(mev));
+  const [mrvValue, setMrvValue] = useState(String(mrv));
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  function reset() {
+    setMevValue(String(mev));
+    setMrvValue(String(mrv));
+    setError(null);
+  }
+
+  function validate(): { mev: number; mrv: number } | null {
+    const m = Number(mevValue);
+    const r = Number(mrvValue);
+    if (!Number.isInteger(m) || !Number.isInteger(r)) {
+      setError('Enter whole numbers of sets.');
+      return null;
+    }
+    if (m < 1 || m > VOLUME_TARGET_MAX || r < 1 || r > VOLUME_TARGET_MAX) {
+      setError(`Values must be between 1 and ${VOLUME_TARGET_MAX} sets.`);
+      return null;
+    }
+    if (r <= m) {
+      setError('MRV must be greater than MEV.');
+      return null;
+    }
+    return { mev: m, mrv: r };
+  }
+
+  async function save() {
+    const parsed = validate();
+    if (!parsed) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/volume-targets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ muscleGroup, mev: parsed.mev, mrv: parsed.mrv }),
+      });
+      if (!res.ok) {
+        setError('Could not save the target.');
+        return;
+      }
+      setOpen(false);
+      router.refresh();
+    } catch {
+      setError('Could not save the target.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function clear() {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/volume-targets', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ muscleGroup }),
+      });
+      if (!res.ok) {
+        setError('Could not reset the target.');
+        return;
+      }
+      setOpen(false);
+      router.refresh();
+    } catch {
+      setError('Could not reset the target.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        setOpen(o);
+        if (o) reset();
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="sm" className="h-7 px-2 text-xs">
+          Edit
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{label} volume target</DialogTitle>
+          <DialogDescription>
+            Your personal weekly set band (MEV-MRV) for {label.toLowerCase()}.
+            Leave it to use the {defaultMev}-{defaultMrv} default.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex gap-4">
+          <div className="flex-1">
+            <Label htmlFor={`mev-${muscleGroup}`}>MEV (sets/week)</Label>
+            <Input
+              id={`mev-${muscleGroup}`}
+              type="number"
+              min={1}
+              max={VOLUME_TARGET_MAX}
+              value={mevValue}
+              onChange={(e) => setMevValue(e.target.value)}
+            />
+          </div>
+          <div className="flex-1">
+            <Label htmlFor={`mrv-${muscleGroup}`}>MRV (sets/week)</Label>
+            <Input
+              id={`mrv-${muscleGroup}`}
+              type="number"
+              min={1}
+              max={VOLUME_TARGET_MAX}
+              value={mrvValue}
+              onChange={(e) => setMrvValue(e.target.value)}
+            />
+          </div>
+        </div>
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        <DialogFooter className="gap-2 sm:gap-2">
+          {custom && (
+            <Button
+              variant="outline"
+              onClick={clear}
+              disabled={busy}
+              className="mr-auto"
+            >
+              Reset to default
+            </Button>
+          )}
+          <Button onClick={save} disabled={busy}>
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/lib/schemas/volume-target.test.ts
+++ b/lib/schemas/volume-target.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import {
+  volumeTargetInputSchema,
+  volumeTargetClearSchema,
+  VOLUME_TARGET_MAX,
+} from './volume-target';
+
+describe('volumeTargetInputSchema (issue #211)', () => {
+  it('accepts a valid in-range band', () => {
+    const parsed = volumeTargetInputSchema.safeParse({
+      muscleGroup: 'CHEST',
+      mev: 8,
+      mrv: 18,
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data).toEqual({ muscleGroup: 'CHEST', mev: 8, mrv: 18 });
+    }
+  });
+
+  it('coerces numeric strings', () => {
+    const parsed = volumeTargetInputSchema.safeParse({
+      muscleGroup: 'QUADS',
+      mev: '10',
+      mrv: '20',
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data.mev).toBe(10);
+  });
+
+  it('rejects mrv not strictly greater than mev', () => {
+    expect(
+      volumeTargetInputSchema.safeParse({ muscleGroup: 'CHEST', mev: 12, mrv: 12 })
+        .success,
+    ).toBe(false);
+    expect(
+      volumeTargetInputSchema.safeParse({ muscleGroup: 'CHEST', mev: 15, mrv: 10 })
+        .success,
+    ).toBe(false);
+  });
+
+  it('rejects mev below 1 and values above the max', () => {
+    expect(
+      volumeTargetInputSchema.safeParse({ muscleGroup: 'CHEST', mev: 0, mrv: 10 })
+        .success,
+    ).toBe(false);
+    expect(
+      volumeTargetInputSchema.safeParse({
+        muscleGroup: 'CHEST',
+        mev: 5,
+        mrv: VOLUME_TARGET_MAX + 1,
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects non-integers and an unknown muscle group', () => {
+    expect(
+      volumeTargetInputSchema.safeParse({ muscleGroup: 'CHEST', mev: 8.5, mrv: 18 })
+        .success,
+    ).toBe(false);
+    expect(
+      volumeTargetInputSchema.safeParse({ muscleGroup: 'NOT_A_GROUP', mev: 8, mrv: 18 })
+        .success,
+    ).toBe(false);
+  });
+});
+
+describe('volumeTargetClearSchema', () => {
+  it('accepts a known muscle group and rejects an unknown one', () => {
+    expect(volumeTargetClearSchema.safeParse({ muscleGroup: 'BICEPS' }).success).toBe(
+      true,
+    );
+    expect(volumeTargetClearSchema.safeParse({ muscleGroup: 'XYZ' }).success).toBe(
+      false,
+    );
+  });
+});

--- a/lib/schemas/volume-target.ts
+++ b/lib/schemas/volume-target.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+
+// Per-muscle weekly volume target input (issue #211). Sets the user's personal
+// MEV/MRV band for one muscle group, classified against the progress-page
+// volume card. The muscle group must be one of the Prisma MuscleGroup enum
+// values; the band is bounded so a typo cannot store a nonsensical landmark.
+//
+// Bounds: mev >= 1 (a target of zero sets is not a meaningful floor), and the
+// ceiling mrv must be strictly greater than mev (an empty or inverted band is
+// rejected). The sane upper cap of 40 sets/week is generous - well above any
+// recoverable per-muscle weekly volume in the literature - while keeping the
+// value display-friendly.
+export const MUSCLE_GROUPS = [
+  'CHEST',
+  'BACK_WIDTH',
+  'BACK_THICKNESS',
+  'SHOULDERS_FRONT',
+  'SHOULDERS_LATERAL',
+  'SHOULDERS_REAR',
+  'BICEPS',
+  'TRICEPS',
+  'FOREARMS',
+  'QUADS',
+  'HAMSTRINGS',
+  'GLUTES',
+  'CALVES',
+  'ABS',
+  'LOWER_BACK',
+  'OTHER',
+] as const;
+
+export const VOLUME_TARGET_MAX = 40;
+
+export const volumeTargetInputSchema = z
+  .object({
+    muscleGroup: z.enum(MUSCLE_GROUPS),
+    mev: z.coerce.number().int().min(1).max(VOLUME_TARGET_MAX),
+    mrv: z.coerce.number().int().min(1).max(VOLUME_TARGET_MAX),
+  })
+  .refine((d) => d.mrv > d.mev, {
+    message: 'mrv must be greater than mev',
+    path: ['mrv'],
+  });
+
+export type VolumeTargetInput = z.infer<typeof volumeTargetInputSchema>;
+
+// The muscleGroup-only body for clearing a target (reset to default).
+export const volumeTargetClearSchema = z.object({
+  muscleGroup: z.enum(MUSCLE_GROUPS),
+});
+
+export type VolumeTargetClear = z.infer<typeof volumeTargetClearSchema>;

--- a/lib/stats.test.ts
+++ b/lib/stats.test.ts
@@ -10,6 +10,7 @@ import {
   isoWeekKey,
   isoWeekStart,
   isStalled,
+  resolveVolumeBand,
   setVolume,
   STALL_LOOKBACK_SESSIONS,
   STALL_TOLERANCE,
@@ -263,6 +264,42 @@ describe('classifyWeeklySets (MEV/MRV band)', () => {
     expect(classifyWeeklySets(8, 6, 12)).toBe('WITHIN');
     expect(classifyWeeklySets(5, 6, 12)).toBe('BELOW_MEV');
     expect(classifyWeeklySets(13, 6, 12)).toBe('ABOVE_MRV');
+  });
+});
+
+describe('resolveVolumeBand (issue #211)', () => {
+  it('returns the defaults when no targets are passed', () => {
+    expect(resolveVolumeBand('CHEST')).toEqual({
+      mev: WEEKLY_SETS_MEV,
+      mrv: WEEKLY_SETS_MRV,
+      custom: false,
+    });
+  });
+
+  it('returns the defaults for a muscle group without a custom target', () => {
+    expect(resolveVolumeBand('BICEPS', { CHEST: { mev: 8, mrv: 16 } })).toEqual({
+      mev: WEEKLY_SETS_MEV,
+      mrv: WEEKLY_SETS_MRV,
+      custom: false,
+    });
+  });
+
+  it('returns the user band, flagged custom, when one is set', () => {
+    expect(resolveVolumeBand('CHEST', { CHEST: { mev: 12, mrv: 22 } })).toEqual({
+      mev: 12,
+      mrv: 22,
+      custom: true,
+    });
+  });
+
+  it('falls back to defaults for an internally inconsistent stored band', () => {
+    // A hand-tampered row (mrv <= mev or mev < 1) is ignored, not trusted.
+    expect(resolveVolumeBand('CHEST', { CHEST: { mev: 18, mrv: 10 } }).custom).toBe(
+      false,
+    );
+    expect(resolveVolumeBand('CHEST', { CHEST: { mev: 0, mrv: 10 } }).custom).toBe(
+      false,
+    );
   });
 });
 

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -270,6 +270,31 @@ export function weeklyVolumeByMuscleGroup(
 export const WEEKLY_SETS_MEV = 10;
 export const WEEKLY_SETS_MRV = 20;
 
+// A resolved MEV/MRV band for one muscle group, plus whether it came from the
+// user's own VolumeTarget (issue #211) or the global defaults above.
+export interface VolumeBand {
+  mev: number;
+  mrv: number;
+  custom: boolean;
+}
+
+// Resolves the band to apply for a muscle group: the user's per-muscle target
+// when one is set, else the global defaults. Pure: the caller passes the
+// already-loaded targets map (muscleGroup -> { mev, mrv }), so classification
+// stays free of any DB access. A target is honored only when it is internally
+// consistent (mev >= 1 and mrv > mev), matching the Zod input bounds, so a
+// hand-tampered row can never produce an inverted band.
+export function resolveVolumeBand(
+  muscleGroup: string,
+  targets?: Record<string, { mev: number; mrv: number }>,
+): VolumeBand {
+  const t = targets?.[muscleGroup];
+  if (t && t.mev >= 1 && t.mrv > t.mev) {
+    return { mev: t.mev, mrv: t.mrv, custom: true };
+  }
+  return { mev: WEEKLY_SETS_MEV, mrv: WEEKLY_SETS_MRV, custom: false };
+}
+
 // Where a weekly working-set count falls relative to the MEV/MRV band.
 export type VolumeLandmarkZone = 'BELOW_MEV' | 'WITHIN' | 'ABOVE_MRV';
 

--- a/prisma/migrations/20260615084935_add_volume_target/migration.sql
+++ b/prisma/migrations/20260615084935_add_volume_target/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "VolumeTarget" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "muscleGroup" "MuscleGroup" NOT NULL,
+    "mev" INTEGER NOT NULL,
+    "mrv" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "VolumeTarget_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "VolumeTarget_userId_muscleGroup_key" ON "VolumeTarget"("userId", "muscleGroup");
+
+-- AddForeignKey
+ALTER TABLE "VolumeTarget" ADD CONSTRAINT "VolumeTarget_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,6 +47,7 @@ model User {
   exerciseGoals ExerciseGoal[]
   bodyweightEntries BodyweightEntry[]
   bodyMeasurements BodyMeasurement[]
+  volumeTargets VolumeTarget[]
 }
 
 enum Sex {
@@ -266,6 +267,28 @@ model ExerciseGoal {
   achievedAt   DateTime?
 
   @@unique([userId, exerciseId])
+}
+
+// Per-muscle weekly volume targets (issue #211). Personalizes the MEV/MRV
+// reference band the progress-page volume card classifies against: serious
+// lifters individualize these landmarks. Additive and fully optional - one row
+// per (userId, muscleGroup); the ABSENCE of a row falls back to the global
+// defaults (WEEKLY_SETS_MEV / WEEKLY_SETS_MRV in lib/stats.ts), so existing
+// users are unaffected. mev >= 1 and mrv > mev are enforced by the Zod input
+// schema; the band stays a display-only heuristic and never feeds progression
+// or coach logic.
+model VolumeTarget {
+  id          String      @id @default(cuid())
+  userId      String
+  user        User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  muscleGroup MuscleGroup
+  // Minimum effective volume (sets/week) and maximum recoverable volume.
+  mev         Int
+  mrv         Int
+  createdAt   DateTime    @default(now())
+  updatedAt   DateTime    @updatedAt
+
+  @@unique([userId, muscleGroup])
 }
 
 // Bodyweight history (issue #99). Additive: User.bodyweight stays the single

--- a/tests/integration/volume-targets-route.test.ts
+++ b/tests/integration/volume-targets-route.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { db } from '@/lib/db';
+import { getCurrentUserId } from '@/lib/auth';
+
+// Auth is read through getCurrentUserId (via requireApiUserId in @/lib/api).
+vi.mock('@/lib/auth', () => ({ getCurrentUserId: vi.fn() }));
+const mockUserId = vi.mocked(getCurrentUserId);
+
+import {
+  GET as listTargets,
+  POST as postTarget,
+  DELETE as deleteTarget,
+} from '@/app/api/volume-targets/route';
+
+function actAs(userId: string) {
+  mockUserId.mockResolvedValue(userId);
+}
+
+function jsonReq(method: string, body: unknown): Request {
+  return new Request('http://test.local/api/volume-targets', {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+async function seedUsers() {
+  const [a, b] = await Promise.all([
+    db.user.create({ data: { email: 'vt-owner@test.dev', passwordHash: 'x' } }),
+    db.user.create({ data: { email: 'vt-stranger@test.dev', passwordHash: 'x' } }),
+  ]);
+  return { a, b };
+}
+
+beforeEach(() => {
+  mockUserId.mockReset();
+});
+
+describe('POST /api/volume-targets (issue #211)', () => {
+  it('creates a target for the owner and upserts in place on a second post', async () => {
+    const { a } = await seedUsers();
+    actAs(a.id);
+
+    const created = await postTarget(
+      jsonReq('POST', { muscleGroup: 'CHEST', mev: 8, mrv: 18 }),
+    );
+    expect(created.status).toBe(201);
+    expect(await created.json()).toEqual({ muscleGroup: 'CHEST', mev: 8, mrv: 18 });
+
+    // Second post for the same group updates, never duplicates.
+    const updated = await postTarget(
+      jsonReq('POST', { muscleGroup: 'CHEST', mev: 10, mrv: 22 }),
+    );
+    expect(updated.status).toBe(201);
+    const rows = await db.volumeTarget.findMany({ where: { userId: a.id } });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ muscleGroup: 'CHEST', mev: 10, mrv: 22 });
+  });
+
+  it('rejects an invalid band (mrv <= mev) with 400 and stores nothing', async () => {
+    const { a } = await seedUsers();
+    actAs(a.id);
+    const res = await postTarget(
+      jsonReq('POST', { muscleGroup: 'CHEST', mev: 15, mrv: 10 }),
+    );
+    expect(res.status).toBe(400);
+    expect(await db.volumeTarget.count({ where: { userId: a.id } })).toBe(0);
+  });
+
+  it('rejects an unauthenticated request with 401', async () => {
+    mockUserId.mockResolvedValue(null);
+    const res = await postTarget(
+      jsonReq('POST', { muscleGroup: 'CHEST', mev: 8, mrv: 18 }),
+    );
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /api/volume-targets', () => {
+  it('returns only the requesting user targets', async () => {
+    const { a, b } = await seedUsers();
+    await db.volumeTarget.create({
+      data: { userId: a.id, muscleGroup: 'CHEST', mev: 8, mrv: 18 },
+    });
+    await db.volumeTarget.create({
+      data: { userId: b.id, muscleGroup: 'QUADS', mev: 12, mrv: 24 },
+    });
+
+    actAs(a.id);
+    const res = await listTargets();
+    const targets = await res.json();
+    expect(targets).toEqual([{ muscleGroup: 'CHEST', mev: 8, mrv: 18 }]);
+  });
+});
+
+describe('DELETE /api/volume-targets (reset to default)', () => {
+  it('clears the owner target and is idempotent', async () => {
+    const { a } = await seedUsers();
+    await db.volumeTarget.create({
+      data: { userId: a.id, muscleGroup: 'CHEST', mev: 8, mrv: 18 },
+    });
+    actAs(a.id);
+
+    const res = await deleteTarget(jsonReq('DELETE', { muscleGroup: 'CHEST' }));
+    expect(res.status).toBe(200);
+    expect(await db.volumeTarget.count({ where: { userId: a.id } })).toBe(0);
+
+    // Deleting again is a no-op success.
+    const again = await deleteTarget(jsonReq('DELETE', { muscleGroup: 'CHEST' }));
+    expect(again.status).toBe(200);
+  });
+
+  it("cannot clear another user's target", async () => {
+    const { a, b } = await seedUsers();
+    await db.volumeTarget.create({
+      data: { userId: b.id, muscleGroup: 'QUADS', mev: 12, mrv: 24 },
+    });
+
+    actAs(a.id);
+    const res = await deleteTarget(jsonReq('DELETE', { muscleGroup: 'QUADS' }));
+    expect(res.status).toBe(200);
+    // B's target is untouched: A only addressed its own (empty) rows.
+    expect(await db.volumeTarget.count({ where: { userId: b.id } })).toBe(1);
+  });
+});


### PR DESCRIPTION
Lets lifters individualize the MEV/MRV band the progress-page volume card classifies against, instead of the fixed 10/20 defaults. Additive and fully optional - a muscle group with no saved target falls back to the global defaults, so existing users are unaffected.

## What changed
- **Schema/migration (additive)**: `VolumeTarget` model - `id, userId, muscleGroup (enum), mev, mrv`, unique `(userId, muscleGroup)`, `onDelete: Cascade`. New table only.
- **API** `app/api/volume-targets/route.ts`: Zod-bounded, ownership-scoped GET (list) / POST (upsert) / DELETE (clear). Bounds: `mev >= 1`, `mrv > mev`, max 40. Every handler is scoped to the authenticated user by construction.
- **lib/stats**: `resolveVolumeBand(group, targets)` merges the user's saved band with the defaults (and ignores an internally inconsistent stored band). `classifyWeeklySets` stays pure - the resolved band is passed in.
- **Progress page**: resolves a per-muscle band and classifies each group against it; the card shows each group's active band and whether it is custom or default.
- **UI**: inline `VolumeTargetEditor` dialog per muscle group - mev/mrv inputs with client-side validation mirroring the Zod bounds, Save, and Reset-to-default (shown only on a custom band).

## Reinforced controls (complex-feature directive)
- **Additive migration validated on the test DB**: `prisma migrate reset` (all migrations applied from scratch) + `prisma migrate diff` reports "No difference detected". Fresh rollback baseline `autonomy-baseline-2026-06-15` tagged on main before this PR.
- **Tests at every touched layer**: Zod (`mrv > mev`, bounds, enum, coercion); route integration (owner upsert-in-place, invalid-band 400 with nothing stored, 401, GET isolation, idempotent clear, cannot clear another user's row); `resolveVolumeBand` unit (default / custom / inconsistent fallback); component (save POST, validation block, reset DELETE, reset hidden on default).

## How I tested
`bash scripts/verify.sh --full` equivalent: lint, typecheck, build all pass; unit (new schema/stats/component tests green); integration 159 pass (incl. 6 new volume-targets tests); E2E 13 pass.

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)