### PR TITLE
docs: write up batch 12 (exercise cues, per-muscle frequency, e1RM loading table)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Maximum heart rate on cardio sets: the peak HR is stored, imported from and
   exported to TCX, and shown next to the average; the CSV export gains
   avg/max HR columns.
+- Exercise cues in the session: an exercise's technique note (e.g. "keep
+  elbows tucked, pause at the bottom") now shows as an always-visible line
+  while you log it, so the form reminder is there exactly when you need it.
+- Per-muscle weekly training frequency on the progress page: each muscle
+  group's number of distinct training days per week ("Nx/week"), next to its
+  volume - frequency is a distinct training variable from total volume.
+- An e1RM percentage loading table on the per-exercise progress view: the
+  loads at 95-60% of your best estimated 1RM, rounded to a loadable plate
+  jump in your unit, for planning percentage-based work (5/3/1, etc.).
 - Free-text, AI-parsed set logging (the last roadmap item): an opt-in
   "Parse with AI" button turns a plain description ("bench, 100 kilos, 5 reps,
   2 in the tank" or "ran 5k in 25 minutes") into the set fields for you to

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -1535,3 +1535,17 @@ continuously, no per-change approval, self-challenge with subagents, keep a roll
 **Permissions re-audit (L9).** Re-read .claude/settings.json: the deny list is intact (rm -rf, git push --force/-f/--force-with-lease, git reset --hard, curl, wget). The 37 allow entries are all coherent with what the loop runs (npm/npx/git/gh/file ops); no dangerous scope creep, no sudo/broad-rm/network grants.
 
 **Filed.** #219 (fix the flaky readiness-checkin userEvent test - times out under parallel WSL2 load, green in CI) and #220 (colocated unit coverage for lib/last-performance.ts - the cardio-totals/HR-averaging logic from #179 is only integration-tested). Code markers: none. Roadmap: complete. Coverage otherwise healthy (the untrusted set-parse validation is unit-tested; thin wrappers are integration-covered).
+
+---
+
+## 2026-06-16 - Batch 12 (beyond-roadmap polish): 3 CLEAN + 1 dedup fix
+
+**Context.** First ideation past the completed roadmap - mature-product polish, kept anti-busywork (each a verified real gap, not filler): exercise cues in session (#224), per-muscle frequency (#225), e1RM % loading table (#226). All additive, display-only.
+
+**Decided / shipped.**
+- #228/#229/#230 merged on green; one consolidated light correctness review (proportionate to display-only/no-contract risk) returned 3/3 CLEAN - it confirmed the non-vacuous bits: frequency counts distinct calendar days (not raw sets) and the loading table converts kg->display unit BEFORE rounding so loads land on real plate jumps. One NIT (the exercise note rendered twice - cue + collapsible) fixed in #232 (#231): the collapsible now holds only the program-specific note.
+- The product is feature-complete on its vision; ideation is now polish/completeness. Deferred unchanged: FIT import, mobility session type, Serwist.
+
+**Challenged.** One consolidated Opus correctness review (right-sized for low risk). Accepted-change rate: 4 merged / 0 abandoned.
+
+**Deferred to human.** Nothing. Process note: the in-loop CI poll briefly merged two docs/1-file PRs on "no checks reported" before the workflow registered; both were locally full-gate-green and confirmed green on main post-merge - harden the poll to treat "no checks reported" as wait, not proceed.

--- a/docs/loops/ideas-backlog.md
+++ b/docs/loops/ideas-backlog.md
@@ -52,6 +52,6 @@ research and the product wedge). See `docs/loops/08-ideation-loop.md` for how th
 - shipped - free-text (AI-parsed) set logging (issue #210, 2026-06-15, PR #216) - the LAST roadmap item; multi-lens review CLEAN incl. untrusted-output (12 hostile model outputs fail closed, a parse never logs a set)
 - shipped - user-settable weekly volume targets (issue #211, 2026-06-15, PR #215) - additive VolumeTarget; review CLEAN (classifyWeeklySets stays pure)
 - shipped - give the AI coach your all-time records (issue #212, 2026-06-15, PR #214) - review CLEAN, output contract intact
-- proposed - show the exercise's notes/cues in the session set logger (issue #224, 2026-06-16) - Exercise.notes never surfaced while logging; display-only form-cue line
-- proposed - per-muscle weekly training frequency on the progress page (issue #225, 2026-06-16) - frequency is a distinct hypertrophy variable from volume; pure derivation, display-only
-- proposed - e1RM-based percentage loading table on the per-exercise progress view (issue #226, 2026-06-16) - turns the e1RM trend into a planning tool (5/3/1-style %s); pure, display-only
+- shipped - show the exercise's notes/cues in the session set logger (issue #224, 2026-06-16, PR #228 + dedup fix #232) - review CLEAN; the one NIT (cue shown twice) fixed
+- shipped - per-muscle weekly training frequency on the progress page (issue #225, 2026-06-16, PR #229) - review CLEAN; distinct-day counting, not set count
+- shipped - e1RM-based percentage loading table on the per-exercise progress view (issue #226, 2026-06-16, PR #230) - review CLEAN; converts to display unit before rounding


### PR DESCRIPTION
Content-loop tail for batch 12 (#228 exercise cues, #229 per-muscle frequency, #230 e1RM loading table) + the #232 dedup fix.

- CHANGELOG: the three additive display-only features.
- Backlog: shipped with the 3/3 CLEAN consolidated correctness review.
- Journal: first beyond-roadmap polish batch; notes a CI-poll hardening (treat 'no checks reported' as wait).
- Media unchanged: the new surfaces (session cue, per-muscle frequency on the volume row, the collapsible loading table) are not among the four captured screenshots.

bash scripts/verify.sh - GREEN-GATE PASSED.

After merge: redeploy the demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)