### PR TITLE
chore: drop the dead MAX_TRACK_POINTS import in the FIT decoder

### DIFF
--- a/lib/import/fit.ts
+++ b/lib/import/fit.ts
@@ -8,12 +8,7 @@ import {
   MAX_HR_MIN,
 } from '@/lib/cardio';
 import { IMPORT_CSV_MAX_BYTES } from '@/lib/import/csv';
-import {
-  cleanTrackPoint,
-  downsampleTrack,
-  MAX_TRACK_POINTS,
-  type TrackPoint,
-} from '@/lib/import/track';
+import { cleanTrackPoint, downsampleTrack, type TrackPoint } from '@/lib/import/track';
 
 // ============================================================
 // FIT activity file parser (issue #249) - pure, no DB


### PR DESCRIPTION
Fix-forward from the post-hoc review of #259 (GPX track capture). After refactoring the FIT decoder onto the shared `lib/import/track.ts`, `MAX_TRACK_POINTS` was imported but no longer referenced directly (`downsampleTrack` uses it internally) - an eslint unused-import warning. Removes it.

## How I tested
- `bash scripts/verify.sh` green; eslint clean on `lib/import/fit.ts`.