### PR TITLE
feat: import training history from a GymCoach (native) CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,10 @@ on your own key - all self-hosted.
 
 - **Self-hosted** - your training lives in your own Postgres; the AI runs on your
   own key. No subscription, no rate-limited free tier.
-- **Import and export** - bring history in from a Strong or Hevy CSV (dry-run
-  preview, duplicate-safe, cardio included), and export everything back to CSV or
-  TCX anytime.
+- **Import and export** - bring history in from a Strong or Hevy CSV, or from
+  GymCoach's own history CSV (a spreadsheet with the same columns works too;
+  dry-run preview, duplicate-safe, cardio included), and export everything back
+  to CSV or TCX anytime.
 
 ## Stack
 

--- a/app/api/history/csv/route.ts
+++ b/app/api/history/csv/route.ts
@@ -5,8 +5,10 @@ import { csvEscape, HISTORY_CSV_HEADERS } from '@/lib/csv';
 import { effectiveWeight, estimate1RM, setVolume } from '@/lib/stats';
 
 // GET /api/history/csv?programId=...&month=YYYY-MM
-// Returns a CSV (UTF-8 + BOM for Excel) with one row per non-warmup set.
-// Same filters as the /history page.
+// Returns a CSV (UTF-8 + BOM for Excel) with one row per set (warmups
+// included, flagged by is_warmup). Same filters as the /history page.
+// The GymCoach CSV import (app/api/import/gymcoach/route.ts, issue #270) is
+// the symmetric inverse of this export.
 export async function GET(req: Request) {
   try {
     const userId = await requireApiUserId();

--- a/app/api/import/gymcoach/route.ts
+++ b/app/api/import/gymcoach/route.ts
@@ -1,0 +1,151 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { ApiError, handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
+import { rateLimit } from '@/lib/rate-limit';
+import { gymcoachImportInputSchema } from '@/lib/schemas/import';
+import { GYMCOACH_CSV_MAX_BYTES, parseGymcoachCsv } from '@/lib/import/gymcoach-csv';
+import {
+  buildStrongImportPlan,
+  executeStrongImport,
+  setDuplicateKey,
+} from '@/lib/import/strong-import';
+
+// How many per-line errors the response reports (the count is always exact).
+const MAX_REPORTED_ERRORS = 50;
+
+// POST /api/import/gymcoach: import a GymCoach native history CSV (issue
+// #270) - the symmetric inverse of GET /api/history/csv. Mirrors the Strong
+// and Hevy routes (both stay untouched) with the GymCoach parser in front of
+// the shared planner/executor. mode=preview parses and plans without writing
+// anything; mode=confirm performs the import inside one transaction. The file
+// content is untrusted: hard caps, Zod on every value (in the parser and on
+// the body), and no write outside the transaction.
+export async function POST(req: Request) {
+  try {
+    const userId = await requireApiUserId();
+
+    // Shared budget with the other import routes: one allowance per user.
+    const rl = rateLimit(`import:${userId}`, 10, 60_000);
+    if (!rl.ok) {
+      throw new ApiError(429, `Too many import requests. Retry in ${rl.retryAfterSec}s.`);
+    }
+
+    // Cheap early reject on a declared oversize. The header is advisory only
+    // (absent on chunked bodies, possibly malformed); the real control is the
+    // streamed byte cap inside parseJsonBody below.
+    const contentLength = Number(req.headers.get('content-length') ?? 0);
+    if (contentLength > GYMCOACH_CSV_MAX_BYTES * 1.5) {
+      throw new ApiError(413, 'File too large: the limit is 5 MB.');
+    }
+
+    const data = await parseJsonBody(req, gymcoachImportInputSchema, {
+      // 1.5x leaves room for the JSON envelope and string escaping around the
+      // 5 MB CSV payload itself (which the schema caps exactly).
+      maxBytes: GYMCOACH_CSV_MAX_BYTES * 1.5,
+    });
+    const parsed = parseGymcoachCsv(data.csv);
+    if (!parsed.ok) {
+      throw new ApiError(400, parsed.fatalError ?? 'Unreadable file.');
+    }
+
+    // Existing data on the imported days, for duplicate skipping and the
+    // "you already trained that day" preview warning.
+    const dateKeys = [...new Set(parsed.rows.map((r) => r.dateKey))].sort();
+    const existingSetKeys = new Set<string>();
+    const existingSessionDates = new Set<string>();
+    if (dateKeys.length > 0) {
+      const rangeStart = new Date(`${dateKeys[0]}T00:00:00.000Z`);
+      const rangeEnd = new Date(`${dateKeys[dateKeys.length - 1]}T00:00:00.000Z`);
+      rangeEnd.setUTCDate(rangeEnd.getUTCDate() + 1);
+      const sessions = await db.session.findMany({
+        where: { userId, startedAt: { gte: rangeStart, lt: rangeEnd } },
+        select: {
+          startedAt: true,
+          sets: {
+            select: {
+              setNumber: true,
+              weight: true,
+              reps: true,
+              durationSec: true,
+              distanceM: true,
+              exercise: { select: { name: true } },
+            },
+          },
+        },
+      });
+      for (const session of sessions) {
+        const dateKey = session.startedAt.toISOString().slice(0, 10);
+        existingSessionDates.add(dateKey);
+        for (const set of session.sets) {
+          existingSetKeys.add(
+            setDuplicateKey(
+              dateKey,
+              set.exercise.name,
+              set.setNumber,
+              set.weight,
+              set.reps,
+              set.durationSec,
+              set.distanceM,
+            ),
+          );
+        }
+      }
+    }
+
+    const exercises = await db.exercise.findMany({
+      where: { userId },
+      select: { name: true },
+    });
+    const plan = buildStrongImportPlan(
+      parsed.rows,
+      exercises.map((e) => e.name),
+      existingSetKeys,
+    );
+
+    const common = {
+      duplicatesSkipped: plan.duplicateCount,
+      // Every cardio row is representable here (duration_sec is explicit), so
+      // cardioSkipped is always 0; the field keeps the shared preview shape.
+      cardioSets: plan.cardioSetCount,
+      cardioSkipped: 0,
+      errorCount: parsed.errors.length,
+      errors: parsed.errors.slice(0, MAX_REPORTED_ERRORS),
+    };
+
+    if (data.mode === 'preview') {
+      return NextResponse.json({
+        mode: 'preview',
+        sessions: plan.sessions.length,
+        sets: plan.totalSets,
+        newExercises: plan.newExerciseNames,
+        existingSessionDates: [...existingSessionDates]
+          .filter((d) => dateKeys.includes(d))
+          .sort(),
+        ...common,
+      });
+    }
+
+    if (plan.totalSets === 0) {
+      throw new ApiError(400, 'Nothing to import: no valid, non-duplicate set found.');
+    }
+
+    // One transaction per import: a failure anywhere rolls back every row.
+    // A multi-year export creates hundreds of sessions in sequential writes,
+    // so the 5 s Prisma default timeout would abort exactly the imports this
+    // feature exists for.
+    const result = await db.$transaction(
+      async (tx) => executeStrongImport(tx, userId, plan, 'GymCoach CSV'),
+      { timeout: 60_000, maxWait: 5_000 },
+    );
+
+    return NextResponse.json({
+      mode: 'confirm',
+      createdSessions: result.createdSessions,
+      createdSets: result.createdSets,
+      createdExercises: result.createdExercises,
+      ...common,
+    });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/components/settings/import-section.tsx
+++ b/components/settings/import-section.tsx
@@ -93,16 +93,18 @@ interface FitBatchPreview {
   skipped: number;
 }
 
-type ImportFormat = 'STRONG' | 'HEVY' | 'TCX' | 'GPX' | 'FIT';
+type ImportFormat = 'STRONG' | 'HEVY' | 'GYMCOACH' | 'TCX' | 'GPX' | 'FIT';
 
 // Copy and endpoint per supported source app. Strong keeps its unit toggle
 // (its export follows the app's unit setting); Hevy always exports kg, so the
 // toggle is hidden for it. TCX (issue #152) and GPX (issue #204) are both
 // single-activity cardio files - they share the preview/confirm UI.
+// `source` names where the history comes from in the intro sentence.
 const FORMAT_META: Record<
   ImportFormat,
   {
     label: string;
+    source: string;
     endpoint: string;
     exportHint: string;
     hasUnitToggle: boolean;
@@ -112,6 +114,7 @@ const FORMAT_META: Record<
 > = {
   STRONG: {
     label: 'Strong',
+    source: 'the Strong app',
     endpoint: '/api/import/strong',
     exportHint: 'export it as CSV (Settings, then Export data)',
     hasUnitToggle: true,
@@ -120,14 +123,26 @@ const FORMAT_META: Record<
   },
   HEVY: {
     label: 'Hevy',
+    source: 'the Hevy app',
     endpoint: '/api/import/hevy',
     exportHint: 'export it as CSV (Settings, then Export & Import Data)',
     hasUnitToggle: false,
     accept: '.csv,text/csv',
     fileKind: 'CSV',
   },
+  GYMCOACH: {
+    label: 'GymCoach',
+    source: 'a GymCoach history CSV',
+    endpoint: '/api/import/gymcoach',
+    exportHint:
+      'use the CSV from the History page export, or any spreadsheet with the same columns (session_date, workout, exercise, set_number, external_load_kg, reps, ...)',
+    hasUnitToggle: false,
+    accept: '.csv,text/csv',
+    fileKind: 'CSV',
+  },
   TCX: {
     label: 'TCX file',
+    source: 'a TCX file',
     endpoint: '/api/import/tcx',
     exportHint:
       'export the activity as TCX from your watch platform (Garmin Connect, Polar Flow, ...) and it becomes one cardio session with duration, distance and heart rate',
@@ -137,6 +152,7 @@ const FORMAT_META: Record<
   },
   GPX: {
     label: 'GPX file',
+    source: 'a GPX file',
     endpoint: '/api/import/gpx',
     exportHint:
       'export the route as GPX from Strava, Komoot or Apple Fitness and it becomes one cardio session with duration, distance and heart rate',
@@ -146,6 +162,7 @@ const FORMAT_META: Record<
   },
   FIT: {
     label: 'FIT file',
+    source: 'a FIT file',
     endpoint: '/api/import/fit',
     exportHint:
       'export the activity as a FIT file from your Garmin (or other) watch and it becomes one cardio session with duration, distance and heart rate',
@@ -375,7 +392,7 @@ export function ImportSection() {
         <p className="text-xs text-muted-foreground">
           {isCardioActivity
             ? `Bring a cardio workout: ${meta.exportHint}. Preview it here, then confirm.`
-            : `Bring your training history from the ${meta.label} app: ${meta.exportHint}, preview it here, then confirm.`}
+            : `Bring your training history from ${meta.source}: ${meta.exportHint}, preview it here, then confirm.`}
         </p>
       </CardHeader>
       <CardContent className="flex flex-col gap-3">
@@ -392,6 +409,7 @@ export function ImportSection() {
               <SelectContent>
                 <SelectItem value="STRONG">Strong</SelectItem>
                 <SelectItem value="HEVY">Hevy</SelectItem>
+                <SelectItem value="GYMCOACH">GymCoach CSV</SelectItem>
                 <SelectItem value="TCX">TCX file</SelectItem>
                 <SelectItem value="GPX">GPX file</SelectItem>
                 <SelectItem value="FIT">FIT file</SelectItem>

--- a/lib/import/gymcoach-csv.test.ts
+++ b/lib/import/gymcoach-csv.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect } from 'vitest';
+import { csvEscape, HISTORY_CSV_HEADERS } from '@/lib/csv';
+import {
+  GYMCOACH_CSV_MAX_BYTES,
+  GYMCOACH_CSV_MAX_ROWS,
+  parseGymcoachCsv,
+  stripFormulaGuard,
+} from './gymcoach-csv';
+
+// Minimal header: only the required columns, in a shuffled order to prove the
+// mapping is name-based, plus workout for grouping.
+const MIN_HEADER = 'reps,external_load_kg,set_number,exercise,session_date,workout';
+
+function minRow(over: Partial<Record<string, string>> = {}): string {
+  const cells = {
+    reps: '8',
+    external_load_kg: '80',
+    set_number: '1',
+    exercise: 'Bench Press',
+    session_date: '2026-05-02',
+    workout: 'Push Day',
+    ...over,
+  };
+  return [
+    cells.reps,
+    cells.external_load_kg,
+    cells.set_number,
+    cells.exercise,
+    cells.session_date,
+    cells.workout,
+  ].join(',');
+}
+
+// Build a full export-shaped row (all HISTORY_CSV_HEADERS columns) the same
+// way app/api/history/csv/route.ts does: csvEscape on every cell.
+function exportRow(over: Partial<Record<(typeof HISTORY_CSV_HEADERS)[number], string>> = {}): string {
+  const defaults: Record<(typeof HISTORY_CSV_HEADERS)[number], string> = {
+    session_id: 'sess-1',
+    session_date: '2026-05-02',
+    session_started_at: '2026-05-02T09:13:00.000Z',
+    session_finished_at: '2026-05-02T10:05:00.000Z',
+    duration_min: '52',
+    program: 'PPL',
+    workout: 'Push Day',
+    exercise: 'Bench Press',
+    muscle_group: 'CHEST',
+    uses_bodyweight: 'false',
+    set_number: '1',
+    external_load_kg: '80',
+    effective_weight_kg: '80',
+    reps: '8',
+    rir: '2',
+    is_warmup: 'false',
+    is_drop_set: 'false',
+    volume_kg: '640',
+    estimated_1rm_kg: '101.28',
+    set_notes: 'felt strong',
+    duration_sec: '',
+    distance_m: '',
+    avg_hr: '',
+    max_hr: '',
+  };
+  const cells = { ...defaults, ...over };
+  return HISTORY_CSV_HEADERS.map((h) => csvEscape(cells[h])).join(',');
+}
+
+const EXPORT_HEADER = HISTORY_CSV_HEADERS.join(',');
+
+describe('parseGymcoachCsv - header handling', () => {
+  it('accepts the full export header (BOM included) and the minimal one', () => {
+    const full = parseGymcoachCsv('﻿' + [EXPORT_HEADER, exportRow()].join('\n'));
+    expect(full.ok).toBe(true);
+    expect(full.rows).toHaveLength(1);
+
+    const minimal = parseGymcoachCsv([MIN_HEADER, minRow()].join('\n'));
+    expect(minimal.ok).toBe(true);
+    expect(minimal.rows).toHaveLength(1);
+  });
+
+  it('rejects a header missing a required column', () => {
+    const res = parseGymcoachCsv('session_date,exercise,set_number,reps\n2026-05-02,Bench,1,8');
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toMatch(/unrecognized format/i);
+  });
+
+  it('rejects a Strong-format file (formats are not interchangeable)', () => {
+    const res = parseGymcoachCsv(
+      'Date,Workout Name,Exercise Name,Set Order,Weight,Reps\n2026-05-02,Push,Bench,1,80,8',
+    );
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toMatch(/unrecognized format/i);
+  });
+
+  it('rejects an empty file and enforces the hard caps', () => {
+    expect(parseGymcoachCsv('').ok).toBe(false);
+
+    const big = 'x'.repeat(GYMCOACH_CSV_MAX_BYTES + 1);
+    expect(parseGymcoachCsv(big).fatalError).toMatch(/too large/i);
+
+    const rows = Array.from({ length: GYMCOACH_CSV_MAX_ROWS + 1 }, () => minRow());
+    const res = parseGymcoachCsv([MIN_HEADER, ...rows].join('\n'));
+    expect(res.ok).toBe(false);
+    expect(res.fatalError).toMatch(/too many rows/i);
+  });
+});
+
+describe('parseGymcoachCsv - export round-trip', () => {
+  it('reads back what the history export writes (strength row)', () => {
+    const res = parseGymcoachCsv([EXPORT_HEADER, exportRow()].join('\n'));
+    expect(res.ok).toBe(true);
+    expect(res.errors).toEqual([]);
+    expect(res.rows[0]).toEqual({
+      dateKey: '2026-05-02',
+      workoutName: 'Push Day',
+      exerciseName: 'Bench Press',
+      setOrder: 1,
+      weightKg: 80,
+      reps: 8,
+      rir: 2,
+      notes: 'felt strong',
+      isWarmup: false,
+      isDropSet: false,
+      durationSec: null,
+      distanceM: null,
+      avgHr: null,
+      maxHr: null,
+      startedAtIso: '2026-05-02T09:13:00.000Z',
+      finishedAtIso: '2026-05-02T10:05:00.000Z',
+      sessionKey: 'id:sess-1',
+    });
+  });
+
+  it('reads back a cardio row with duration, distance and heart rate', () => {
+    const res = parseGymcoachCsv(
+      [
+        EXPORT_HEADER,
+        exportRow({
+          exercise: 'Running',
+          external_load_kg: '0',
+          reps: '1',
+          rir: '',
+          set_notes: '',
+          duration_sec: '1800',
+          distance_m: '5000',
+          avg_hr: '150',
+          max_hr: '172',
+        }),
+      ].join('\n'),
+    );
+    expect(res.errors).toEqual([]);
+    expect(res.rows[0]).toMatchObject({
+      exerciseName: 'Running',
+      weightKg: 0,
+      reps: 1,
+      durationSec: 1800,
+      distanceM: 5000,
+      avgHr: 150,
+      maxHr: 172,
+      rir: null,
+      notes: null,
+    });
+  });
+
+  it('un-escapes the formula-injection guard the export adds (true round-trip)', () => {
+    // csvEscape turns '=2+2' into "'=2+2"; importing the export must restore
+    // the raw stored value, not keep growing quote prefixes.
+    const res = parseGymcoachCsv(
+      [
+        EXPORT_HEADER,
+        exportRow({ exercise: '=2+2', workout: '+DDE', set_notes: '@cmd' }),
+      ].join('\n'),
+    );
+    expect(res.errors).toEqual([]);
+    expect(res.rows[0]).toMatchObject({
+      exerciseName: '=2+2',
+      workoutName: '+DDE',
+      notes: '@cmd',
+    });
+  });
+
+  it('keeps quoted fields with commas and newlines intact', () => {
+    const res = parseGymcoachCsv(
+      [EXPORT_HEADER, exportRow({ set_notes: 'line one\nwith, comma' })].join('\n'),
+    );
+    expect(res.errors).toEqual([]);
+    expect(res.rows[0]?.notes).toBe('line one\nwith, comma');
+  });
+});
+
+describe('stripFormulaGuard', () => {
+  it('strips the guard quote only when it hides a formula character', () => {
+    expect(stripFormulaGuard("'=SUM(A1)")).toBe('=SUM(A1)');
+    expect(stripFormulaGuard("'+1")).toBe('+1');
+    expect(stripFormulaGuard("'-1")).toBe('-1');
+    expect(stripFormulaGuard("'@cmd")).toBe('@cmd');
+    // A legitimate leading apostrophe stays.
+    expect(stripFormulaGuard("'til failure")).toBe("'til failure");
+    expect(stripFormulaGuard('plain')).toBe('plain');
+  });
+});
+
+describe('parseGymcoachCsv - lenient optional columns', () => {
+  it('works without session_id / times / flags: noon fallback and defaults', () => {
+    const res = parseGymcoachCsv([MIN_HEADER, minRow()].join('\n'));
+    expect(res.rows[0]).toMatchObject({
+      startedAtIso: null,
+      finishedAtIso: null,
+      isWarmup: false,
+      isDropSet: false,
+      rir: null,
+      notes: null,
+    });
+    expect(res.rows[0]).not.toHaveProperty('sessionKey');
+  });
+
+  it('defaults an empty workout cell to a generic name', () => {
+    const res = parseGymcoachCsv([MIN_HEADER, minRow({ workout: '' })].join('\n'));
+    expect(res.rows[0]?.workoutName).toBe('Workout');
+  });
+
+  it('reads a hand-edited zoneless timestamp as UTC, never server-local', () => {
+    const res = parseGymcoachCsv(
+      [
+        EXPORT_HEADER,
+        exportRow({
+          session_started_at: '2026-05-02 09:13',
+          session_finished_at: '2026-05-02T10:05:30',
+        }),
+      ].join('\n'),
+    );
+    expect(res.errors).toEqual([]);
+    expect(res.rows[0]?.startedAtIso).toBe('2026-05-02T09:13:00.000Z');
+    expect(res.rows[0]?.finishedAtIso).toBe('2026-05-02T10:05:30.000Z');
+  });
+
+  it('degrades a malformed timestamp to null instead of failing the row', () => {
+    const res = parseGymcoachCsv(
+      [EXPORT_HEADER, exportRow({ session_started_at: 'yesterday-ish' })].join('\n'),
+    );
+    expect(res.errors).toEqual([]);
+    expect(res.rows[0]?.startedAtIso).toBeNull();
+  });
+
+  it('allows reps 0 on a strength row (the native set schema allows it)', () => {
+    const res = parseGymcoachCsv([MIN_HEADER, minRow({ reps: '0' })].join('\n'));
+    expect(res.errors).toEqual([]);
+    expect(res.rows[0]?.reps).toBe(0);
+  });
+
+  it('parses warmup/dropset flags from the export booleans', () => {
+    const res = parseGymcoachCsv(
+      [EXPORT_HEADER, exportRow({ is_warmup: 'true', is_drop_set: 'TRUE' })].join('\n'),
+    );
+    expect(res.rows[0]).toMatchObject({ isWarmup: true, isDropSet: true });
+  });
+});
+
+describe('parseGymcoachCsv - hostile and malformed rows', () => {
+  it('collects per-line errors without failing the file', () => {
+    const res = parseGymcoachCsv(
+      [
+        MIN_HEADER,
+        minRow(),
+        minRow({ session_date: 'not-a-date' }),
+        minRow({ session_date: '2026-13-40' }),
+        minRow({ reps: 'DROP TABLE' }),
+        minRow({ reps: '101' }),
+        minRow({ external_load_kg: '-5' }),
+        minRow({ external_load_kg: '9001' }),
+        minRow({ set_number: '0' }),
+        minRow({ exercise: '' }),
+        minRow({ exercise: 'x'.repeat(121) }),
+      ].join('\n'),
+    );
+    expect(res.ok).toBe(true);
+    expect(res.rows).toHaveLength(1);
+    expect(res.errors).toHaveLength(9);
+    // 1-based file lines: header is line 1, the first bad row is line 3.
+    expect(res.errors.map((e) => e.line)).toEqual([3, 4, 5, 6, 7, 8, 9, 10, 11]);
+  });
+
+  it('rejects out-of-range rir and heart rate with per-line errors', () => {
+    const res = parseGymcoachCsv(
+      [
+        EXPORT_HEADER,
+        exportRow({ rir: '9' }),
+        exportRow({ duration_sec: '1800', avg_hr: '400', rir: '' }),
+        exportRow({ duration_sec: '0' }),
+        exportRow({ duration_sec: '1800', distance_m: '-10', rir: '' }),
+      ].join('\n'),
+    );
+    expect(res.rows).toHaveLength(0);
+    expect(res.errors).toHaveLength(4);
+  });
+
+  it('rejects cardio-only fields on a strength row instead of dropping them', () => {
+    const res = parseGymcoachCsv(
+      [
+        EXPORT_HEADER,
+        exportRow({ avg_hr: '150' }),
+        exportRow({ distance_m: '5000' }),
+      ].join('\n'),
+    );
+    expect(res.rows).toHaveLength(0);
+    expect(res.errors.map((e) => e.reason)).toEqual([
+      'avg_hr/max_hr require a cardio row (non-empty duration_sec).',
+      'distance_m requires a cardio row (non-empty duration_sec).',
+    ]);
+  });
+
+  it('neutralizes formula payloads only via the guard, never evaluates', () => {
+    // A hostile cell is just data: it round-trips as a string.
+    const res = parseGymcoachCsv(
+      [MIN_HEADER, minRow({ exercise: '=HYPERLINK(evil)' })].join('\n'),
+    );
+    expect(res.errors).toEqual([]);
+    expect(res.rows[0]?.exerciseName).toBe('=HYPERLINK(evil)');
+  });
+});

--- a/lib/import/gymcoach-csv.ts
+++ b/lib/import/gymcoach-csv.ts
@@ -1,0 +1,355 @@
+import { z } from 'zod';
+import {
+  AVG_HR_MAX,
+  AVG_HR_MIN,
+  MAX_DISTANCE_M,
+  MAX_DURATION_SEC,
+  MAX_HR_MAX,
+  MAX_HR_MIN,
+} from '@/lib/cardio';
+import {
+  asNumber,
+  headerKey,
+  IMPORT_CSV_MAX_BYTES,
+  IMPORT_CSV_MAX_ROWS,
+  readCsvRecords,
+  type CsvLineError,
+} from '@/lib/import/csv';
+import type { NormalizedImportRow } from '@/lib/import/strong-import';
+
+// ============================================================
+// GymCoach native CSV import parser (issue #270) - pure, no DB
+// ============================================================
+// The symmetric inverse of the history CSV export (lib/csv.ts +
+// app/api/history/csv/route.ts): the same column names in, normalized rows
+// out. A user can re-import GymCoach's own export, or bulk-load a spreadsheet
+// that uses the same columns. Mirrors lib/import/strong-csv.ts and
+// lib/import/hevy-csv.ts: the file content is UNTRUSTED user data - no eval,
+// the same hard size and row caps, every value Zod-validated before it leaves
+// this module. Bad lines become per-line errors; only an unrecognized header
+// or a blown cap is fatal.
+//
+// Column contract (HISTORY_CSV_HEADERS in lib/csv.ts):
+// - Required: session_date, exercise, set_number, external_load_kg, reps.
+// - Honored when present: session_id (keeps two same-day sessions separate),
+//   session_started_at / session_finished_at (real times), workout, rir,
+//   is_warmup, is_drop_set, set_notes, duration_sec, distance_m, avg_hr,
+//   max_hr.
+// - Ignored (derived on export, recomputed after import): duration_min,
+//   program, muscle_group, uses_bodyweight, effective_weight_kg, volume_kg,
+//   estimated_1rm_kg.
+
+export const GYMCOACH_CSV_MAX_BYTES = IMPORT_CSV_MAX_BYTES;
+export const GYMCOACH_CSV_MAX_ROWS = IMPORT_CSV_MAX_ROWS;
+
+// One normalized row: the shared NormalizedImportRow with the GymCoach
+// extras always present.
+export interface GymcoachCsvRow extends NormalizedImportRow {
+  isWarmup: boolean;
+  isDropSet: boolean;
+  rir: number | null;
+  notes: string | null;
+  avgHr: number | null;
+  maxHr: number | null;
+  startedAtIso: string | null;
+  finishedAtIso: string | null;
+}
+
+export interface GymcoachCsvParseResult {
+  // False when the file as a whole is unusable (bad header, cap exceeded).
+  ok: boolean;
+  fatalError: string | null;
+  rows: GymcoachCsvRow[];
+  errors: CsvLineError[];
+}
+
+// Bounds mirror lib/schemas/set.ts so imported sets satisfy the same contract
+// as manually logged ones. Unlike the Strong/Hevy parsers, reps 0 is allowed:
+// the native set schema allows it, so the export can contain it.
+const strengthSchema = z.object({
+  weightKg: z.number().min(0).max(500),
+  reps: z.number().int().min(0).max(100),
+});
+
+const cardioSchema = z.object({
+  weightKg: z.number().min(0).max(500),
+  reps: z.number().int().min(0).max(100),
+  durationSec: z.number().int().min(1).max(MAX_DURATION_SEC),
+  distanceM: z.number().min(0).max(MAX_DISTANCE_M).nullable(),
+  avgHr: z.number().int().min(AVG_HR_MIN).max(AVG_HR_MAX).nullable(),
+  maxHr: z.number().int().min(MAX_HR_MIN).max(MAX_HR_MAX).nullable(),
+});
+
+const commonSchema = z.object({
+  dateKey: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  workoutName: z.string().trim().min(1).max(200),
+  exerciseName: z.string().trim().min(1).max(120),
+  setOrder: z.number().int().min(1).max(50),
+  rir: z.number().int().min(0).max(5).nullable(),
+  notes: z.string().trim().max(500).nullable(),
+});
+
+interface HeaderMap {
+  sessionId: number | null;
+  sessionDate: number;
+  startedAt: number | null;
+  finishedAt: number | null;
+  workout: number | null;
+  exercise: number;
+  setNumber: number;
+  weight: number;
+  reps: number;
+  rir: number | null;
+  isWarmup: number | null;
+  isDropSet: number | null;
+  notes: number | null;
+  durationSec: number | null;
+  distanceM: number | null;
+  avgHr: number | null;
+  maxHr: number | null;
+}
+
+// Recognize the GymCoach export header (extra columns are fine, order does
+// not matter). The names are the HISTORY_CSV_HEADERS contract.
+function mapHeader(cells: string[]): HeaderMap | null {
+  const keys = cells.map(headerKey);
+  const find = (name: string) => {
+    const idx = keys.indexOf(name);
+    return idx === -1 ? null : idx;
+  };
+
+  const sessionDate = find('session_date');
+  const exercise = find('exercise');
+  const setNumber = find('set_number');
+  const weight = find('external_load_kg');
+  const reps = find('reps');
+  if (
+    sessionDate === null ||
+    exercise === null ||
+    setNumber === null ||
+    weight === null ||
+    reps === null
+  ) {
+    return null;
+  }
+  return {
+    sessionId: find('session_id'),
+    sessionDate,
+    startedAt: find('session_started_at'),
+    finishedAt: find('session_finished_at'),
+    workout: find('workout'),
+    exercise,
+    setNumber,
+    weight,
+    reps,
+    rir: find('rir'),
+    isWarmup: find('is_warmup'),
+    isDropSet: find('is_drop_set'),
+    notes: find('set_notes'),
+    durationSec: find('duration_sec'),
+    distanceM: find('distance_m'),
+    avgHr: find('avg_hr'),
+    maxHr: find('max_hr'),
+  };
+}
+
+// Inverse of the export's formula-injection neutralization (lib/csv.ts):
+// csvEscape prefixes a leading = + - @ tab or CR with a single quote so the
+// cell reads as literal text in a spreadsheet. Stripping that prefix here
+// makes export -> import a true round-trip; the raw value is stored, and the
+// next export neutralizes it again. Values that do not carry the marker are
+// untouched.
+export function stripFormulaGuard(value: string): string {
+  return /^'[=+\-@\t\r]/.test(value) ? value.slice(1) : value;
+}
+
+// 'YYYY-MM-DD' day key; a time suffix is tolerated. Returns null when the
+// cell is not a real calendar date.
+function toDateKey(cell: string): string | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})([ T].*)?$/.exec(cell.trim());
+  if (!m) return null;
+  const [, y, mo, d] = m;
+  const date = new Date(Date.UTC(Number(y), Number(mo) - 1, Number(d)));
+  if (
+    date.getUTCFullYear() !== Number(y) ||
+    date.getUTCMonth() !== Number(mo) - 1 ||
+    date.getUTCDate() !== Number(d)
+  ) {
+    return null;
+  }
+  return `${y}-${mo}-${d}`;
+}
+
+// The export writes full ISO instants (2026-05-02T09:13:00.000Z). Accept an
+// ISO-like date-time; anything else degrades to null (noon-UTC fallback),
+// like Hevy's optional end_time. A hand-edited zoneless value (no Z or
+// offset) is read as UTC - the same wall-clock-as-UTC convention as the Hevy
+// parser - never as server-local time.
+function toIso(cell: string | undefined): string | null {
+  let trimmed = (cell ?? '').trim();
+  if (!/^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}/.test(trimmed)) return null;
+  trimmed = trimmed.replace(' ', 'T');
+  if (!/(Z|[+-]\d{2}:?\d{2})$/i.test(trimmed)) trimmed += 'Z';
+  const date = new Date(trimmed);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+// The export writes 'true' / 'false'; hand-edited spreadsheets get a little
+// slack. Anything unrecognized reads as false.
+function toBool(cell: string | undefined): boolean {
+  const key = (cell ?? '').trim().toLowerCase();
+  return key === 'true' || key === '1' || key === 'yes';
+}
+
+// Empty/absent optional numeric cell reads as null; garbage as NaN so Zod
+// rejects it with a per-line error.
+function asOptionalNumber(cell: string | undefined): number | null {
+  if (cell === undefined || cell.trim() === '') return null;
+  return asNumber(cell);
+}
+
+const firstIssue = (error: z.ZodError): string => {
+  const issue = error.issues[0];
+  return issue ? `${issue.path.join('.')}: ${issue.message}` : 'Invalid row.';
+};
+
+// Parse a GymCoach history CSV. Weight is already kg (the export's storage
+// unit), so there is no unit toggle.
+export function parseGymcoachCsv(text: string): GymcoachCsvParseResult {
+  const fail = (fatalError: string): GymcoachCsvParseResult => ({
+    ok: false,
+    fatalError,
+    rows: [],
+    errors: [],
+  });
+
+  if (text.length > GYMCOACH_CSV_MAX_BYTES) {
+    return fail('File too large: the limit is 5 MB.');
+  }
+
+  // The export prepends a UTF-8 BOM for Excel; drop it before the header read.
+  const records = readCsvRecords(text.replace(/^﻿/, ''));
+  const header = records[0];
+  if (!header) return fail('Empty file.');
+  const map = mapHeader(header.fields);
+  if (!map) {
+    return fail(
+      'Unrecognized format: expected a GymCoach history CSV with the columns ' +
+        'session_date, exercise, set_number, external_load_kg, reps.',
+    );
+  }
+
+  const dataRecords = records.slice(1);
+  if (dataRecords.length > GYMCOACH_CSV_MAX_ROWS) {
+    return fail(
+      `Too many rows: ${dataRecords.length} (the limit is ${GYMCOACH_CSV_MAX_ROWS}). Split the export and import in parts.`,
+    );
+  }
+
+  const rows: GymcoachCsvRow[] = [];
+  const errors: CsvLineError[] = [];
+
+  for (const record of dataRecords) {
+    const get = (idx: number | null) =>
+      idx === null ? undefined : record.fields[idx];
+
+    const dateKey = toDateKey(get(map.sessionDate) ?? '');
+    if (!dateKey) {
+      errors.push({ line: record.line, reason: 'Invalid or missing session_date.' });
+      continue;
+    }
+
+    const notesRaw = stripFormulaGuard(get(map.notes) ?? '').trim();
+    const common = commonSchema.safeParse({
+      dateKey,
+      // An export of a free session has an empty workout cell; the honest
+      // grouping label mirrors the export's own granularity.
+      workoutName: stripFormulaGuard(get(map.workout) ?? '').trim() || 'Workout',
+      exerciseName: stripFormulaGuard(get(map.exercise) ?? '').trim(),
+      setOrder: asNumber(get(map.setNumber)),
+      rir: asOptionalNumber(get(map.rir)),
+      notes: notesRaw === '' ? null : notesRaw,
+    });
+    if (!common.success) {
+      errors.push({ line: record.line, reason: firstIssue(common.error) });
+      continue;
+    }
+
+    const durationSec = asOptionalNumber(get(map.durationSec));
+    const avgHr = asOptionalNumber(get(map.avgHr));
+    const maxHr = asOptionalNumber(get(map.maxHr));
+
+    const base = {
+      ...common.data,
+      isWarmup: toBool(get(map.isWarmup)),
+      isDropSet: toBool(get(map.isDropSet)),
+      startedAtIso: toIso(get(map.startedAt)),
+      finishedAtIso: toIso(get(map.finishedAt)),
+      // session_id keeps two same-day sessions with the same workout name
+      // apart; it is only a grouping key, never stored.
+      ...(get(map.sessionId)?.trim()
+        ? { sessionKey: `id:${get(map.sessionId)!.trim().slice(0, 100)}` }
+        : {}),
+    };
+
+    // A non-empty duration_sec marks a cardio set (the export writes it on
+    // cardio sets only); duration/distance/HR then follow the #133 bounds.
+    if (durationSec !== null) {
+      const repsCell = asOptionalNumber(get(map.reps));
+      const cardio = cardioSchema.safeParse({
+        weightKg: asNumber(get(map.weight)),
+        // Imported cardio sets are stored as reps 1 by convention; an
+        // explicit value in the file is validated and kept.
+        reps: repsCell === null ? 1 : repsCell,
+        durationSec,
+        distanceM: asOptionalNumber(get(map.distanceM)),
+        avgHr,
+        maxHr,
+      });
+      if (!cardio.success) {
+        errors.push({ line: record.line, reason: firstIssue(cardio.error) });
+        continue;
+      }
+      rows.push({ ...base, ...cardio.data });
+      continue;
+    }
+
+    // Strength row: duration/distance must stay empty, and heart rate is a
+    // cardio-only signal (lib/schemas/set.ts) - reject instead of silently
+    // dropping data.
+    if (asOptionalNumber(get(map.distanceM)) !== null) {
+      errors.push({
+        line: record.line,
+        reason: 'distance_m requires a cardio row (non-empty duration_sec).',
+      });
+      continue;
+    }
+    if (avgHr !== null || maxHr !== null) {
+      errors.push({
+        line: record.line,
+        reason: 'avg_hr/max_hr require a cardio row (non-empty duration_sec).',
+      });
+      continue;
+    }
+
+    const strength = strengthSchema.safeParse({
+      weightKg: asNumber(get(map.weight)),
+      reps: asNumber(get(map.reps)),
+    });
+    if (!strength.success) {
+      errors.push({ line: record.line, reason: firstIssue(strength.error) });
+      continue;
+    }
+
+    rows.push({
+      ...base,
+      ...strength.data,
+      durationSec: null,
+      distanceM: null,
+      avgHr: null,
+      maxHr: null,
+    });
+  }
+
+  return { ok: true, fatalError: null, rows, errors };
+}

--- a/lib/import/strong-import.test.ts
+++ b/lib/import/strong-import.test.ts
@@ -3,6 +3,7 @@ import {
   buildStrongImportPlan,
   sessionDateFromKey,
   setDuplicateKey,
+  type NormalizedImportRow,
 } from './strong-import';
 import type { StrongCsvRow } from './strong-csv';
 
@@ -160,5 +161,45 @@ describe('buildStrongImportPlan - cardio sets', () => {
     expect(setDuplicateKey('2026-05-02', 'Bench', 1, 80, 8, null, null)).toBe(
       '2026-05-02|bench|1|80|8',
     );
+  });
+});
+
+describe('buildStrongImportPlan - GymCoach extras (issue #270)', () => {
+  // Rows shaped like the GymCoach CSV parser emits: the shared normalized row
+  // with the issue #270 extras (sessionKey, rir, notes, heart rate).
+  function nrow(over: Partial<NormalizedImportRow> = {}): NormalizedImportRow {
+    return { ...row(), ...over };
+  }
+
+  it('keeps two same-day sessions with the same workout name apart via sessionKey', () => {
+    const plan = buildStrongImportPlan(
+      [nrow({ sessionKey: 'id:a' }), nrow({ sessionKey: 'id:b', setOrder: 2 })],
+      [],
+      new Set(),
+    );
+    expect(plan.sessions).toHaveLength(2);
+  });
+
+  it('falls back to the historical (date, workout name) grouping without a sessionKey', () => {
+    const plan = buildStrongImportPlan([nrow(), nrow({ setOrder: 2 })], [], new Set());
+    expect(plan.sessions).toHaveLength(1);
+  });
+
+  it('carries rir, notes and heart rate onto the planned sets', () => {
+    const plan = buildStrongImportPlan(
+      [
+        nrow({ rir: 2, notes: 'felt strong' }),
+        nrow({ setOrder: 2, durationSec: 1800, distanceM: 5000, avgHr: 150, maxHr: 172 }),
+        nrow({ setOrder: 3 }),
+      ],
+      [],
+      new Set(),
+    );
+    const sets = plan.sessions[0]!.sets;
+    expect(sets[0]).toMatchObject({ rir: 2, notes: 'felt strong' });
+    expect(sets[1]).toMatchObject({ avgHr: 150, maxHr: 172, durationSec: 1800 });
+    // Untouched Strong/Hevy-shaped rows plan without the extra keys.
+    expect(sets[2]).not.toHaveProperty('rir');
+    expect(sets[2]).not.toHaveProperty('notes');
   });
 });

--- a/lib/import/strong-import.ts
+++ b/lib/import/strong-import.ts
@@ -28,9 +28,19 @@ export interface NormalizedImportRow {
   // Absent/null on strength rows - their path is unchanged.
   durationSec?: number | null;
   distanceM?: number | null;
+  // Richer per-set data the GymCoach native CSV carries (issue #270). Absent
+  // for Strong/Hevy rows - their path is unchanged.
+  rir?: number | null;
+  notes?: string | null;
+  avgHr?: number | null;
+  maxHr?: number | null;
   // Real session times as ISO strings, when the source export has them.
   startedAtIso?: string | null;
   finishedAtIso?: string | null;
+  // Explicit session grouping key (issue #270): the GymCoach export carries a
+  // session_id, so two same-day sessions with the same workout name stay
+  // separate. Absent falls back to the historical (dateKey, workoutName) key.
+  sessionKey?: string;
 }
 
 export interface PlannedSet {
@@ -42,6 +52,10 @@ export interface PlannedSet {
   isDropSet?: boolean;
   durationSec?: number | null;
   distanceM?: number | null;
+  rir?: number | null;
+  notes?: string | null;
+  avgHr?: number | null;
+  maxHr?: number | null;
 }
 
 export interface PlannedSession {
@@ -129,7 +143,7 @@ export function buildStrongImportPlan(
       newAllCardioByLower.set(lower, false);
     }
 
-    const sessionKey = `${row.dateKey}|${row.workoutName}`;
+    const sessionKey = row.sessionKey ?? `${row.dateKey}|${row.workoutName}`;
     let session = sessionsByKey.get(sessionKey);
     if (!session) {
       session = { dateKey: row.dateKey, workoutName: row.workoutName, sets: [] };
@@ -143,6 +157,10 @@ export function buildStrongImportPlan(
       ...(row.isWarmup !== undefined && { isWarmup: row.isWarmup }),
       ...(row.isDropSet !== undefined && { isDropSet: row.isDropSet }),
       ...(isCardio && { durationSec: row.durationSec, distanceM: row.distanceM ?? null }),
+      ...(row.rir != null && { rir: row.rir }),
+      ...(row.notes != null && { notes: row.notes }),
+      ...(row.avgHr != null && { avgHr: row.avgHr }),
+      ...(row.maxHr != null && { maxHr: row.maxHr }),
     });
     totalSets++;
     if (isCardio) cardioSetCount++;
@@ -283,6 +301,10 @@ export async function executeStrongImport(
           isDropSet: s.isDropSet ?? false,
           durationSec: s.durationSec ?? null,
           distanceM: s.distanceM ?? null,
+          rir: s.rir ?? null,
+          notes: s.notes ?? null,
+          avgHr: s.avgHr ?? null,
+          maxHr: s.maxHr ?? null,
           completedAt: startedAt,
         };
       }),

--- a/lib/schemas/import.ts
+++ b/lib/schemas/import.ts
@@ -27,6 +27,15 @@ export const hevyImportInputSchema = z.object({
 
 export type HevyImportInput = z.infer<typeof hevyImportInputSchema>;
 
+// GymCoach native CSV import request (issue #270): the history CSV export fed
+// back in. Same cap and modes; no unit field - the export stores weight in kg.
+export const gymcoachImportInputSchema = z.object({
+  csv: z.string().min(1).max(STRONG_CSV_MAX_BYTES, 'File too large: the limit is 5 MB.'),
+  mode: z.enum(['preview', 'confirm']),
+});
+
+export type GymcoachImportInput = z.infer<typeof gymcoachImportInputSchema>;
+
 // TCX cardio import request (issue #152). The xml field carries the raw file
 // text (untrusted XML - the parser refuses DTDs/entities by construction and
 // the size cap is enforced here AND on the streamed body read); same

--- a/tests/e2e/gymcoach-import.spec.ts
+++ b/tests/e2e/gymcoach-import.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '@playwright/test';
+
+// GymCoach native CSV import (issue #270): switch the settings import section
+// to GymCoach, upload a history-export-shaped CSV, check the dry-run preview,
+// confirm, and find the imported session in the history. Mirrors
+// hevy-import.spec.ts, which is untouched.
+
+// One warmup + two working sets + one broken line. The history page counts
+// working sets only, so it shows "2 sets" after the confirm.
+const GYMCOACH_CSV = [
+  'session_id,session_date,session_started_at,session_finished_at,workout,exercise,set_number,external_load_kg,reps,rir,is_warmup,is_drop_set,set_notes,duration_sec,distance_m,avg_hr,max_hr',
+  's1,2026-05-02,2026-05-02T09:13:00.000Z,2026-05-02T10:05:00.000Z,Push Day,Bench Press,1,40,8,,true,false,,,,,',
+  's1,2026-05-02,2026-05-02T09:13:00.000Z,2026-05-02T10:05:00.000Z,Push Day,Bench Press,2,80,8,2,false,false,,,,,',
+  's1,2026-05-02,2026-05-02T09:13:00.000Z,2026-05-02T10:05:00.000Z,Push Day,Bench Press,3,80,7,1,false,false,,,,,',
+  's1,not-a-date,2026-05-02T09:13:00.000Z,2026-05-02T10:05:00.000Z,Push Day,Bench Press,4,80,6,,false,false,,,,,',
+].join('\n');
+
+test('a lifter can preview and confirm a GymCoach CSV import', async ({ page }) => {
+  // Sign up through the API (fresh user; the cookie lands in the context). A
+  // unique X-Forwarded-For keeps this spec in its own register rate-limit
+  // bucket - the suite's parallel UI signups use up the 5/min per-IP budget.
+  const registerRes = await page.request.post('/api/auth/register', {
+    headers: { 'x-forwarded-for': '10.111.0.6' },
+    data: {
+      displayName: 'GymCoach CSV E2E',
+      email: `e2e-gymcoach-csv-${Date.now()}@test.dev`,
+      password: 'supersecret',
+    },
+  });
+  expect(registerRes.ok()).toBeTruthy();
+
+  await page.goto('/settings');
+  await expect(page.getByText('Import from Strong')).toBeVisible();
+
+  // Switch the source to GymCoach CSV: the unit toggle (Strong-only) disappears.
+  await page.getByLabel('Source app').click();
+  await page.getByRole('option', { name: 'GymCoach CSV' }).click();
+  await expect(page.getByText('Import from GymCoach')).toBeVisible();
+  await expect(page.getByText('Strong weight unit')).not.toBeVisible();
+
+  // Upload the file: the dry-run preview appears, nothing imported yet.
+  await page
+    .locator('input[type="file"][accept=".csv,text/csv"]')
+    .setInputFiles({
+      name: 'gymcoach-history.csv',
+      mimeType: 'text/csv',
+      buffer: Buffer.from(GYMCOACH_CSV, 'utf-8'),
+    });
+
+  const preview = page.getByTestId('import-preview');
+  await expect(preview).toBeVisible();
+  await expect(preview).toContainText('1 session, 3 sets to import');
+  await expect(preview).toContainText('1 new exercise will be created: Bench Press');
+  await expect(preview).toContainText('Line 5');
+
+  // Confirm and find the imported session in the history with its real time.
+  await page.getByRole('button', { name: /confirm import/i }).click();
+  await expect(page.getByTestId('import-preview')).not.toBeVisible();
+
+  await page.goto('/history');
+  await expect(page.getByText('May 02, 2026')).toBeVisible();
+  await expect(page.getByText('2 sets')).toBeVisible();
+});

--- a/tests/integration/gymcoach-import-route.test.ts
+++ b/tests/integration/gymcoach-import-route.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { db } from '@/lib/db';
+import { getCurrentUserId } from '@/lib/auth';
+
+// GymCoach native CSV import (issue #270): the symmetric inverse of the
+// history CSV export. Mirrors hevy-import-route.test.ts, plus a true
+// export -> import round-trip through the real export route.
+
+vi.mock('@/lib/auth', () => ({ getCurrentUserId: vi.fn() }));
+const mockUserId = vi.mocked(getCurrentUserId);
+
+import { POST as postImport } from '@/app/api/import/gymcoach/route';
+import { GET as getCsv } from '@/app/api/history/csv/route';
+
+function actAs(userId: string) {
+  mockUserId.mockResolvedValue(userId);
+}
+
+function importReq(body: unknown): Request {
+  return new Request('http://test.local/api/import/gymcoach', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+// Minimal-but-realistic file: the required columns plus the extras the
+// importer honors. Two sessions (real times on the first), one warmup, rir,
+// notes and one cardio row with heart rate.
+const HEADER =
+  'session_id,session_date,session_started_at,session_finished_at,workout,exercise,set_number,external_load_kg,reps,rir,is_warmup,is_drop_set,set_notes,duration_sec,distance_m,avg_hr,max_hr';
+
+const CSV = [
+  HEADER,
+  's1,2026-05-02,2026-05-02T09:13:00.000Z,2026-05-02T10:05:00.000Z,Push Day,Bench Press,1,40,8,,true,false,,,,,',
+  's1,2026-05-02,2026-05-02T09:13:00.000Z,2026-05-02T10:05:00.000Z,Push Day,Bench Press,2,80,8,2,false,false,felt strong,,,,',
+  's1,2026-05-02,2026-05-02T09:13:00.000Z,2026-05-02T10:05:00.000Z,Push Day,Bench Press,3,60,10,0,false,true,,,,,',
+  's2,2026-05-03,,,Pull Day,Imported Row,1,70,10,,false,false,,,,,',
+  's3,2026-05-03,,,Pull Day,Running,1,0,1,,false,false,,1800,5000,150,172',
+].join('\n');
+
+async function seedUser(email = 'gymcoach-importer@test.dev') {
+  return db.user.create({ data: { email, passwordHash: 'x' } });
+}
+
+beforeEach(() => {
+  mockUserId.mockReset();
+});
+
+describe('POST /api/import/gymcoach (preview)', () => {
+  it('returns counts and per-line info without writing anything', async () => {
+    const user = await seedUser();
+    actAs(user.id);
+
+    const res = await postImport(importReq({ csv: CSV, mode: 'preview' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      mode: 'preview',
+      // s2 and s3 share the day and workout name but stay separate sessions.
+      sessions: 3,
+      sets: 5,
+      newExercises: ['Bench Press', 'Imported Row', 'Running'],
+      duplicatesSkipped: 0,
+      cardioSets: 1,
+      cardioSkipped: 0,
+      errorCount: 0,
+    });
+
+    expect(await db.session.count()).toBe(0);
+    expect(await db.set.count()).toBe(0);
+    expect(await db.exercise.count()).toBe(0);
+  });
+
+  it('rejects an unrecognized header with a clear message', async () => {
+    const user = await seedUser();
+    actAs(user.id);
+    const res = await postImport(importReq({ csv: 'foo,bar\n1,2', mode: 'preview' }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/unrecognized format/i);
+  });
+
+  it('rejects a Strong-format file (formats are not interchangeable)', async () => {
+    const user = await seedUser();
+    actAs(user.id);
+    const res = await postImport(
+      importReq({
+        csv: 'Date,Workout Name,Exercise Name,Set Order,Weight,Reps\n2026-05-02,Push,Bench,1,80,8',
+        mode: 'preview',
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/gymcoach history csv/i);
+  });
+
+  it('requires auth', async () => {
+    mockUserId.mockResolvedValue(null);
+    const res = await postImport(importReq({ csv: CSV, mode: 'preview' }));
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('POST /api/import/gymcoach (confirm)', () => {
+  it('creates sessions with real times and persists rir, notes, flags and HR', async () => {
+    const user = await seedUser();
+    actAs(user.id);
+
+    const res = await postImport(importReq({ csv: CSV, mode: 'confirm' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      mode: 'confirm',
+      createdSessions: 3,
+      createdSets: 5,
+      createdExercises: 3,
+      cardioSets: 1,
+    });
+
+    const sessions = await db.session.findMany({
+      where: { userId: user.id },
+      orderBy: { startedAt: 'asc' },
+      include: { sets: { orderBy: { setNumber: 'asc' } } },
+    });
+    expect(sessions).toHaveLength(3);
+    // Real export times on the first session, noon-UTC fallback on the rest.
+    expect(sessions[0]?.startedAt.toISOString()).toBe('2026-05-02T09:13:00.000Z');
+    expect(sessions[0]?.finishedAt?.toISOString()).toBe('2026-05-02T10:05:00.000Z');
+    expect(sessions[0]?.notes).toBe('Imported from GymCoach CSV - Push Day');
+    expect(sessions[1]?.startedAt.toISOString()).toBe('2026-05-03T12:00:00.000Z');
+
+    // Per-set extras persisted: warmup/dropset flags, rir (including 0), notes.
+    expect(
+      sessions[0]?.sets.map((s) => [s.isWarmup, s.isDropSet, s.rir, s.notes]),
+    ).toEqual([
+      [true, false, null, null],
+      [false, false, 2, 'felt strong'],
+      [false, true, 0, null],
+    ]);
+
+    // The cardio set carries duration, distance and both HR values.
+    const cardioSet = await db.set.findFirst({
+      where: { exercise: { name: 'Running' } },
+    });
+    expect(cardioSet).toMatchObject({
+      durationSec: 1800,
+      distanceM: 5000,
+      avgHr: 150,
+      maxHr: 172,
+      weight: 0,
+      reps: 1,
+    });
+
+    // Cardio-only imported exercises are created as CARDIO.
+    const created = await db.exercise.findMany({
+      where: { userId: user.id },
+      orderBy: { name: 'asc' },
+    });
+    expect(created.map((e) => e.category)).toEqual(['ISOLATION', 'ISOLATION', 'CARDIO']);
+  });
+
+  it('round-trips the real history CSV export back into equivalent sets', async () => {
+    // Seed a mixed session for the exporter, with a formula-looking exercise
+    // name so the neutralization guard is exercised end to end.
+    const exporter = await seedUser('gymcoach-exporter@test.dev');
+    const bench = await db.exercise.create({
+      data: {
+        userId: exporter.id,
+        name: '=Bench, "Press"',
+        muscleGroup: 'CHEST',
+        category: 'COMPOUND',
+      },
+    });
+    const running = await db.exercise.create({
+      data: { userId: exporter.id, name: 'Running', muscleGroup: 'OTHER', category: 'CARDIO' },
+    });
+    const session = await db.session.create({
+      data: {
+        userId: exporter.id,
+        startedAt: new Date('2026-06-01T10:00:00Z'),
+        finishedAt: new Date('2026-06-01T11:00:00Z'),
+      },
+    });
+    await db.set.create({
+      data: {
+        sessionId: session.id,
+        exerciseId: bench.id,
+        setNumber: 1,
+        weight: 100,
+        reps: 5,
+        rir: 1,
+        notes: 'top set',
+      },
+    });
+    await db.set.create({
+      data: {
+        sessionId: session.id,
+        exerciseId: running.id,
+        setNumber: 1,
+        weight: 0,
+        reps: 1,
+        durationSec: 1800,
+        distanceM: 5000,
+        avgHr: 152,
+        maxHr: 181,
+      },
+    });
+
+    actAs(exporter.id);
+    const csvRes = await getCsv(new Request('http://test.local/api/history/csv'));
+    expect(csvRes.status).toBe(200);
+    const csvText = await csvRes.text();
+
+    // Import the export into a fresh account: everything must come back.
+    const importer = await seedUser('gymcoach-reimporter@test.dev');
+    actAs(importer.id);
+    const res = await postImport(importReq({ csv: csvText, mode: 'confirm' }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      createdSessions: 1,
+      createdSets: 2,
+      createdExercises: 2,
+      errorCount: 0,
+    });
+
+    const imported = await db.session.findFirstOrThrow({
+      where: { userId: importer.id },
+      include: { sets: { include: { exercise: true } } },
+    });
+    expect(imported.startedAt.toISOString()).toBe('2026-06-01T10:00:00.000Z');
+    expect(imported.finishedAt?.toISOString()).toBe('2026-06-01T11:00:00.000Z');
+
+    const benchSet = imported.sets.find((s) => s.exercise.name === '=Bench, "Press"');
+    expect(benchSet).toMatchObject({ weight: 100, reps: 5, rir: 1, notes: 'top set' });
+    const runSet = imported.sets.find((s) => s.exercise.name === 'Running');
+    expect(runSet).toMatchObject({
+      durationSec: 1800,
+      distanceM: 5000,
+      avgHr: 152,
+      maxHr: 181,
+    });
+  });
+
+  it("never matches or touches another user's exercises", async () => {
+    const user = await seedUser();
+    const other = await seedUser('gymcoach-other@test.dev');
+    await db.exercise.create({
+      data: { userId: other.id, name: 'Bench Press', muscleGroup: 'CHEST', category: 'COMPOUND' },
+    });
+    actAs(user.id);
+
+    await postImport(importReq({ csv: CSV, mode: 'confirm' }));
+    expect(
+      await db.exercise.count({ where: { userId: user.id, name: 'Bench Press' } }),
+    ).toBe(1);
+    expect(await db.set.count({ where: { session: { userId: other.id } } })).toBe(0);
+  });
+
+  it('skips exact duplicates on re-import (idempotence)', async () => {
+    const user = await seedUser();
+    actAs(user.id);
+
+    await postImport(importReq({ csv: CSV, mode: 'confirm' }));
+    const res = await postImport(importReq({ csv: CSV, mode: 'confirm' }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/nothing to import/i);
+
+    expect(await db.session.count({ where: { userId: user.id } })).toBe(3);
+    expect(await db.set.count({ where: { session: { userId: user.id } } })).toBe(5);
+  });
+
+  it('rejects invalid input (Zod) and writes nothing', async () => {
+    const user = await seedUser();
+    actAs(user.id);
+    const res = await postImport(importReq({ csv: CSV, mode: 'apply' }));
+    expect(res.status).toBe(400);
+    expect(await db.session.count()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

A GymCoach-native CSV import - the symmetric inverse of the history CSV export (`GET /api/history/csv`): the same columns back in, through the hardened pipeline the Strong/Hevy imports already use.

- **Parser** `lib/import/gymcoach-csv.ts`: name-based mapping of the `HISTORY_CSV_HEADERS` contract (required: `session_date`, `exercise`, `set_number`, `external_load_kg`, `reps`; honored: session id/times, workout, rir, warmup/dropset flags, set notes, duration/distance, avg/max HR; derived columns ignored). BOM-tolerant, hard byte/row caps, per-line errors on hostile or malformed rows, and it un-escapes the export's formula-injection guard (`'=` -> `=`) so export -> import is a true round-trip; the next export re-neutralizes.
- **Shared planner/executor** (`lib/import/strong-import.ts`) extended additively: optional `sessionKey` grouping (the export's `session_id` keeps two same-day sessions with the same name apart) and `rir`/`notes`/`avgHr`/`maxHr` passthrough. Strong/Hevy paths are byte-identical (pinned by tests).
- **Route** `app/api/import/gymcoach/route.ts` mirrors the Hevy route: shared rate bucket, advisory content-length reject + streamed body cap, Zod body schema, dry-run `preview` (counts + per-line errors + already-trained-day warning) and transactional `confirm`, ownership-scoped exercise reuse/create.
- **Settings** exposes the new source (GymCoach CSV) in the import section; README updated.

Closes #270

## How I tested

- `bash scripts/verify.sh --full` - GREEN (prisma generate, lint, typecheck, unit, build, integration incl. the new route tests, and 16 E2E incl. the new `gymcoach-import.spec.ts`), against the ephemeral test Postgres on :5434.
- Tests added at every touched layer: 19 parser unit tests (round-trip with the real export shape, formula-injection guard inverse, hostile/malformed rows, caps), 3 planner unit tests (sessionKey grouping + extras passthrough + Strong/Hevy shape untouched), 8 route integration tests (preview writes nothing, a real export -> import round-trip through `GET /api/history/csv`, cross-user isolation, idempotent re-import, Zod rejects), 1 E2E (preview -> confirm -> history).
- Independent skeptic review (correctness + does-it-work + security lenses): READY, no blocking findings; two nits fixed (zoneless hand-edited timestamps now read as UTC like the Hevy parser; stale export-route comment corrected).

## Process note (for the maintainer log)

An intermediate commit of this work (a49e21f) briefly landed on `main` directly: this checkout is shared with a concurrent ship tick, and the working tree had been switched back to `main` under my feature work. It was remediated immediately without force-push by reverting on `main` (fe25d66) and re-applying the work here via cherry-pick (13fac65). `main` content is exactly b2221f5 again; this PR is the reviewed path for the feature.