### PR TITLE
fix: do not show the exercise cue twice in the session set logger

### DIFF
--- a/components/session/exercise-card.tsx
+++ b/components/session/exercise-card.tsx
@@ -204,7 +204,7 @@ export function ExerciseCard({
           </div>
         )}
 
-        {(programExercise.notes || exo.notes) && (
+        {programExercise.notes && (
           <div>
             <Button
               variant="ghost"
@@ -217,13 +217,10 @@ export function ExerciseCard({
             </Button>
             {notesOpen && (
               <div className="mt-2 space-y-2 rounded-md bg-muted/50 p-3 text-xs leading-relaxed text-muted-foreground">
+                {/* The exercise's own notes are the always-visible cue under the
+                    header; this block holds only the program-specific note so
+                    the same text is never shown twice. */}
                 {programExercise.notes && <p className="whitespace-pre-line">{programExercise.notes}</p>}
-                {exo.notes && (
-                  <p className="whitespace-pre-line">
-                    <span className="font-medium text-foreground">Technique: </span>
-                    {exo.notes}
-                  </p>
-                )}
               </div>
             )}
           </div>


### PR DESCRIPTION
Closes #231 - the one NIT from the correctness review of batch 12 (#228/#229/#230 were all CLEAN; this is the single non-blocking redundancy).

Exercise.notes was shown twice (always-visible cue + collapsible 'Technique:'). The collapsible now holds only the program-specific note; the exercise's own cue lives solely in the always-visible line. Display-only.

bash scripts/verify.sh - GREEN-GATE PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)