### PR TITLE
feat: show aerobic decoupling (HR drift) on imported cardio sessions

### DIFF
--- a/app/(app)/history/[id]/page.tsx
+++ b/app/(app)/history/[id]/page.tsx
@@ -12,6 +12,7 @@ import { formatCardioSet, formatDistance, formatDuration, formatPace, formatSpee
 import { formatWeight } from '@/lib/units';
 import { DeleteSessionButton } from '@/components/history/delete-session-button';
 import { ActivityTrackChart } from '@/components/history/activity-track-chart';
+import { TrackDecoupling } from '@/components/history/track-decoupling';
 
 interface Params {
   params: Promise<{ id: string }>;
@@ -287,14 +288,16 @@ export default async function HistorySessionPage(props: Params) {
                         </table>
                       ) : null}
                       {isCardio &&
-                        entry.sets.map((s) =>
-                          Array.isArray(s.track) && s.track.length > 0 ? (
-                            <ActivityTrackChart
-                              key={`track-${s.id}`}
-                              track={s.track as { t: number; d?: number; hr?: number }[]}
-                            />
-                          ) : null,
-                        )}
+                        entry.sets.map((s) => {
+                          if (!Array.isArray(s.track) || s.track.length === 0) return null;
+                          const track = s.track as { t: number; d?: number; hr?: number }[];
+                          return (
+                            <div key={`track-${s.id}`}>
+                              <ActivityTrackChart track={track} />
+                              <TrackDecoupling track={track} />
+                            </div>
+                          );
+                        })}
                       {!isCardio && (
                       <table className="w-full text-sm">
                         <thead>

--- a/components/history/track-decoupling.test.tsx
+++ b/components/history/track-decoupling.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TrackDecoupling } from './track-decoupling';
+
+// The show/hide decision and the wording are the parts that matter: the
+// readout appears only when the track carries both cumulative distance and
+// heart rate (trackDecoupling returns a number), and the explainer says
+// "held steady" under the ~5% threshold and "faded" above it.
+
+describe('TrackDecoupling', () => {
+  const steady = [0, 100, 200, 300, 400].map((t) => ({ t, d: t * 3, hr: 150 }));
+
+  it('shows the percentage and the held-steady explainer for a steady track', () => {
+    render(<TrackDecoupling track={steady} />);
+    expect(screen.getByTestId('track-decoupling')).toBeInTheDocument();
+    expect(screen.getByText('Aerobic decoupling')).toBeInTheDocument();
+    expect(screen.getByText('0.0%')).toBeInTheDocument();
+    expect(screen.getByText(/held steady/)).toBeInTheDocument();
+  });
+
+  it('says the pace per heartbeat faded when decoupling exceeds the threshold', () => {
+    // Constant speed, HR jumping 140 -> 165 in the second half (~10%).
+    const hrs = [140, 140, 140, 165, 165];
+    const track = steady.map((p, i) => ({ ...p, hr: hrs[i]! }));
+    render(<TrackDecoupling track={track} />);
+    expect(screen.getByText(/faded/)).toBeInTheDocument();
+    expect(screen.queryByText(/held steady/)).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when the track has no heart rate', () => {
+    const { container } = render(
+      <TrackDecoupling track={[0, 100, 200, 300].map((t) => ({ t, d: t * 3 }))} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when the track has no distance', () => {
+    const { container } = render(
+      <TrackDecoupling track={[0, 100, 200, 300].map((t) => ({ t, hr: 150 }))} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing for an empty track', () => {
+    const { container } = render(<TrackDecoupling track={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/components/history/track-decoupling.tsx
+++ b/components/history/track-decoupling.tsx
@@ -1,0 +1,31 @@
+import { trackDecoupling } from '@/lib/cardio';
+import type { TrackPoint } from '@/lib/import/track';
+
+// Threshold (in percent) under which the pace-per-heartbeat efficiency is
+// considered to have held steady. ~5% is the commonly used cutoff for a
+// well-paced aerobic effort.
+const STEADY_THRESHOLD_PCT = 5;
+
+// Aerobic decoupling readout for an imported cardio set (issue #268): one
+// percentage plus a plain-language explainer, shown only when the stored
+// track carries both cumulative distance and heart rate (trackDecoupling
+// returns null otherwise, and this renders nothing).
+export function TrackDecoupling({ track }: { track: TrackPoint[] }) {
+  const decoupling = trackDecoupling(track);
+  if (decoupling == null) return null;
+
+  const held = decoupling <= STEADY_THRESHOLD_PCT;
+  return (
+    <div className="mt-3 text-xs" data-testid="track-decoupling">
+      <p className="font-medium text-muted-foreground">Aerobic decoupling</p>
+      <p className="mt-0.5">
+        <span className="text-sm font-semibold">{decoupling.toFixed(1)}%</span>
+        <span className="ml-2 text-muted-foreground">
+          Lower is better - your pace per heartbeat{' '}
+          {held ? 'held steady' : 'faded'} over the second half of this
+          activity.
+        </span>
+      </p>
+    </div>
+  );
+}

--- a/lib/cardio.test.ts
+++ b/lib/cardio.test.ts
@@ -11,6 +11,7 @@ import {
   parseDurationToSec,
   speedKmh,
   sumCardioWorkingSets,
+  trackDecoupling,
 } from './cardio';
 
 describe('isCardioSet', () => {
@@ -158,5 +159,100 @@ describe('sumCardioWorkingSets (issue #183)', () => {
     expect(
       sumCardioWorkingSets([{ durationSec: 300, distanceM: 800, isWarmup: true }]),
     ).toEqual({ durationSec: 0, distanceM: 0 });
+  });
+});
+
+describe('trackDecoupling (issue #268)', () => {
+  // 5 points at a constant 3 m/s: t 0..400 every 100 s, d = 3 * t.
+  const steadyDistance = [0, 100, 200, 300, 400].map((t) => ({ t, d: t * 3 }));
+
+  it('is ~0% for a steady track (same speed, same HR in both halves)', () => {
+    const track = steadyDistance.map((p) => ({ ...p, hr: 150 }));
+    expect(trackDecoupling(track)).toBeCloseTo(0, 5);
+  });
+
+  it('is positive when HR drifts up at constant speed', () => {
+    // First half at 140 bpm, second half rising to 154 bpm. With the boundary
+    // sample shared, avg HR is 140 vs 149.333 -> exactly 6.25% decoupling.
+    const hrs = [140, 140, 140, 154, 154];
+    const track = steadyDistance.map((p, i) => ({ ...p, hr: hrs[i]! }));
+    expect(trackDecoupling(track)).toBeCloseTo(6.25, 2);
+  });
+
+  it('is positive when the pace fades at constant HR', () => {
+    // 3 m/s for the first half, 2 m/s for the second -> (1 - 2/3) * 100.
+    const ds = [0, 300, 600, 800, 1000];
+    const track = ds.map((d, i) => ({ t: i * 100, d, hr: 150 }));
+    expect(trackDecoupling(track)).toBeCloseTo(33.333, 2);
+  });
+
+  it('is negative for a negative split (faster second half at the same HR)', () => {
+    // 2 m/s then 3 m/s -> (1 - 3/2) * 100 = -50%.
+    const ds = [0, 200, 400, 700, 1000];
+    const track = ds.map((d, i) => ({ t: i * 100, d, hr: 150 }));
+    expect(trackDecoupling(track)).toBeCloseTo(-50, 2);
+  });
+
+  it('splits at the time midpoint, not at the middle sample index', () => {
+    // Samples clustered in the first 30 s plus one late point: the time
+    // midpoint (t=200) puts the first four points in the first half. 3 m/s
+    // for 30 s then 1 m/s for 370 s at constant HR -> (1 - 1/3) * 100.
+    const track = [
+      { t: 0, d: 0, hr: 150 },
+      { t: 10, d: 30, hr: 150 },
+      { t: 20, d: 60, hr: 150 },
+      { t: 30, d: 90, hr: 150 },
+      { t: 400, d: 460, hr: 150 },
+    ];
+    expect(trackDecoupling(track)).toBeCloseTo(66.667, 2);
+  });
+
+  it('sorts by time, so an out-of-order track still computes', () => {
+    const track = steadyDistance.map((p) => ({ ...p, hr: 150 })).reverse();
+    expect(trackDecoupling(track)).toBeCloseTo(0, 5);
+  });
+
+  it('is null when the track lacks distance or heart rate', () => {
+    expect(trackDecoupling(steadyDistance)).toBeNull(); // no HR
+    expect(
+      trackDecoupling([0, 100, 200, 300, 400].map((t) => ({ t, hr: 150 }))),
+    ).toBeNull(); // no distance
+  });
+
+  it('is null with fewer than two usable samples per half', () => {
+    expect(trackDecoupling([])).toBeNull();
+    expect(
+      trackDecoupling([
+        { t: 0, d: 0, hr: 140 },
+        { t: 100, d: 300, hr: 145 },
+        { t: 200, d: 600, hr: 150 },
+      ]),
+    ).toBeNull();
+  });
+
+  it('ignores samples missing either field when counting usable points', () => {
+    // Only 3 of the 5 points carry both d and hr -> below the threshold.
+    const track = [
+      { t: 0, d: 0, hr: 140 },
+      { t: 100, d: 300 },
+      { t: 200, d: 600, hr: 150 },
+      { t: 300, hr: 155 },
+      { t: 400, d: 1200, hr: 160 },
+    ];
+    expect(trackDecoupling(track)).toBeNull();
+  });
+
+  it('is null for a degenerate track (no distance covered or no time elapsed)', () => {
+    expect(
+      trackDecoupling([0, 100, 200, 300, 400].map((t) => ({ t, d: 500, hr: 150 }))),
+    ).toBeNull(); // distance never advances
+    expect(
+      trackDecoupling([
+        { t: 0, d: 0, hr: 150 },
+        { t: 0, d: 100, hr: 150 },
+        { t: 0, d: 200, hr: 150 },
+        { t: 0, d: 300, hr: 150 },
+      ]),
+    ).toBeNull(); // all at the same instant
   });
 });

--- a/lib/cardio.ts
+++ b/lib/cardio.ts
@@ -1,4 +1,5 @@
 import type { WeightUnit } from '@/lib/prisma-client';
+import type { TrackPoint } from '@/lib/import/track';
 
 // ============================================================
 // Cardio sets (issue #133) - duration/distance helpers
@@ -165,4 +166,73 @@ export function formatSpeed(
     return `${+mph.toFixed(1)} mph`;
   }
   return `${+kmh.toFixed(1)} km/h`;
+}
+
+// ============================================================
+// Aerobic decoupling (issue #268) - HR drift over an imported track
+// ============================================================
+// How much the pace-per-heartbeat efficiency degrades between the first and
+// the second half of an activity (a.k.a. cardiac drift). Lower is better: a
+// well-developed aerobic base holds the same speed at the same heart rate for
+// the whole effort. Computed purely from the stored TrackPoint[] of an
+// imported cardio set - no schema or API change.
+
+// Below this many usable samples per half the split averages are too noisy to
+// mean anything, so the metric is hidden rather than shown wrong.
+export const MIN_DECOUPLING_POINTS_PER_HALF = 2;
+
+// Efficiency (speed per heartbeat) over one half of a track: distance covered
+// divided by elapsed time, divided by the mean heart rate of the half's
+// samples. Null when the half has no positive time or distance span.
+function halfEfficiency(points: TrackPoint[]): number | null {
+  const first = points[0]!;
+  const last = points[points.length - 1]!;
+  const dt = last.t - first.t;
+  const dd = (last.d as number) - (first.d as number);
+  if (dt <= 0 || dd <= 0) return null;
+  const avgHr = points.reduce((sum, p) => sum + (p.hr as number), 0) / points.length;
+  if (avgHr <= 0) return null;
+  return dd / dt / avgHr;
+}
+
+// Aerobic decoupling in percent from an imported activity track, or null when
+// the track cannot support it (no cumulative distance, no heart rate, too few
+// samples, or a degenerate time/distance span). Splits the track at its time
+// midpoint, computes efficiency = speed / avg HR for each half (the boundary
+// sample closes the first half and opens the second, so no segment is lost)
+// and returns (effFirst - effSecond) / effFirst * 100. Positive = the pace
+// per heartbeat faded; near zero or negative = it held.
+export function trackDecoupling(track: TrackPoint[]): number | null {
+  const points = track
+    .filter(
+      (p) =>
+        Number.isFinite(p.t) &&
+        typeof p.d === 'number' &&
+        Number.isFinite(p.d) &&
+        typeof p.hr === 'number' &&
+        Number.isFinite(p.hr),
+    )
+    .sort((a, b) => a.t - b.t);
+  if (points.length < MIN_DECOUPLING_POINTS_PER_HALF * 2) return null;
+
+  const tMid = (points[0]!.t + points[points.length - 1]!.t) / 2;
+  // Last index still inside the first half; it is shared as the boundary of
+  // both halves so the two spans cover the whole track.
+  let split = 0;
+  for (let i = 0; i < points.length; i++) {
+    if (points[i]!.t <= tMid) split = i;
+  }
+  const firstHalf = points.slice(0, split + 1);
+  const secondHalf = points.slice(split);
+  if (
+    firstHalf.length < MIN_DECOUPLING_POINTS_PER_HALF ||
+    secondHalf.length < MIN_DECOUPLING_POINTS_PER_HALF
+  ) {
+    return null;
+  }
+
+  const effFirst = halfEfficiency(firstHalf);
+  const effSecond = halfEfficiency(secondHalf);
+  if (effFirst == null || effSecond == null) return null;
+  return ((effFirst - effSecond) / effFirst) * 100;
 }


### PR DESCRIPTION
Adds the aerobic decoupling (cardiac drift) metric to the cardio session detail, computed purely from the already-stored imported activity track. Display-only: no schema, API, or LLM-contract change.

Closes #268

## What changed
- `lib/cardio.ts`: new pure helper `trackDecoupling(track)` - filters the track to samples carrying both cumulative distance and HR, splits at the time midpoint (boundary sample shared so no segment is lost), computes efficiency = speed / avg HR per half, returns `(effFirst - effSecond) / effFirst * 100`, or null on any degenerate input (missing distance/HR, fewer than 2 usable samples per half, zero time/distance span) so nothing misleading is ever shown. Type-only import of `TrackPoint`, so no runtime import cycle with `lib/import/track.ts`.
- `components/history/track-decoupling.tsx`: small server component rendering the percentage plus a one-line explainer ("lower is better - your pace per heartbeat held steady / faded"), hidden when the helper returns null.
- `app/(app)/history/[id]/page.tsx`: renders the readout under the existing HR-over-time chart for each imported cardio set with a track.

## Tests
- `lib/cardio.test.ts`: steady track (~0%), HR drift at constant speed (exactly 6.25%), pace fade at constant HR (33.3%), negative split (-50%), time-midpoint split pinned against a count-based split, out-of-order input, and all the null/hidden cases (no d, no hr, too few samples, degenerate spans, mixed samples).
- `components/history/track-decoupling.test.tsx`: shows percentage + held/faded wording, renders nothing without distance, HR, or points.

## How I tested
- `bash scripts/verify.sh` (prisma generate + lint + typecheck + unit + build): PASSED. Display-only change, so the fast gate applies per the charter.
- Targeted `vitest run` on the two touched test files: 38/38 passing.

## Review
Independent skeptic subagent review: verdict READY, zero blocking findings. Its test-coverage NIT (pin the time-based split with uneven timestamps) was addressed in this PR. Two cosmetic NITs deliberately left out of scope: no display cap on extreme percentages, and "held steady" wording for strong negative splits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)