### PR TITLE
feat: render cardio activities properly in the history list

### DIFF
--- a/app/(app)/history/page.tsx
+++ b/app/(app)/history/page.tsx
@@ -7,6 +7,7 @@ import { EmptyState } from '@/components/ui/empty-state';
 import { Badge } from '@/components/ui/badge';
 import { applyBodyweight, totalVolume } from '@/lib/stats';
 import { formatWeight } from '@/lib/units';
+import { formatDistance, formatDuration } from '@/lib/cardio';
 import { HistoryFilters } from '@/components/history/history-filters';
 
 interface SearchParams {
@@ -60,7 +61,9 @@ export default async function HistoryPage(
             reps: true,
             isWarmup: true,
             durationSec: true,
-            exercise: { select: { usesBodyweight: true } },
+            distanceM: true,
+            avgHr: true,
+            exercise: { select: { usesBodyweight: true, name: true, category: true } },
           },
         },
       },
@@ -121,11 +124,26 @@ export default async function HistoryPage(
                 user?.bodyweight,
               );
               const volume = totalVolume(enrichedSets);
-              const workingSets = s.sets.filter((set) => !set.isWarmup).length;
+              const working = s.sets.filter((set) => !set.isWarmup);
+              const workingSets = working.length;
               const durationMin =
                 s.finishedAt && s.startedAt
                   ? Math.round((s.finishedAt.getTime() - s.startedAt.getTime()) / 60000)
                   : null;
+              // A cardio/imported activity (issue #133+): every working set is a
+              // CARDIO set. Render it as the activity (name, distance, duration,
+              // HR) instead of "Free session - 0 kg vol", which reads as empty.
+              const cardioSets = working.filter(
+                (set) => set.exercise.category === 'CARDIO' && set.durationSec != null,
+              );
+              const isCardio = workingSets > 0 && cardioSets.length === workingSets;
+              const cardioName = cardioSets[0]?.exercise.name ?? 'Cardio';
+              const cardioDistance = cardioSets.reduce((sum, set) => sum + (set.distanceM ?? 0), 0);
+              const cardioDurationSec = cardioSets.reduce(
+                (sum, set) => sum + (set.durationSec ?? 0),
+                0,
+              );
+              const cardioAvgHr = cardioSets.find((set) => set.avgHr != null)?.avgHr ?? null;
               return (
                 <li key={s.id}>
                   <Link href={`/history/${s.id}`} className="block">
@@ -143,20 +161,36 @@ export default async function HistoryPage(
                             </span>
                           </div>
                           <p className="mt-0.5 truncate text-base font-medium">
-                            {s.workout?.name ?? 'Free session'}
+                            {s.workout?.name ?? (isCardio ? cardioName : 'Free session')}
                           </p>
                           <div className="mt-1 flex flex-wrap gap-1.5 text-xs">
                             {s.program && (
                               <Badge variant="secondary">{s.program.name}</Badge>
                             )}
-                            <Badge variant="outline">
-                              {workingSets} set{workingSets > 1 ? 's' : ''}
-                            </Badge>
-                            <Badge variant="outline">
-                              {formatWeight(volume, unit, { decimals: 0 })} vol.
-                            </Badge>
-                            {durationMin != null && (
-                              <Badge variant="outline">{durationMin} min</Badge>
+                            {isCardio ? (
+                              <>
+                                {cardioDistance > 0 && (
+                                  <Badge variant="outline">{formatDistance(cardioDistance)}</Badge>
+                                )}
+                                <Badge variant="outline">
+                                  {formatDuration(cardioDurationSec || (durationMin ?? 0) * 60)}
+                                </Badge>
+                                {cardioAvgHr != null && (
+                                  <Badge variant="outline">{cardioAvgHr} bpm</Badge>
+                                )}
+                              </>
+                            ) : (
+                              <>
+                                <Badge variant="outline">
+                                  {workingSets} set{workingSets > 1 ? 's' : ''}
+                                </Badge>
+                                <Badge variant="outline">
+                                  {formatWeight(volume, unit, { decimals: 0 })} vol.
+                                </Badge>
+                                {durationMin != null && (
+                                  <Badge variant="outline">{durationMin} min</Badge>
+                                )}
+                              </>
                             )}
                           </div>
                         </div>

--- a/tests/e2e/gpx-import.spec.ts
+++ b/tests/e2e/gpx-import.spec.ts
@@ -62,6 +62,11 @@ test('a lifter can import a GPX activity as a cardio session', async ({ page }) 
 
   await page.goto('/history');
   await expect(page.getByText('May 21, 2026')).toBeVisible();
+  // The history list renders the imported activity as a cardio session (name +
+  // HR), not an empty "Free session - 0 kg vol" row.
+  await expect(page.getByText('Running')).toBeVisible();
+  await expect(page.getByText('155 bpm')).toBeVisible();
+  await expect(page.getByText('Free session')).toHaveCount(0);
 
   // The session detail shows the cardio set with its average heart rate, plus
   // the heart-rate-over-time chart built from the trackpoints (issue #259).


### PR DESCRIPTION
Reported on the live demo: the history list was full of empty-looking **"Free session - 1 set - 0 kg vol."** rows. Those are the cardio/imported sessions - they have no program, and the row showed a strength-style set-count + volume (0 for cardio), so they read as empty junk.

Now the row is **cardio-aware**: when every working set is a CARDIO set, it shows the **activity name** (Running / Cycling) with **distance, duration and average heart rate** instead of the meaningless set/volume. Strength sessions render exactly as before.

Before: `Free session · 1 set · 0 kg vol. · 35 min`
After: `Running · 4.86 km · 29:52 · 151 bpm`

- `tests/e2e/gpx-import.spec.ts` now asserts the history LIST shows the activity (name + `bpm`) and **no** `Free session` row.
- Verified visually against the seeded demo data; `bash scripts/verify.sh` passes.