### PR TITLE
chore: address the batch-11 review nits (RIR clamp, dead prop, parse-route tests)

### DIFF
--- a/app/(app)/progress/page.tsx
+++ b/app/(app)/progress/page.tsx
@@ -481,7 +481,6 @@ export default async function ProgressPage(
                 total: w.total,
               }))}
               volumeLandmarks={volumeLandmarks}
-              volumeTargets={volumeTargets}
               defaultBand={{ mev: WEEKLY_SETS_MEV, mrv: WEEKLY_SETS_MRV }}
               recap={recap}
               unit={unit}

--- a/components/progress/progress-dashboard.tsx
+++ b/components/progress/progress-dashboard.tsx
@@ -85,7 +85,6 @@ interface Props {
   volumeLandmarks: VolumeLandmarks | null;
   // Issue #211: the user's saved per-muscle targets (muscleGroup -> band) and
   // the global defaults, for the inline editor.
-  volumeTargets: Record<string, { mev: number; mrv: number }>;
   defaultBand: { mev: number; mrv: number };
   recap: RecapRow[];
   unit: WeightUnit;
@@ -144,7 +143,6 @@ export function ProgressDashboard({
   exercisePoints,
   weeklyPoints,
   volumeLandmarks,
-  volumeTargets,
   defaultBand,
   recap,
   unit,

--- a/components/session/set-input.tsx
+++ b/components/session/set-input.tsx
@@ -188,7 +188,13 @@ export function SetInput({
           // shorthand parser; convert to the kg the form stores.
           weight: fromDisplayWeight(parsed.weight, unit),
           reps: parsed.reps,
-          rir: parsed.rir != null ? parsed.rir : f.rir,
+          // Clamp the parsed RIR to the selectable button range so a model
+          // value of 4-5 maps to the closest option instead of leaving no
+          // button highlighted (the set API still accepts 0-5).
+          rir:
+            parsed.rir != null
+              ? Math.min(parsed.rir, RIR_OPTIONS[RIR_OPTIONS.length - 1]!)
+              : f.rir,
         }));
       }
     } catch {

--- a/tests/integration/set-parse-route.test.ts
+++ b/tests/integration/set-parse-route.test.ts
@@ -112,4 +112,32 @@ describe('POST /api/sets/parse (issue #210)', () => {
     const res = await parseSet(jsonReq({ exerciseId: bench.id, text: '100 for 8' }));
     expect(res.status).toBe(401);
   });
+
+  it('rejects an over-length text with 400 (never reaches the model)', async () => {
+    const { a, bench } = await seed();
+    actAs(a.id);
+    // text is bounded to 500 chars so a huge blob cannot be forwarded to the LLM.
+    const res = await parseSet(
+      jsonReq({ exerciseId: bench.id, text: 'x'.repeat(501) }),
+    );
+    expect(res.status).toBe(400);
+    expect(await db.set.count()).toBe(0);
+  });
+
+  it('rate-limits a burst with 429', async () => {
+    const { a, bench } = await seed();
+    actAs(a.id);
+    // The route allows 20 parses/min per user; the 21st is rejected.
+    let limited = false;
+    for (let i = 0; i < 25; i++) {
+      const res = await parseSet(jsonReq({ exerciseId: bench.id, text: '100 for 8' }));
+      if (res.status === 429) {
+        expect(res.headers.get('retry-after') ?? res.headers.get('Retry-After')).toBeTruthy();
+        limited = true;
+        break;
+      }
+    }
+    expect(limited).toBe(true);
+    expect(await db.set.count()).toBe(0);
+  });
 });


### PR DESCRIPTION
Addresses the non-blocking NITs from the three CLEAN independent reviews of batch 11 (#214/#215/#216):
- RIR clamp: a model-parsed RIR of 4/5 now maps to the closest quick-button (0-3) instead of leaving none highlighted; the set API still accepts 0-5.
- Parse-route coverage: an over-length text 400s before the LLM, a burst 429s with Retry-After; both pin no-set-logged.
- Drop the dead volumeTargets prop (needless client payload; resolveVolumeBand uses the page-level value directly).

bash scripts/verify.sh - GREEN-GATE PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)