### PR TITLE
feat: e1RM-based percentage loading table on the progress view

### DIFF
--- a/components/progress/progress-dashboard.tsx
+++ b/components/progress/progress-dashboard.tsx
@@ -31,6 +31,7 @@ import {
   type VolumeLandmarkZone,
 } from '@/lib/stats';
 import { roundWeight, toDisplayWeight, unitLabel } from '@/lib/units';
+import { computeLoadingTable } from '@/lib/loading-table';
 import { ExerciseGoalCard, type GoalView } from '@/components/progress/exercise-goal-card';
 import { VolumeTargetEditor } from '@/components/progress/volume-target-editor';
 
@@ -174,6 +175,18 @@ export function ProgressDashboard({
 
   const selectedExo = exercises.find((e) => e.id === selectedExerciseId);
 
+  // Percentage-of-e1RM loading table (issue #226): rows of default percentages
+  // of the selected exercise's best e1RM, rounded to a loadable increment in
+  // the display unit. The best e1RM is stored in kg, so convert before deriving
+  // so the rounding lands on plate jumps in the user's unit. Empty (table
+  // hidden) when the exercise has no e1RM yet.
+  const loadingRows = useMemo(
+    () => computeLoadingTable(toDisplay(selectedBestE1RM), unit),
+    // toDisplay is a pure function of `unit`; depend on its inputs.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selectedBestE1RM, unit],
+  );
+
   // Read-only summary: exercises whose e1RM has plateaued recently.
   const stalledLifts = recap.filter((r) => r.stalled);
 
@@ -292,6 +305,51 @@ export function ProgressDashboard({
           )}
         </CardContent>
       </Card>
+
+      {/* Training loads table (issue #226): percentages of the selected
+          exercise's best e1RM, rounded to a loadable increment in the display
+          unit. Collapsible/secondary so it does not crowd the chart, and hidden
+          entirely when the exercise has no e1RM yet. */}
+      {selectedExerciseId && loadingRows.length > 0 && (
+        <Card>
+          <CardContent className="pt-6">
+            <details className="group">
+              <summary className="flex cursor-pointer list-none items-center justify-between gap-2">
+                <span className="text-base font-semibold">Training loads</span>
+                <span className="text-xs text-muted-foreground group-open:hidden">
+                  Show
+                </span>
+                <span className="hidden text-xs text-muted-foreground group-open:inline">
+                  Hide
+                </span>
+              </summary>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Percentages of your best estimated 1RM ({toDisplay(selectedBestE1RM)}{' '}
+                {unitSuffix}), rounded to a loadable increment. Planning aid, not a
+                prescription.
+              </p>
+              <table className="mt-3 w-full text-sm">
+                <thead>
+                  <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                    <th className="py-2 font-medium">% of e1RM</th>
+                    <th className="py-2 text-right font-medium">Load</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {loadingRows.map((row) => (
+                    <tr key={row.percent} className="border-b last:border-0">
+                      <td className="py-1.5">{row.percent}%</td>
+                      <td className="py-1.5 text-right tabular-nums">
+                        {row.weight} {unitSuffix}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </details>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Target goal for the selected exercise */}
       {selectedExerciseId && selectedExo && (

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -6,6 +6,53 @@ by the charter in [`07-autonomy.md`](07-autonomy.md).
 
 ---
 
+## 2026-06-16 - Three display-only slices: exercise cue in the logger, weekly frequency, e1RM loading table (#224/#225/#226)
+
+**Context.** Maintainer tick, three additive DISPLAY-ONLY product slices, serialized by ascending
+size (each PR merged before the next branch was cut). All three authored by JulienAu, trust-gated
+(login allowlist + collaborator check HTTP 204). Inherited model this cycle (Fable unavailable). None
+touched schema, API, or the LLM contract; each shipped colocated tests and passed `bash scripts/verify.sh`.
+
+**Decided / shipped.**
+- **#224 (PR #228, merged on green).** Surface `Exercise.notes` as an always-visible muted "cue" line
+  under the exercise header in the session set logger (`components/session/exercise-card.tsx`), so the
+  form reminder is there exactly while logging. Read the source first: the full exercise row (with
+  `notes`) was ALREADY threaded through the session-runner serialized shape via
+  `ProgramExercise & { exercise: Exercise }`, so NO serialization change was needed (the issue allowed
+  for it but it was unnecessary). The card already rendered `exo.notes` behind a collapsed "Notes /
+  mind-muscle cue" toggle; this adds the always-visible line on top, leaving the per-set quick-note
+  field and the collapsible block unchanged. Component tests cover with-notes / without-notes / cardio.
+- **#225 (PR #229, merged on green).** New pure `weeklyFrequencyByMuscleGroup` in `lib/stats.ts`:
+  distinct training days (UTC calendar days with >= 1 working set hitting the group) per muscle group
+  per ISO week. Deliberately mirrors `weeklySetsByMuscleGroup`'s ISO-week bucketing and warmup + cardio
+  exclusion so frequency reads consistently with the volume card. Surfaced as "Nx/week" on each Volume
+  landmarks row, for the EXACT week the card already displays (page picks the frequency point matching
+  `latestCompletedWeek.weekKey`), so volume and frequency describe the same week. Reuses the
+  `weeklySetsRaw` query already on the page. Unit tests: two sets same day = 1, two days = 2, warmup +
+  cardio excluded, empty week = 0.
+- **#226 (PR #N, this entry rides here, merged on green).** New pure `computeLoadingTable` in
+  `lib/loading-table.ts`: default percentages (95..60%) of an exercise's best e1RM, each rounded to the
+  NEAREST loadable increment (2.5 kg / 5 lb) in the display unit (round-to-nearest, distinct from the
+  warm-up ramp's round-DOWN, since a planned working load reads best on the closest plate jump). The
+  e1RM is stored in kg and is bodyweight-adjusted for bodyweight movements (consistent with the rest of
+  the page); the dashboard converts to the display unit before deriving so rounding lands on real plate
+  jumps. Rendered as a collapsible native `<details>` "Training loads" table on the selected exercise's
+  progress view, hidden entirely when the exercise has no e1RM (empty list). Unit tests pin the
+  percentage->load math in kg and lb, the round-to-nearest behavior, the no-e1RM empty case, and a
+  custom percentage set.
+
+**Challenged.** No review subagent was spawned this run (nested run). Per the charter's backstop these
+are flagged for an OPTIONAL light post-merge correctness review by the orchestrator; all three are
+pure additive display-only derivations with no production-contract surface, so the risk is low. Self-checked
+that each new test is non-vacuous (e.g. the frequency test distinguishes distinct-day counting from a
+raw set count; the loading-table test distinguishes round-to-nearest from round-down).
+
+**Production bugs surfaced.** None. No unexpected schema/contract need arose; scope held to display-only.
+
+**Deferred.** Nothing.
+
+---
+
 ## 2026-06-15 - Test-only hardening: de-flake readiness check-in + pin last-performance derivation (#219/#220)
 
 **Context.** Maintainer tick, two test-only issues, serialized (PR #222 MERGED before the #220 branch

--- a/lib/loading-table.test.ts
+++ b/lib/loading-table.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeLoadingTable,
+  DEFAULT_LOADING_PERCENTAGES,
+} from './loading-table';
+
+describe('computeLoadingTable (issue #226)', () => {
+  it('returns a row per default percentage, heaviest first', () => {
+    const rows = computeLoadingTable(100, 'KG');
+    expect(rows.map((r) => r.percent)).toEqual([...DEFAULT_LOADING_PERCENTAGES]);
+    expect(rows[0]!.percent).toBe(95);
+    expect(rows[rows.length - 1]!.percent).toBe(60);
+  });
+
+  it('rounds each load to the nearest 2.5 kg in kilograms', () => {
+    // 100 kg e1RM: exact multiples of 5 kg for these percentages.
+    const rows = computeLoadingTable(100, 'KG');
+    const byPercent = Object.fromEntries(rows.map((r) => [r.percent, r.weight]));
+    expect(byPercent[95]).toBe(95);
+    expect(byPercent[90]).toBe(90);
+    expect(byPercent[60]).toBe(60);
+  });
+
+  it('rounds to the nearest 2.5 kg increment for non-round e1RMs', () => {
+    // 102 kg e1RM: 85% = 86.7 -> nearest 2.5 = 87.5; 70% = 71.4 -> 72.5? no,
+    // 71.4 / 2.5 = 28.56 -> round 29 -> 72.5. 65% = 66.3 -> 26.52 -> 27 -> 67.5.
+    const rows = computeLoadingTable(102, 'KG');
+    const byPercent = Object.fromEntries(rows.map((r) => [r.percent, r.weight]));
+    expect(byPercent[85]).toBe(87.5);
+    expect(byPercent[70]).toBe(72.5);
+    expect(byPercent[65]).toBe(67.5);
+    // Every weight is a multiple of 2.5.
+    for (const r of rows) {
+      expect((r.weight / 2.5) % 1).toBe(0);
+    }
+  });
+
+  it('rounds to the nearest 5 lb in pounds', () => {
+    // e1RM already in the display unit (lb). 225 lb best.
+    const rows = computeLoadingTable(225, 'LB');
+    const byPercent = Object.fromEntries(rows.map((r) => [r.percent, r.weight]));
+    // 90% = 202.5 -> nearest 5 = 200 (202.5/5 = 40.5 -> round 40 -> 200... ties
+    // round to even via Math.round: 40.5 -> 41 -> 205). Math.round(40.5)=41.
+    expect(byPercent[90]).toBe(205);
+    // Every weight is a multiple of 5.
+    for (const r of rows) {
+      expect((r.weight / 5) % 1).toBe(0);
+    }
+  });
+
+  it('returns an empty list when there is no usable e1RM', () => {
+    expect(computeLoadingTable(0, 'KG')).toEqual([]);
+    expect(computeLoadingTable(-10, 'KG')).toEqual([]);
+    expect(computeLoadingTable(Number.NaN, 'KG')).toEqual([]);
+    expect(computeLoadingTable(Number.POSITIVE_INFINITY, 'LB')).toEqual([]);
+  });
+
+  it('accepts a custom percentage set', () => {
+    const rows = computeLoadingTable(100, 'KG', [100, 50]);
+    expect(rows).toEqual([
+      { percent: 100, weight: 100 },
+      { percent: 50, weight: 50 },
+    ]);
+  });
+});

--- a/lib/loading-table.ts
+++ b/lib/loading-table.ts
@@ -1,0 +1,59 @@
+// Pure percentage-of-e1RM loading table (issue #226).
+//
+// Many programs (5/3/1, nSuns, the templates we ship) prescribe loads as a
+// percentage of a training max, and lifters plan heavy/volume days by
+// percentage. Given the best estimated 1RM already computed for an exercise on
+// the progress view, this derives a small "% of your best" loading table: a
+// row per default percentage, with the load rounded to a loadable increment in
+// the user's display unit. It is a pure function, fully unit-tested, and
+// display-only: it never creates or mutates a Set.
+//
+// The e1RM is passed in the user's DISPLAY unit (kg or lb) so the rounded loads
+// land on plate jumps the lifter actually uses; the caller converts the
+// kg-stored e1RM before calling in here.
+
+import { WeightUnit } from '@prisma/client';
+import { roundWeight } from '@/lib/units';
+
+// Default percentages, heaviest first. A sensible spread for planning heavy and
+// volume days off a training max.
+export const DEFAULT_LOADING_PERCENTAGES: readonly number[] = [
+  95, 90, 85, 80, 75, 70, 65, 60,
+];
+
+// Loadable increment per unit: a clean plate jump (2.5 kg / 5 lb), matching the
+// warm-up calculator's rounding so the whole page rounds loads consistently.
+const LOADING_INCREMENT: Record<WeightUnit, number> = {
+  KG: 2.5,
+  LB: 5,
+};
+
+export interface LoadingRow {
+  // The percentage of the best e1RM this row represents (whole percent).
+  percent: number;
+  // The load in the display unit, rounded to the nearest loadable increment.
+  weight: number;
+}
+
+// Round a weight to the NEAREST loadable increment for the unit. Unlike the
+// warm-up ramp (which rounds down so a warm-up never creeps up), a planned
+// working load reads best rounded to the closest plate jump.
+function roundToIncrement(weight: number, unit: WeightUnit): number {
+  const step = LOADING_INCREMENT[unit];
+  return roundWeight(Math.round(weight / step) * step, 2);
+}
+
+// Build the loading table from a best estimated 1RM expressed in the display
+// unit. Returns an empty list when there is no usable e1RM (zero, negative, or
+// non-finite) so the caller can simply hide the table for a new exercise.
+export function computeLoadingTable(
+  bestE1RM: number,
+  unit: WeightUnit,
+  percentages: readonly number[] = DEFAULT_LOADING_PERCENTAGES,
+): LoadingRow[] {
+  if (!Number.isFinite(bestE1RM) || bestE1RM <= 0) return [];
+  return percentages.map((percent) => ({
+    percent,
+    weight: roundToIncrement((bestE1RM * percent) / 100, unit),
+  }));
+}


### PR DESCRIPTION
Adds a compact "Training loads" table to the selected exercise's progress view: default percentages (95..60%) of the exercise's best estimated 1RM, each rounded to a loadable increment in the user's display unit. Turns the progress view into a planning aid for percentage-based programs (5/3/1, nSuns, the shipped templates).

- New pure `computeLoadingTable` in `lib/loading-table.ts`: rounds each percentage's load to the NEAREST loadable increment (2.5 kg / 5 lb), distinct from the warm-up ramp's round-down since a planned working load reads best on the closest plate jump.
- The best e1RM is stored in kg and bodyweight-adjusted for bodyweight movements (consistent with the rest of the page); the dashboard converts to the display unit before deriving so rounding lands on real plate jumps. Correct kg/lb.
- Rendered as a collapsible native `<details>` so it does not crowd the chart; hidden entirely when the exercise has no e1RM yet (new exercise), no crash.
- Display-only, no schema / API / prompt change. Colocated unit test pins the percentage->load math (kg + lb), round-to-nearest, and the empty/no-e1RM case.
- Also rides the autonomy-log entry for this run (#224/#225/#226).

`bash scripts/verify.sh` passes.

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)