### PR TITLE
test: stabilize flaky readiness-checkin soreness test (#219)

### DIFF
--- a/components/session/readiness-checkin.test.tsx
+++ b/components/session/readiness-checkin.test.tsx
@@ -27,7 +27,11 @@ describe('ReadinessCheckin', () => {
   });
 
   async function openForm() {
-    const user = userEvent.setup();
+    // delay: null removes user-event's per-keystroke/per-click setTimeout, which
+    // is what stalls this suite under parallel CPU contention (issue #219). The
+    // interactions are still driven through user-event, so the asserted behavior
+    // is unchanged; only the artificial inter-event delay is dropped.
+    const user = userEvent.setup({ delay: null });
     render(<ReadinessCheckin />);
     await user.click(
       screen.getByRole('button', { name: /readiness check-in \(optional\)/i }),
@@ -64,7 +68,11 @@ describe('ReadinessCheckin', () => {
     ).toBeInTheDocument();
   });
 
-  it('submits a partial soreness map and a note when filled in', async () => {
+  // Raised timeout as a belt-and-suspenders for the heaviest interaction case
+  // (two soreness toggles + typing a note): even with delay:null the default 5s
+  // budget can be eaten by scheduler contention when the whole suite runs in
+  // parallel under load (issue #219). The assertion below is unchanged.
+  it('submits a partial soreness map and a note when filled in', { timeout: 15000 }, async () => {
     const user = await openForm();
 
     await user.click(screen.getByRole('button', { name: 'Overall readiness: 5' }));


### PR DESCRIPTION
## What

The unit test `components/session/readiness-checkin.test.tsx` -> "submits a partial soreness map and a note when filled in" intermittently times out (default 5s) when the full unit suite runs in parallel under CPU contention (observed on WSL2 during `verify.sh`). It passes in isolation and is green in CI where tiers run separately.

## Fix (test-only)

- `userEvent.setup({ delay: null })` in the shared `openForm` helper, dropping user-event's artificial per-keystroke / per-click timer that stalls under contention. Interactions still run through user-event, so behavior under test is unchanged.
- Raised the timeout to 15s on the single heaviest case (two soreness toggles + typing a note) as belt-and-suspenders.

No component or production change; assertions are identical.

## Verification

- `npx vitest run components/session/readiness-checkin.test.tsx` x3: all green.
- `bash scripts/verify.sh`: GREEN.

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)