### PR TITLE
feat: per-muscle weekly training frequency on the progress page

### DIFF
--- a/app/(app)/progress/page.tsx
+++ b/app/(app)/progress/page.tsx
@@ -13,6 +13,7 @@ import {
   isoWeekKey,
   trainingConsistency,
   weeklyConditioning,
+  weeklyFrequencyByMuscleGroup,
   weeklySetsByMuscleGroup,
   weeklyVolumeByMuscleGroup,
   resolveVolumeBand,
@@ -210,6 +211,19 @@ export default async function ProgressPage(
     })),
   );
 
+  // Weekly training FREQUENCY per muscle group (issue #225): distinct training
+  // days (calendar days with >= 1 working set) per muscle, same warmup/cardio
+  // exclusion and ISO-week bucketing as the set-count card. Shown alongside the
+  // volume on the landmarks view as "Nx/week".
+  const weeklyFrequencyPoints = weeklyFrequencyByMuscleGroup(
+    weeklySetsRaw.map((s) => ({
+      isWarmup: s.isWarmup,
+      durationSec: s.durationSec,
+      muscleGroup: s.exercise.muscleGroup,
+      sessionStartedAt: s.session.startedAt,
+    })),
+  );
+
   // Classify the most recent completed (non-current) week against the band so
   // the dashboard can flag below MEV / within / above MRV per muscle group.
   // Falling back to the latest available week keeps a signal when only the
@@ -220,6 +234,13 @@ export default async function ProgressPage(
       .reverse()
       .find((w) => w.weekKey !== currentWeekKey) ??
     weeklySetsPoints[weeklySetsPoints.length - 1];
+  // Frequency for the exact week the landmarks card displays, so volume and
+  // frequency describe the same week per muscle group.
+  const frequencyForWeek =
+    latestCompletedWeek
+      ? weeklyFrequencyPoints.find((w) => w.weekKey === latestCompletedWeek.weekKey)
+          ?.byMuscleGroup ?? {}
+      : {};
   const volumeLandmarks = latestCompletedWeek
     ? {
         weekKey: latestCompletedWeek.weekKey,
@@ -235,6 +256,9 @@ export default async function ProgressPage(
                 group,
                 {
                   sets,
+                  // Distinct training days for this muscle in the same week
+                  // (issue #225). 0 when the muscle was not trained.
+                  frequency: frequencyForWeek[group] ?? 0,
                   zone: classifyWeeklySets(sets, band.mev, band.mrv),
                   mev: band.mev,
                   mrv: band.mrv,

--- a/components/progress/progress-dashboard.tsx
+++ b/components/progress/progress-dashboard.tsx
@@ -67,6 +67,9 @@ interface VolumeLandmarks {
     string,
     {
       sets: number;
+      // Issue #225: distinct training days for this muscle in the same week
+      // (the weekly training frequency, shown as "Nx/week").
+      frequency: number;
       zone: VolumeLandmarkZone;
       // Issue #211: the band actually applied to this group (the user's custom
       // target when set, else the defaults).
@@ -408,6 +411,11 @@ export function ProgressDashboard({
                     <span className="flex items-center gap-2">
                       <span className="text-muted-foreground">
                         {row.sets} {row.sets === 1 ? 'set' : 'sets'}
+                      </span>
+                      {/* Weekly training frequency (issue #225): distinct
+                          training days for this muscle in the same week. */}
+                      <span className="text-xs text-muted-foreground">
+                        {row.frequency}x/week
                       </span>
                       <Badge variant={meta.variant}>{meta.label}</Badge>
                       <VolumeTargetEditor

--- a/lib/stats.test.ts
+++ b/lib/stats.test.ts
@@ -17,6 +17,7 @@ import {
   totalVolume,
   trainingConsistency,
   weeklyConditioning,
+  weeklyFrequencyByMuscleGroup,
   weeklySetsByMuscleGroup,
   weeklyVolumeByMuscleGroup,
   WEEKLY_SETS_MEV,
@@ -235,6 +236,90 @@ describe('weeklySetsByMuscleGroup', () => {
   it('returns an empty list when there are no working sets', () => {
     expect(
       weeklySetsByMuscleGroup([
+        {
+          isWarmup: true,
+          muscleGroup: 'CHEST',
+          sessionStartedAt: new Date('2026-05-04T10:00:00Z'),
+        },
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe('weeklyFrequencyByMuscleGroup (issue #225)', () => {
+  it('counts distinct training days per muscle group and ISO week', () => {
+    const sets = [
+      // week 18: chest trained on two distinct days (Mon + Wed) -> 2;
+      // two chest sets the same day (Mon) still count as one day.
+      {
+        isWarmup: false,
+        muscleGroup: 'CHEST',
+        sessionStartedAt: new Date('2026-04-27T10:00:00Z'),
+      },
+      {
+        isWarmup: false,
+        muscleGroup: 'CHEST',
+        sessionStartedAt: new Date('2026-04-27T18:00:00Z'),
+      },
+      {
+        isWarmup: false,
+        muscleGroup: 'CHEST',
+        sessionStartedAt: new Date('2026-04-29T10:00:00Z'),
+      },
+      // back trained once that week -> 1
+      {
+        isWarmup: false,
+        muscleGroup: 'BACK_WIDTH',
+        sessionStartedAt: new Date('2026-04-29T10:00:00Z'),
+      },
+      // week 19: chest once more -> 1
+      {
+        isWarmup: false,
+        muscleGroup: 'CHEST',
+        sessionStartedAt: new Date('2026-05-04T10:00:00Z'),
+      },
+    ];
+    const points = weeklyFrequencyByMuscleGroup(sets);
+    expect(points).toHaveLength(2);
+    const w18 = points[0]!;
+    const w19 = points[1]!;
+    expect(w18.weekKey).toBe('2026-W18');
+    expect(w18.byMuscleGroup.CHEST).toBe(2);
+    expect(w18.byMuscleGroup.BACK_WIDTH).toBe(1);
+    expect(w19.weekKey).toBe('2026-W19');
+    expect(w19.byMuscleGroup.CHEST).toBe(1);
+  });
+
+  it('excludes warmups and cardio sets (consistent with the volume card)', () => {
+    const sets = [
+      // one real working day for chest
+      {
+        isWarmup: false,
+        muscleGroup: 'CHEST',
+        sessionStartedAt: new Date('2026-04-27T10:00:00Z'),
+      },
+      // a warmup on a different day must NOT add a chest day
+      {
+        isWarmup: true,
+        muscleGroup: 'CHEST',
+        sessionStartedAt: new Date('2026-04-29T10:00:00Z'),
+      },
+      // a cardio set (durationSec != null) on a different day must NOT count
+      {
+        isWarmup: false,
+        durationSec: 1800,
+        muscleGroup: 'CHEST',
+        sessionStartedAt: new Date('2026-04-30T10:00:00Z'),
+      },
+    ];
+    const points = weeklyFrequencyByMuscleGroup(sets);
+    expect(points).toHaveLength(1);
+    expect(points[0]!.byMuscleGroup.CHEST).toBe(1);
+  });
+
+  it('returns an empty list for a week with no working sets', () => {
+    expect(
+      weeklyFrequencyByMuscleGroup([
         {
           isWarmup: true,
           muscleGroup: 'CHEST',

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -353,6 +353,62 @@ export function weeklySetsByMuscleGroup(
   );
 }
 
+export interface WeeklyFrequencyPoint {
+  weekKey: string; // YYYY-Www
+  weekStart: Date; // Monday 00:00 UTC
+  // Distinct training days per muscle group in the week (calendar days, UTC,
+  // with >= 1 working set hitting that group). Absent groups count as 0.
+  byMuscleGroup: Record<string, number>;
+}
+
+// Aggregates the weekly training FREQUENCY by muscle group (issue #225):
+// the number of DISTINCT calendar days (UTC) in each ISO week on which the
+// muscle group received at least one working set. Mirrors
+// `weeklySetsByMuscleGroup` (same ISO-week bucketing, same warmup + cardio
+// exclusion) so the frequency reads consistently with the volume card, but
+// counts distinct days rather than sets - two sets the same day count once,
+// two different days count twice. Display-only: never feeds progression or
+// coach logic.
+export function weeklyFrequencyByMuscleGroup(
+  sets: (Pick<Set, 'isWarmup'> &
+    MaybeCardio & {
+      muscleGroup: string;
+      sessionStartedAt: Date;
+    })[],
+): WeeklyFrequencyPoint[] {
+  interface Bucket {
+    weekStart: Date;
+    // muscleGroup -> set of UTC calendar-day strings (YYYY-MM-DD).
+    days: Map<string, globalThis.Set<string>>;
+  }
+  const byWeek = new Map<string, Bucket>();
+  for (const s of sets) {
+    if (s.isWarmup || isCardioSet(s)) continue;
+    const key = isoWeekKey(s.sessionStartedAt);
+    let entry = byWeek.get(key);
+    if (!entry) {
+      entry = { weekStart: isoWeekStart(s.sessionStartedAt), days: new Map() };
+      byWeek.set(key, entry);
+    }
+    const day = s.sessionStartedAt.toISOString().slice(0, 10);
+    let groupDays = entry.days.get(s.muscleGroup);
+    if (!groupDays) {
+      groupDays = new globalThis.Set<string>();
+      entry.days.set(s.muscleGroup, groupDays);
+    }
+    groupDays.add(day);
+  }
+  return [...byWeek.entries()]
+    .map(([weekKey, entry]) => ({
+      weekKey,
+      weekStart: entry.weekStart,
+      byMuscleGroup: Object.fromEntries(
+        [...entry.days.entries()].map(([group, days]) => [group, days.size]),
+      ),
+    }))
+    .sort((a, b) => a.weekStart.getTime() - b.weekStart.getTime());
+}
+
 // ============================================================
 // Conditioning (weekly cardio minutes / distance / sessions)
 // ============================================================


### PR DESCRIPTION
Adds per-muscle weekly training FREQUENCY (how many distinct days per week each muscle group is trained) alongside the existing per-muscle volume on the progress page.

- New pure derivation `weeklyFrequencyByMuscleGroup` in `lib/stats.ts`: distinct training days (calendar days, UTC, with >= 1 working set hitting the group) per muscle group per ISO week. Mirrors `weeklySetsByMuscleGroup`'s ISO-week bucketing and warmup + cardio exclusion, so frequency reads consistently with the volume card.
- Surfaced as a small "Nx/week" line on each row of the Volume landmarks card, for the exact week the card already displays (so volume and frequency describe the same week per muscle).
- Reuses the `weeklySetsRaw` query already on the page; display-only, no schema / API / prompt change. Empty state unchanged (the card only renders when there are landmark rows).
- Colocated unit tests: distinct-day counting (two sets same day = 1, two days = 2), warmup + cardio exclusion, empty week = 0.

`bash scripts/verify.sh` passes.

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)