### PR TITLE
docs: write up batch 11 - the roadmap is complete (AI set logging, coach records, volume targets)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Maximum heart rate on cardio sets: the peak HR is stored, imported from and
   exported to TCX, and shown next to the average; the CSV export gains
   avg/max HR columns.
+- Free-text, AI-parsed set logging (the last roadmap item): an opt-in
+  "Parse with AI" button turns a plain description ("bench, 100 kilos, 5 reps,
+  2 in the tank" or "ran 5k in 25 minutes") into the set fields for you to
+  confirm. The deterministic shorthand stays the fast path; the model output
+  is validated and fails closed, and a parse never logs a set on its own.
+- The AI coach now sees your all-time records, so a weekly debrief can
+  acknowledge a new PR and anchor advice on your bests.
+- Personal weekly volume targets: set your own MEV/MRV per muscle group; the
+  volume-landmark card uses them where set and the defaults otherwise.
 - A free-text note to your coach: write a short note the AI coach reads -
   injuries, illness, life constraints - so its advice accounts for your own
   current context. It is the correctable half of "what your coach sees"; the

--- a/README.md
+++ b/README.md
@@ -259,6 +259,11 @@ docker compose -f docker-compose.prod.yml --profile demo up -d --build
 docker compose -f docker-compose.prod.yml --profile demo run --rm seed-demo
 ```
 
+The public demo is a single shared account, so visitors who start a session
+pollute it. Re-run the seeder on a schedule (e.g. a cron every 30 minutes) so
+the demo always opens on the clean, populated state - it wipes and recreates
+the demo account's data without touching the rest.
+
 ## Roadmap
 
 - [x] Single user MVP (logging, progress, weekly AI debrief, program adjustments)

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -1425,3 +1425,18 @@ continuously, no per-change approval, self-challenge with subagents, keep a roll
 **Challenged.** Three parallel Opus reviews (one hostile-security). Accepted-change rate: 3 merged / 0 abandoned. The resilience pattern held: durable git/PR state meant the socket death cost no work; the mandatory review validated dead-tick code under attack.
 
 **Deferred to human.** Nothing. Future: FIT import (binary, needs a decoder), free-text AI set logging (LLM-shaped), mobility session type (low confidence), Serwist (build-time chore). #169 (Next 15) already done.
+
+---
+
+## 2026-06-15 (later) - Batch 11 reviewed (3x CLEAN); ROADMAP COMPLETE; shared-demo pollution fixed
+
+**Context.** Batch 11 (#212 coach records, #211 volume targets, #210 free-text AI set logging) shipped; #210 was the LAST unchecked README roadmap item - the roadmap is now fully checked, MVP -> complete AI coach.
+
+**Decided / shipped.**
+- Three independent Opus reviews: all CLEAN. #216/#210 cleared an untrusted-model-output lens - the reviewer ran 12 hostile model outputs (Infinity/NaN/out-of-range/wrong-kind/injected "log this set"/__proto__) all fail closed, proved a parse never logs a set (no db write in the call graph), and confirmed the route is rate-limited + body-capped + the parse contract is separate from <adjustments>. #214 (records, output contract intact) and #215 (volume targets, additive migration no drift, classifier stays pure) CLEAN.
+- NIT cleanup in #217: clamp a model-parsed RIR of 4-5 to the selectable button range; add the missing parse-route 429/oversize tests; drop a dead volumeTargets prop.
+- Operations: found and fixed why the operator kept seeing an "empty" demo - it is a single SHARED account that visitors pollute (their in-progress session makes the home lead with "Resume session"). Installed a `*/30` light-reset cron on the VPS (re-seeds the demo account, no downtime) alongside the nightly full reset; documented the periodic-reseed need in the README demo section.
+
+**Challenged.** Three parallel Opus reviews (one untrusted-output-weighted). Accepted-change rate: 4 merged / 0 abandoned + the cleanup.
+
+**Deferred to human.** Nothing. The README roadmap is complete; future product work is now pure ideation (FIT import, mobility, etc.). The recurring readiness-checkin.test.tsx WSL2-only flake (green in CI) is worth a robustness pass next triage.

--- a/docs/loops/ideas-backlog.md
+++ b/docs/loops/ideas-backlog.md
@@ -49,6 +49,6 @@ research and the product wedge). See `docs/loops/08-ideation-loop.md` for how th
 - shipped - body-measurement tracking (waist/arms/etc.) with a trend (issue #202, 2026-06-14, PR #207) - additive BodyMeasurement table; multi-lens review CLEAN (ownership, bounds, migration drift)
 - shipped - maximum heart rate on cardio sets (issue #203, 2026-06-14, PR #206) - additive Set.maxHr; review CLEAN (bounds on all writers, Track subtree stripped before lap-max extraction)
 - shipped - import a GPX file as a cardio session (issue #204, 2026-06-15, PR #208) - third file format; hostile security review CLEAN (21 adversarial cases, no entity table, linear at 5MB, name never read)
-- proposed - free-text (AI-parsed) set logging (issue #210, 2026-06-15) - the LAST roadmap item; opt-in LLM parse fills the set form, never auto-logs, untrusted-output Zod-validated; new parse contract separate from adjustments
-- proposed - user-settable weekly volume targets (personal MEV/MRV) (issue #211, 2026-06-15) - additive VolumeTarget table; personalizes the #81 landmark card, classifyWeeklySets stays pure
-- proposed - give the AI coach your all-time records (issue #212, 2026-06-15) - coach-side consumer of the records board #190; input-side payload, output contract unchanged
+- shipped - free-text (AI-parsed) set logging (issue #210, 2026-06-15, PR #216) - the LAST roadmap item; multi-lens review CLEAN incl. untrusted-output (12 hostile model outputs fail closed, a parse never logs a set)
+- shipped - user-settable weekly volume targets (issue #211, 2026-06-15, PR #215) - additive VolumeTarget; review CLEAN (classifyWeeklySets stays pure)
+- shipped - give the AI coach your all-time records (issue #212, 2026-06-15, PR #214) - review CLEAN, output contract intact


### PR DESCRIPTION
Content-loop tail for batch 11 (#210 free-text AI set logging, #211 volume targets, #212 coach records) + the #217 nit cleanup.

- The README roadmap is now FULLY checked - #210 was the last item. MVP -> complete self-hosted AI coach.
- CHANGELOG: the three features (AI set logging headlined).
- README: a note that the shared public demo needs a periodic reseed cron (the cause of the 'no example data' the operator hit - a single shared account that visitors pollute; a */30 light-reset is now live on the VPS).
- Backlog + journal: three CLEAN reviews recorded (the AI parse cleared a 12-case untrusted-model-output attack), milestone logged.

bash scripts/verify.sh - GREEN-GATE PASSED.

After merge: redeploy the demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)