### PR TITLE
fix(ci): demo deploy is manual-dispatch only; the VPS pulls on a cron

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,6 +1,11 @@
-# Redeploys the public demo instance. Security model (see issue #123):
-# - triggers: weekly schedule + manual dispatch ONLY - never PR events, so
-#   fork PRs can not reach the secrets.
+# Redeploys the public demo instance ON DEMAND. The RELIABLE automatic path is
+# a PULL-model cron ON the VPS (auto-deploy.sh every 2h: it git-fetches main and
+# self-redeploys when it moved) - GitHub-runner-SSH-IN times out at the
+# connection level from shared runner IPs, so this workflow is manual-dispatch
+# only now (the weekly schedule was removed - its failures were pure red noise).
+# Security model (see issue #123):
+# - triggers: manual dispatch ONLY - never PR events, so fork PRs can not reach
+#   the secrets.
 # - permissions: none on the GitHub token.
 # - no third-party actions: plain ssh with a pinned host key.
 # - the SSH key is locked server-side to a forced command that runs the
@@ -11,9 +16,6 @@
 name: Deploy demo
 
 on:
-  schedule:
-    # Weekly, Monday 05:00 UTC (after the nightly data reset at 04:00).
-    - cron: '0 5 * * 1'
   workflow_dispatch: {}
 
 permissions: {}

--- a/README.md
+++ b/README.md
@@ -264,6 +264,11 @@ pollute it. Re-run the seeder on a schedule (e.g. a cron every 30 minutes) so
 the demo always opens on the clean, populated state - it wipes and recreates
 the demo account's data without touching the rest.
 
+To keep the deployed demo on the latest code, prefer a pull-model cron on the
+host (periodically `git fetch` and rebuild only when the branch moved) over an
+inbound SSH deploy from CI - a host reaching out to GitHub is far more reliable
+than CI reaching in to a small VPS.
+
 ## Roadmap
 
 - [x] Single user MVP (logging, progress, weekly AI debrief, program adjustments)


### PR DESCRIPTION
The demo deploy via GitHub-runner SSH timed out at the connection level from shared runner IPs more often than it succeeded (I had to redeploy directly from the VPS most cycles), and the weekly scheduled run showed up as a recurring red X.

Root cause: connection-level timeout (the runner's SYN to port 22 not getting through), not auth/fail2ban - the VPS is reachable from a fixed IP, but runner IPs are shared/variable and intermittently dropped. Not fixable from the workflow side.

Fix: flip from PUSH to PULL. A cron on the VPS (auto-deploy.sh, every 2h) git-fetches main and self-redeploys only when it moved - reliable, no inbound SSH. This workflow becomes manual-dispatch only (drops the flaky weekly schedule + its red-noise runs); workflow_dispatch stays for on-demand. README documents the pull-model preference.

(VPS-side auto-deploy.sh + cron installed and tested separately; this PR is the repo half.)

bash scripts/verify.sh - GREEN-GATE PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)