### PR TITLE
feat: show the exercise's cue in the session set logger

### DIFF
--- a/components/session/exercise-card.test.tsx
+++ b/components/session/exercise-card.test.tsx
@@ -100,6 +100,48 @@ describe('ExerciseCard readiness explainer', () => {
   });
 });
 
+// Issue #224: the exercise's own notes/cue is surfaced as an always-visible
+// muted line under the header (the form reminder while logging), distinct from
+// the per-set quick-note field and the collapsible program-notes block.
+describe('ExerciseCard exercise cue', () => {
+  const CUE = 'keep elbows tucked, pause 1s at the bottom';
+
+  function renderWithExoNotes(notes: string | null, category: Exercise['category'] = 'COMPOUND') {
+    const exoWithNotes: Exercise = { ...exo, notes, category };
+    const peWithNotes: ProgramExercise & { exercise: Exercise } = {
+      ...pe,
+      exercise: exoWithNotes,
+    };
+    return render(
+      <ExerciseCard
+        programExercise={peWithNotes}
+        lastPerformance={lastPerf}
+        readiness={null}
+        deloadActive={false}
+        unit="KG"
+      />,
+    );
+  }
+
+  it('shows the cue line when the exercise has notes', () => {
+    renderWithExoNotes(CUE);
+    expect(screen.getByText(CUE)).toBeInTheDocument();
+  });
+
+  it('shows nothing (no empty element) when the exercise has no notes', () => {
+    renderWithExoNotes(null);
+    expect(screen.queryByText(CUE)).not.toBeInTheDocument();
+    // No collapsible notes block either when neither program nor exercise notes
+    // exist (this card's pe.notes is null).
+    expect(screen.queryByText(/Notes \/ mind-muscle cue/)).not.toBeInTheDocument();
+  });
+
+  it('shows the cue for a cardio exercise too', () => {
+    renderWithExoNotes(CUE, 'CARDIO');
+    expect(screen.getByText(CUE)).toBeInTheDocument();
+  });
+});
+
 // Issue #176: a cardio exercise with prior history shows a "Last session"
 // reference (duration / distance / avgHr) instead of a load. The strength
 // branch above pins that strength cards are unchanged.

--- a/components/session/exercise-card.tsx
+++ b/components/session/exercise-card.tsx
@@ -116,6 +116,17 @@ export function ExerciseCard({
           <Badge variant="secondary">{MUSCLE_GROUP_LABELS[exo.muscleGroup]}</Badge>
           <Badge variant="outline">{CATEGORY_LABELS[exo.category]}</Badge>
         </div>
+        {/* Exercise cue (issue #224): when the exercise carries a technique
+            note, surface it as an always-visible muted line right under the
+            header so the form reminder is there exactly while logging the set.
+            This is the exercise's own notes; the per-set quick-note field and
+            the collapsible program-notes block below are unchanged. */}
+        {exo.notes && (
+          <p className="mt-1.5 flex items-start gap-1.5 text-sm text-muted-foreground">
+            <Lightbulb className="mt-0.5 size-3.5 shrink-0" aria-hidden />
+            <span className="whitespace-pre-line">{exo.notes}</span>
+          </p>
+        )}
       </CardHeader>
 
       <CardContent className="flex flex-col gap-3 pt-0">


### PR DESCRIPTION
Surfaces `Exercise.notes` as an always-visible muted cue line under the exercise header in the session set logger (`components/session/exercise-card.tsx`), so the technique/form reminder is there exactly while logging the set.

- Distinct from the per-set quick-note field and the existing collapsible program-notes block, both unchanged.
- The full exercise row (with `notes`) was already threaded through the session-runner serialized shape, so no serialization / API / schema / prompt change was needed.
- Shows for both strength and cardio exercises; renders nothing (no empty element) when the exercise has no notes.
- Component tests cover with-notes / without-notes / cardio cases.

Display-only. `bash scripts/verify.sh` passes.

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)