### PR TITLE
feat: add a search box to the exercise catalog

### DIFF
--- a/components/exercises/exercises-view.test.tsx
+++ b/components/exercises/exercises-view.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Exercise } from '@prisma/client';
+import { ExercisesView } from './exercises-view';
+
+// The catalog renders the create/edit dialogs and the delete button, which call
+// useRouter; mock it so the component mounts under jsdom.
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }),
+}));
+
+function exercise(over: Partial<Exercise>): Exercise {
+  return {
+    id: over.id ?? 'e1',
+    userId: 'u',
+    name: over.name ?? 'Exercise',
+    muscleGroup: over.muscleGroup ?? 'CHEST',
+    category: over.category ?? 'COMPOUND',
+    defaultRestSec: 120,
+    notes: null,
+    usesBodyweight: false,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    ...over,
+  };
+}
+
+const exercises: Exercise[] = [
+  exercise({ id: 'e1', name: 'Barbell Bench Press', muscleGroup: 'CHEST' }),
+  exercise({ id: 'e2', name: 'Back Squat', muscleGroup: 'QUADS' }),
+  exercise({ id: 'e3', name: 'Romanian Deadlift', muscleGroup: 'HAMSTRINGS' }),
+];
+
+describe('ExercisesView search (issue #238)', () => {
+  it('shows every exercise when the query is empty', () => {
+    render(<ExercisesView exercises={exercises} />);
+    expect(screen.getByText('Barbell Bench Press')).toBeInTheDocument();
+    expect(screen.getByText('Back Squat')).toBeInTheDocument();
+    expect(screen.getByText('Romanian Deadlift')).toBeInTheDocument();
+  });
+
+  it('narrows the list to name matches, case-insensitively', async () => {
+    const user = userEvent.setup({ delay: null });
+    render(<ExercisesView exercises={exercises} />);
+    await user.type(screen.getByLabelText('Search exercises by name'), 'squat');
+    expect(screen.getByText('Back Squat')).toBeInTheDocument();
+    expect(screen.queryByText('Barbell Bench Press')).not.toBeInTheDocument();
+    expect(screen.queryByText('Romanian Deadlift')).not.toBeInTheDocument();
+  });
+
+  it('shows a no-match empty state when nothing matches', async () => {
+    const user = userEvent.setup({ delay: null });
+    render(<ExercisesView exercises={exercises} />);
+    await user.type(screen.getByLabelText('Search exercises by name'), 'zzz');
+    expect(screen.getByText('No exercises match')).toBeInTheDocument();
+    expect(screen.queryByText('Back Squat')).not.toBeInTheDocument();
+  });
+
+  it('restores the full list when the query is cleared', async () => {
+    const user = userEvent.setup({ delay: null });
+    render(<ExercisesView exercises={exercises} />);
+    const input = screen.getByLabelText('Search exercises by name');
+    await user.type(input, 'squat');
+    expect(screen.queryByText('Barbell Bench Press')).not.toBeInTheDocument();
+    await user.clear(input);
+    expect(screen.getByText('Barbell Bench Press')).toBeInTheDocument();
+    expect(screen.getByText('Romanian Deadlift')).toBeInTheDocument();
+  });
+
+  it('renders the catalog-empty state and no search box when there are no exercises', () => {
+    render(<ExercisesView exercises={[]} />);
+    expect(screen.getByText('No exercises')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Search exercises by name')).not.toBeInTheDocument();
+  });
+});

--- a/components/exercises/exercises-view.tsx
+++ b/components/exercises/exercises-view.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import { Plus, Pencil } from 'lucide-react';
+import { Plus, Pencil, Search } from 'lucide-react';
 import type { Exercise, MuscleGroup } from '@prisma/client';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
 import {
   Card,
   CardContent,
@@ -23,8 +24,18 @@ interface ExercisesViewProps {
 export function ExercisesView({ exercises }: ExercisesViewProps) {
   const [createOpen, setCreateOpen] = useState(false);
   const [editing, setEditing] = useState<Exercise | null>(null);
+  const [query, setQuery] = useState('');
 
-  const grouped = useMemo(() => groupByMuscle(exercises), [exercises]);
+  // Case-insensitive substring match on the exercise name. The query only
+  // narrows the already-loaded list (no API call); an empty query shows
+  // everything, preserving the original behaviour.
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return exercises;
+    return exercises.filter((ex) => ex.name.toLowerCase().includes(q));
+  }, [exercises, query]);
+
+  const grouped = useMemo(() => groupByMuscle(filtered), [filtered]);
 
   return (
     <div className="mx-auto flex max-w-3xl flex-col gap-6">
@@ -41,6 +52,20 @@ export function ExercisesView({ exercises }: ExercisesViewProps) {
         </Button>
       </div>
 
+      {exercises.length > 0 && (
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search exercises by name"
+            aria-label="Search exercises by name"
+            className="pl-9"
+          />
+        </div>
+      )}
+
       {exercises.length === 0 ? (
         <Card>
           <CardHeader>
@@ -48,6 +73,16 @@ export function ExercisesView({ exercises }: ExercisesViewProps) {
             <CardDescription>
               The catalog is empty. Add your first exercise so you can use it in
               a program.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      ) : filtered.length === 0 ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>No exercises match</CardTitle>
+            <CardDescription>
+              No exercise name matches &ldquo;{query.trim()}&rdquo;. Try a different
+              search.
             </CardDescription>
           </CardHeader>
         </Card>

--- a/docs/loops/ideas-backlog.md
+++ b/docs/loops/ideas-backlog.md
@@ -55,3 +55,5 @@ research and the product wedge). See `docs/loops/08-ideation-loop.md` for how th
 - shipped - show the exercise's notes/cues in the session set logger (issue #224, 2026-06-16, PR #228 + dedup fix #232) - review CLEAN; the one NIT (cue shown twice) fixed
 - shipped - per-muscle weekly training frequency on the progress page (issue #225, 2026-06-16, PR #229) - review CLEAN; distinct-day counting, not set count
 - shipped - e1RM-based percentage loading table on the per-exercise progress view (issue #226, 2026-06-16, PR #230) - review CLEAN; converts to display unit before rounding
+- proposed - proactive coach insight card on the home dashboard (issue #237, 2026-06-18) - compose existing deterministic signals (deload/stall/PR/frequency), display-only, no LLM call
+- shipped - search/filter box on the exercise catalog (issue #238, 2026-06-18, PR pending) - client-side name filter over the loaded list, no API change


### PR DESCRIPTION
Adds a name search/filter box to the exercise catalog (`components/exercises/exercises-view.tsx`). Pure client-side filter over the already-loaded list: case-insensitive substring on the exercise name, muscle-group grouping preserved for matches, empty query restores everything, and a dedicated 'No exercises match' empty state distinct from the catalog-empty state. No API change, no new dependency.

Closes #238

## How I tested
- New component test `components/exercises/exercises-view.test.tsx` (5 cases: full list on empty query, case-insensitive narrowing, no-match empty state, clearing restores all, catalog-empty hides the search box) - all green.
- `bash scripts/verify.sh` passed (prisma generate + lint + typecheck + unit + build).