### PR TITLE
test: cover the shared import track sanitizer (close a rotten gate)

### DIFF
--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -1777,3 +1777,35 @@ branching. Recovery identical: CI ran on the push (all green), post-hoc independ
 not the recovery, is the fix.
 
 **Deferred to human.** Nothing - #259 is now fully complete across all three import formats.
+
+---
+
+## 2026-06-30 (triage) - L9 gate spot-check + permissions re-audit: found and closed a rotten gate
+
+**Context.** Backlog empty, code-health current, product wedge complete - but three
+untrusted-input parsers (FIT binary, GPX/TCX XML) and a shared value sanitizer had landed
+since the last L9 pass (2026-06-15), so the right cycle was verifying those security gates
+are genuinely protective.
+
+**Gate spot-check (L9).** Two reverts, never pushed:
+- POSITIVE CONTROL: disabled the FIT CRC verify (lib/import/fit.ts) and re-ran fit.test.ts -
+  exactly the "rejects a CRC mismatch" hostile test FAILED. That gate is sound. Restored.
+- FOUND A ROTTEN GATE: weakened cleanTrackPoint's heart-rate bound (lib/import/track.ts,
+  accept ANY hr) and re-ran ALL 88 importer tests - every one still passed. The shared track
+  sanitizer (cleanTrackPoint + downsampleTrack), which every FIT/GPX/TCX import feeds and
+  whose output is stored on the cardio set AND rendered in the HR chart, had NO direct test:
+  its range checks (t in window, distance 0..1000km, hr 40..250, numbers-only) were entirely
+  uncovered. A regression weakening them would ship silently. Restored.
+
+**Fixed.** Added lib/import/track.test.ts (10 tests) covering cleanTrackPoint (drops
+out-of-window t, out-of-range/non-finite distance and hr, keeps edges, rounds, numbers-only)
+and downsampleTrack (null on empty, <=500 cap, even stride). Verified it CLOSES the gap:
+re-weakening the hr bound now fails the new test.
+
+**Permissions re-audit (L9).** .claude/settings.json deny list intact (rm -rf, git push
+--force/-f/--force-with-lease, git reset --hard, curl, wget). 37 allow entries, no sudo /
+network / broad-rm / scope creep - unchanged from 2026-06-15.
+
+**Filed.** No issues - the one gap was closeable in-cycle (a missing test, not a product
+decision). Code markers: none. The residual high npm advisory (serialize-javascript via the
+next-pwa workbox toolchain) stays human-deferred (a next-pwa major downgrade).

--- a/lib/import/track.test.ts
+++ b/lib/import/track.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { AVG_HR_MAX, AVG_HR_MIN, MAX_DISTANCE_M, MAX_DURATION_SEC } from '@/lib/cardio';
+import { cleanTrackPoint, downsampleTrack, MAX_TRACK_POINTS } from './track';
+
+// The shared sanitizer for imported activity tracks (FIT, GPX, TCX all feed it).
+// Its bounds are the gate between an untrusted file and what gets stored on the
+// cardio set and rendered in the heart-rate chart, so they are tested directly
+// here (not just indirectly through in-range importer fixtures).
+
+describe('cleanTrackPoint (issues #254/#259)', () => {
+  it('keeps a fully valid point, rounding t and hr and trimming distance to cm', () => {
+    expect(cleanTrackPoint(12.6, 1234.567, 150.4)).toEqual({ t: 13, d: 1234.57, hr: 150 });
+  });
+
+  it('keeps a time-only point (no distance, no heart rate)', () => {
+    expect(cleanTrackPoint(30, null, null)).toEqual({ t: 30 });
+    expect(cleanTrackPoint(30, undefined, undefined)).toEqual({ t: 30 });
+  });
+
+  it('drops the whole point when the time is invalid or out of window', () => {
+    expect(cleanTrackPoint(-1, 100, 150)).toBeNull(); // before the start
+    expect(cleanTrackPoint(MAX_DURATION_SEC + 1, 100, 150)).toBeNull(); // past 24h
+    expect(cleanTrackPoint(NaN, 100, 150)).toBeNull();
+    expect(cleanTrackPoint(Infinity, 100, 150)).toBeNull();
+  });
+
+  it('accepts t at the window edges', () => {
+    expect(cleanTrackPoint(0, null, null)).toEqual({ t: 0 });
+    expect(cleanTrackPoint(MAX_DURATION_SEC, null, null)).toEqual({ t: MAX_DURATION_SEC });
+  });
+
+  it('drops an out-of-range or non-finite distance but keeps the point', () => {
+    expect(cleanTrackPoint(10, -5, null)).toEqual({ t: 10 }); // negative distance dropped
+    expect(cleanTrackPoint(10, MAX_DISTANCE_M + 1, null)).toEqual({ t: 10 }); // > 1000 km dropped
+    expect(cleanTrackPoint(10, NaN, null)).toEqual({ t: 10 });
+    expect(cleanTrackPoint(10, Infinity, null)).toEqual({ t: 10 });
+    expect(cleanTrackPoint(10, 0, null)).toEqual({ t: 10, d: 0 }); // zero distance is valid
+  });
+
+  it('drops an out-of-range or non-finite heart rate but keeps the point', () => {
+    expect(cleanTrackPoint(10, null, AVG_HR_MIN - 1)).toEqual({ t: 10 }); // below 40 dropped
+    expect(cleanTrackPoint(10, null, AVG_HR_MAX + 1)).toEqual({ t: 10 }); // above 250 dropped
+    expect(cleanTrackPoint(10, null, 9999)).toEqual({ t: 10 }); // hostile value dropped
+    expect(cleanTrackPoint(10, null, NaN)).toEqual({ t: 10 });
+    expect(cleanTrackPoint(10, null, AVG_HR_MIN)).toEqual({ t: 10, hr: AVG_HR_MIN }); // edge kept
+    expect(cleanTrackPoint(10, null, AVG_HR_MAX)).toEqual({ t: 10, hr: AVG_HR_MAX }); // edge kept
+  });
+
+  it('only ever produces numeric fields (no strings reach the stored JSON)', () => {
+    const p = cleanTrackPoint(5, 10, 120)!;
+    for (const v of Object.values(p)) expect(typeof v).toBe('number');
+  });
+});
+
+describe('downsampleTrack', () => {
+  it('returns null for an empty list', () => {
+    expect(downsampleTrack([])).toBeNull();
+  });
+
+  it('returns the points unchanged when already under the cap', () => {
+    const pts = [
+      { t: 0, d: 0, hr: 140 },
+      { t: 1, d: 5, hr: 142 },
+    ];
+    expect(downsampleTrack(pts)).toEqual(pts);
+  });
+
+  it('caps a long track at MAX_TRACK_POINTS, evenly strided from the first point', () => {
+    const pts = Array.from({ length: 1700 }, (_, i) => ({ t: i, d: i * 2, hr: 150 }));
+    const out = downsampleTrack(pts)!;
+    expect(out.length).toBeGreaterThan(1);
+    expect(out.length).toBeLessThanOrEqual(MAX_TRACK_POINTS);
+    expect(out.length).toBeLessThan(pts.length);
+    expect(out[0]).toEqual({ t: 0, d: 0, hr: 150 });
+    // Evenly strided: the gap between kept points is constant.
+    const stride = out[1]!.t - out[0]!.t;
+    for (let i = 1; i < out.length; i++) {
+      expect(out[i]!.t - out[i - 1]!.t).toBe(stride);
+    }
+  });
+});


### PR DESCRIPTION
From an **L9 gate spot-check** (the recurring "are the gates rotten?" triage check), after three untrusted-input parsers landed.

**Found:** weakening `cleanTrackPoint`'s heart-rate bound left **all 88 importer tests green**. The shared track sanitizer (`lib/import/track.ts` - `cleanTrackPoint` + `downsampleTrack`) is fed by every FIT/GPX/TCX import and its output is stored on the cardio set and rendered in the HR chart, yet its range checks (t in window, distance 0-1000 km, HR 40-250, numbers-only) had **no direct test** - a regression would ship silently.

**Fixed:** `lib/import/track.test.ts` (10 tests) covering the sanitizer's bounds + the downsampler's cap/stride. Verified it closes the gap (re-weakening the HR bound now fails the new test).

Positive control in the same pass: disabling the FIT CRC verify correctly failed its hostile test (that gate is sound). Permissions re-audit: deny list intact, no scope creep. `bash scripts/verify.sh` passes.