### PR TITLE
chore: generate the Prisma client on install (postinstall)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "db:seed": "prisma db seed",
     "seed:demo": "tsx scripts/seed-demo-history.ts",
     "db:studio": "prisma studio",
-    "db:generate": "prisma generate"
+    "db:generate": "prisma generate",
+    "postinstall": "node -e \"const fs=require('fs');if(fs.existsSync('prisma/schema.prisma'))require('child_process').execSync('prisma generate',{stdio:'inherit'})\""
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.98.0",


### PR DESCRIPTION
Follow-up to the Prisma 7 upgrade (#243). The generated client now lives in the gitignored `prisma/generated`, so a fresh `npm install` left no client until `prisma generate` ran - `npm test`/`npm run dev` would fail to resolve `@/prisma/generated/client`.

Adds a guarded `postinstall` that runs `prisma generate` only when `prisma/schema.prisma` exists, so it:
- no-ops in the Docker `deps`/`prod-deps` stages (they `npm ci` with only package.json + lock, no schema),
- generates for a fresh clone, CI, and the demo host's `npm ci`.

## How I tested
- Postinstall command verified both ways (generates with schema, silent exit 0 without).
- `bash scripts/verify.sh` green.
- Rebuilt the full production Docker image - the schema-less `npm ci` stages succeed with the no-op postinstall.