### PR TITLE
feat: surface a proactive coach insight on the home dashboard

### DIFF
--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -1,11 +1,12 @@
 import Link from 'next/link';
-import { Dumbbell, Play, AlertCircle } from 'lucide-react';
+import { Dumbbell, Play, AlertCircle, Lightbulb } from 'lucide-react';
 import { db } from '@/lib/db';
 import { requireSession } from '@/lib/auth';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { DAY_LABELS } from '@/lib/schemas/workout';
+import { getHomeInsight } from '@/lib/home-insight';
 
 export default async function DashboardPage() {
   const session = await requireSession();
@@ -27,6 +28,12 @@ export default async function DashboardPage() {
     },
   });
 
+  // Proactive coach insight (issue #237): the single highest-priority
+  // deterministic signal (recommended deload / stalled lift / fresh PR /
+  // on-track), composed from the existing derivations. Display-only, no LLM
+  // call; null on a brand-new account with no history.
+  const insight = await getHomeInsight(session.userId);
+
   return (
     <main className="flex-1 px-4 py-6">
       <div className="mx-auto flex max-w-2xl flex-col gap-6">
@@ -37,6 +44,20 @@ export default async function DashboardPage() {
             <p className="text-xs text-muted-foreground">{session.email}</p>
           </div>
         </div>
+
+        {insight && (
+          <Link href={insight.href} className="block">
+            <Card className="border-primary/30 bg-primary/5 transition-colors hover:bg-primary/10">
+              <CardHeader className="pb-3">
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <Lightbulb className="size-4 text-primary" />
+                  {insight.title}
+                </CardTitle>
+                <CardDescription>{insight.detail}</CardDescription>
+              </CardHeader>
+            </Card>
+          </Link>
+        )}
 
         {inProgressSession ? (
           <Card className="border-primary/40 bg-primary/5">

--- a/docs/loops/ideas-backlog.md
+++ b/docs/loops/ideas-backlog.md
@@ -55,5 +55,5 @@ research and the product wedge). See `docs/loops/08-ideation-loop.md` for how th
 - shipped - show the exercise's notes/cues in the session set logger (issue #224, 2026-06-16, PR #228 + dedup fix #232) - review CLEAN; the one NIT (cue shown twice) fixed
 - shipped - per-muscle weekly training frequency on the progress page (issue #225, 2026-06-16, PR #229) - review CLEAN; distinct-day counting, not set count
 - shipped - e1RM-based percentage loading table on the per-exercise progress view (issue #226, 2026-06-16, PR #230) - review CLEAN; converts to display unit before rounding
-- proposed - proactive coach insight card on the home dashboard (issue #237, 2026-06-18) - compose existing deterministic signals (deload/stall/PR/frequency), display-only, no LLM call
-- shipped - search/filter box on the exercise catalog (issue #238, 2026-06-18, PR pending) - client-side name filter over the loaded list, no API change
+- shipped - proactive coach insight card on the home dashboard (issue #237, 2026-06-18, PR #240) - pure selector over existing signals (deload > stall > PR > on-track), display-only, no LLM call
+- shipped - search/filter box on the exercise catalog (issue #238, 2026-06-18, PR #239) - client-side name filter over the loaded list, no API change

--- a/lib/home-insight.test.ts
+++ b/lib/home-insight.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { selectHomeInsight, type HomeInsightInput } from './home-insight';
+
+function input(over: Partial<HomeInsightInput>): HomeInsightInput {
+  return {
+    deload: { recommended: false, reasons: [] },
+    stalledExerciseNames: [],
+    recentPR: null,
+    trainingDaysThisWeek: null,
+    ...over,
+  };
+}
+
+describe('selectHomeInsight (issue #237)', () => {
+  it('returns null when there is nothing to surface', () => {
+    expect(selectHomeInsight(input({}))).toBeNull();
+    // trainingDaysThisWeek of 0 is still nothing worth a card.
+    expect(selectHomeInsight(input({ trainingDaysThisWeek: 0 }))).toBeNull();
+  });
+
+  it('prioritises a recommended deload above everything else', () => {
+    const result = selectHomeInsight(
+      input({
+        deload: {
+          recommended: true,
+          reasons: [{ kind: 'stalled-lifts', exerciseNames: ['Squat', 'Bench'] }],
+        },
+        stalledExerciseNames: ['Squat', 'Bench'],
+        recentPR: { exerciseName: 'Deadlift', kind: 'weight' },
+        trainingDaysThisWeek: 3,
+      }),
+    );
+    expect(result?.kind).toBe('deload');
+    expect(result?.detail).toContain('Squat');
+  });
+
+  it('does not surface a deload that is recommended but carries no reasons', () => {
+    // Defensive: recommended with an empty reasons array falls through.
+    const result = selectHomeInsight(
+      input({ deload: { recommended: true, reasons: [] }, trainingDaysThisWeek: 2 }),
+    );
+    expect(result?.kind).toBe('on-track');
+  });
+
+  it('surfaces a stalled lift when no deload is recommended', () => {
+    const one = selectHomeInsight(input({ stalledExerciseNames: ['Overhead Press'] }));
+    expect(one?.kind).toBe('stall');
+    expect(one?.title).toBe('A lift has stalled');
+    expect(one?.detail).toContain('Overhead Press');
+
+    const many = selectHomeInsight(input({ stalledExerciseNames: ['A', 'B', 'C'] }));
+    expect(many?.title).toBe('3 lifts have stalled');
+    expect(many?.detail).toContain('A, B, C');
+  });
+
+  it('stall outranks a PR and on-track', () => {
+    const result = selectHomeInsight(
+      input({
+        stalledExerciseNames: ['Row'],
+        recentPR: { exerciseName: 'Curl', kind: 'e1rm' },
+        trainingDaysThisWeek: 4,
+      }),
+    );
+    expect(result?.kind).toBe('stall');
+  });
+
+  it('celebrates a fresh PR when no deload or stall', () => {
+    const weight = selectHomeInsight(
+      input({ recentPR: { exerciseName: 'Bench', kind: 'weight' }, trainingDaysThisWeek: 1 }),
+    );
+    expect(weight?.kind).toBe('pr');
+    expect(weight?.detail).toContain('heaviest set');
+    expect(weight?.detail).toContain('Bench');
+
+    const e1rm = selectHomeInsight(
+      input({ recentPR: { exerciseName: 'Squat', kind: 'e1rm' } }),
+    );
+    expect(e1rm?.detail).toContain('estimated 1RM');
+  });
+
+  it('falls back to an on-track line with training days this week', () => {
+    const one = selectHomeInsight(input({ trainingDaysThisWeek: 1 }));
+    expect(one?.kind).toBe('on-track');
+    expect(one?.detail).toContain('1 day ');
+
+    const many = selectHomeInsight(input({ trainingDaysThisWeek: 3 }));
+    expect(many?.detail).toContain('3 days');
+  });
+
+  it('always links somewhere actionable', () => {
+    const result = selectHomeInsight(input({ trainingDaysThisWeek: 2 }));
+    expect(result?.href).toBe('/progress');
+  });
+});

--- a/lib/home-insight.ts
+++ b/lib/home-insight.ts
@@ -1,0 +1,237 @@
+import { db } from './db';
+import {
+  applyBodyweight,
+  exerciseProgress,
+  isStalled,
+  isoWeekStart,
+} from './stats';
+import { exerciseRecords } from './records';
+import {
+  recommendDeload,
+  deloadReasonLine,
+  DELOAD_READINESS_MAX_AGE_DAYS,
+  DELOAD_READINESS_LOOKBACK,
+  type DeloadRecommendation,
+} from './deload';
+
+// How far back to look when judging stalled lifts and all-time records for the
+// home insight. Matches the progress page's recent window so the home nudge and
+// the progress page agree on what counts as "recent".
+const INSIGHT_WINDOW_WEEKS = 12;
+
+export type HomeInsightKind = 'deload' | 'stall' | 'pr' | 'on-track';
+
+export interface HomeInsight {
+  kind: HomeInsightKind;
+  title: string;
+  detail: string;
+  // Where the user goes to act on the insight.
+  href: string;
+}
+
+export interface HomeInsightInput {
+  // Program-level deload recommendation (reuses lib/deload).
+  deload: DeloadRecommendation;
+  // Lifts currently flagged by isStalled, any order.
+  stalledExerciseNames: string[];
+  // A personal record hit in the user's most recent finished session, if any.
+  recentPR: { exerciseName: string; kind: 'weight' | 'e1rm' } | null;
+  // Distinct training days in the current ISO week (null when unknown).
+  trainingDaysThisWeek: number | null;
+}
+
+// Pure selector: given the already-derived deterministic signals, returns the
+// single highest-priority insight to greet the user with, or null when there is
+// nothing worth surfacing (e.g. a brand-new account with no history). Priority:
+// a recommended deload > a stalled lift > a fresh personal record > an
+// on-track consistency line. Display-only - no LLM, no side effects.
+export function selectHomeInsight(input: HomeInsightInput): HomeInsight | null {
+  if (input.deload.recommended && input.deload.reasons.length > 0) {
+    return {
+      kind: 'deload',
+      title: 'Recovery may be due',
+      detail: input.deload.reasons.map(deloadReasonLine).join(' '),
+      href: '/progress',
+    };
+  }
+
+  if (input.stalledExerciseNames.length > 0) {
+    const names = input.stalledExerciseNames;
+    return {
+      kind: 'stall',
+      title: names.length === 1 ? 'A lift has stalled' : `${names.length} lifts have stalled`,
+      detail:
+        names.length === 1
+          ? `${names[0]} has not progressed recently. A small change in load, reps, or technique can get it moving again.`
+          : `${names.join(', ')} have not progressed recently. Check the progress page for what to adjust.`,
+      href: '/progress',
+    };
+  }
+
+  if (input.recentPR) {
+    const what =
+      input.recentPR.kind === 'weight' ? 'a new heaviest set' : 'a new best estimated 1RM';
+    return {
+      kind: 'pr',
+      title: 'New personal record',
+      detail: `Your last session set ${what} on ${input.recentPR.exerciseName}. Nice work.`,
+      href: '/progress',
+    };
+  }
+
+  if (input.trainingDaysThisWeek != null && input.trainingDaysThisWeek > 0) {
+    const n = input.trainingDaysThisWeek;
+    return {
+      kind: 'on-track',
+      title: 'You are training consistently',
+      detail: `Trained ${n} day${n > 1 ? 's' : ''} this week. Keep the momentum going.`,
+      href: '/progress',
+    };
+  }
+
+  return null;
+}
+
+// Server-side: gather the deterministic signals for a user and pick the single
+// home insight. Composes the existing derivations (stall detection, deload
+// recommendation, records, weekly frequency) over focused queries; it never
+// writes and never calls the LLM. Returns null when there is nothing to surface.
+export async function getHomeInsight(
+  userId: string,
+  now: Date = new Date(),
+): Promise<HomeInsight | null> {
+  const since = new Date(now);
+  since.setUTCDate(since.getUTCDate() - INSIGHT_WINDOW_WEEKS * 7);
+
+  const user = await db.user.findUnique({
+    where: { id: userId },
+    select: { bodyweight: true },
+  });
+  const bodyweight = user?.bodyweight ?? null;
+
+  // Recent non-warmup strength sets, for stall detection. Grouped by exercise
+  // in memory (one query) rather than per-exercise queries.
+  const recentSets = await db.set.findMany({
+    where: {
+      isWarmup: false,
+      completedAt: { gte: since },
+      session: { userId },
+      exercise: { category: { not: 'CARDIO' } },
+    },
+    orderBy: { completedAt: 'asc' },
+    select: {
+      weight: true,
+      reps: true,
+      isWarmup: true,
+      durationSec: true,
+      sessionId: true,
+      session: { select: { startedAt: true } },
+      exercise: { select: { name: true, usesBodyweight: true } },
+    },
+  });
+
+  const byExercise = new Map<
+    string,
+    {
+      weight: number;
+      reps: number;
+      isWarmup: boolean;
+      durationSec: number | null;
+      sessionId: string;
+      sessionStartedAt: Date;
+      usesBodyweight: boolean;
+    }[]
+  >();
+  for (const s of recentSets) {
+    const list = byExercise.get(s.exercise.name) ?? [];
+    list.push({
+      weight: s.weight,
+      reps: s.reps,
+      isWarmup: s.isWarmup,
+      durationSec: s.durationSec,
+      sessionId: s.sessionId,
+      sessionStartedAt: s.session.startedAt,
+      usesBodyweight: s.exercise.usesBodyweight,
+    });
+    byExercise.set(s.exercise.name, list);
+  }
+
+  const stalledExerciseNames: string[] = [];
+  for (const [name, sets] of byExercise) {
+    const points = exerciseProgress(applyBodyweight(sets, bodyweight));
+    if (isStalled(points.map((p) => p.estimated1RM))) {
+      stalledExerciseNames.push(name);
+    }
+  }
+
+  // Recent readiness check-ins feed the deload recommendation's low-readiness arm.
+  const readinessSince = new Date(now);
+  readinessSince.setUTCDate(readinessSince.getUTCDate() - DELOAD_READINESS_MAX_AGE_DAYS);
+  const checkins = await db.readinessCheckin.findMany({
+    where: { userId, createdAt: { gte: readinessSince } },
+    orderBy: { createdAt: 'desc' },
+    take: DELOAD_READINESS_LOOKBACK,
+    select: { readiness: true },
+  });
+
+  const deload = recommendDeload({
+    stalledExerciseNames,
+    recentReadiness: checkins.map((c) => c.readiness),
+  });
+
+  // A fresh personal record: an all-time record (over full history) whose date
+  // falls on the user's most recent finished session.
+  let recentPR: HomeInsightInput['recentPR'] = null;
+  const lastSession = await db.session.findFirst({
+    where: { userId, finishedAt: { not: null } },
+    orderBy: { startedAt: 'desc' },
+    select: { startedAt: true },
+  });
+  if (lastSession) {
+    const lastDay = lastSession.startedAt.toISOString().slice(0, 10);
+    const recordSets = await db.set.findMany({
+      where: {
+        isWarmup: false,
+        session: { userId },
+        exercise: { category: { not: 'CARDIO' } },
+      },
+      orderBy: { session: { startedAt: 'asc' } },
+      select: {
+        weight: true,
+        reps: true,
+        isWarmup: true,
+        durationSec: true,
+        exercise: { select: { name: true, usesBodyweight: true } },
+        session: { select: { startedAt: true } },
+      },
+    });
+    const records = exerciseRecords(
+      recordSets.map((s) => ({
+        weight:
+          s.exercise.usesBodyweight && bodyweight && bodyweight > 0
+            ? +(bodyweight + s.weight).toFixed(2)
+            : s.weight,
+        reps: s.reps,
+        isWarmup: s.isWarmup,
+        durationSec: s.durationSec,
+        exerciseName: s.exercise.name,
+        sessionStartedAt: s.session.startedAt,
+      })),
+    );
+    const weightPR = records.find((r) => r.maxWeightDate === lastDay);
+    const e1rmPR = records.find((r) => r.bestE1RMDate === lastDay);
+    if (weightPR) recentPR = { exerciseName: weightPR.exerciseName, kind: 'weight' };
+    else if (e1rmPR) recentPR = { exerciseName: e1rmPR.exerciseName, kind: 'e1rm' };
+  }
+
+  // Distinct training days in the current ISO week.
+  const weekStart = isoWeekStart(now);
+  const thisWeekSessions = await db.session.findMany({
+    where: { userId, finishedAt: { not: null }, startedAt: { gte: weekStart } },
+    select: { startedAt: true },
+  });
+  const days = new Set(thisWeekSessions.map((s) => s.startedAt.toISOString().slice(0, 10)));
+  const trainingDaysThisWeek = thisWeekSessions.length > 0 ? days.size : null;
+
+  return selectHomeInsight({ deload, stalledExerciseNames, recentPR, trainingDaysThisWeek });
+}


### PR DESCRIPTION
Adds a single 'Coach insight' card to the home dashboard (`app/(app)/page.tsx`) that proactively surfaces the most important deterministic training signal, composed from existing derivations - no LLM call, display-only.

New `lib/home-insight.ts`:
- `selectHomeInsight` (pure): picks the single highest-priority insight by the order **recommended deload > stalled lift > fresh personal record > on-track consistency**, or null when there is nothing worth surfacing.
- `getHomeInsight` (server): gathers the signals over focused queries and reuses `isStalled`/`exerciseProgress` (stall), `recommendDeload` (deload), `exerciseRecords` (a PR dated to the latest finished session), and distinct training days this ISO week. No writes.

The card links to /progress to act on the insight. A brand-new account with no history renders no card (degrades cleanly).

Closes #237

## How I tested
- New unit test `lib/home-insight.test.ts` (8 cases) covers the full priority order (deload > stall > PR > on-track > none), the singular/plural copy, the defensive 'recommended but no reasons' fall-through, and the actionable link.
- `bash scripts/verify.sh` passed (prisma generate + lint + typecheck + unit + build), re-run after merging main (catalog search #239) into the branch.