### PR TITLE
docs: write up the decoupling + native-CSV-import batch (#278/#279) + lesson L15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Aerobic decoupling (HR drift) on an imported cardio session: the history
+  detail page now shows how much your pace-per-heartbeat efficiency faded
+  between the first and second half of a run or ride, with a plain-language
+  read ("held steady" under ~5 percent, "faded" above). Derived purely from
+  the stored activity track (cumulative distance + heart rate); shown only
+  when the track can support it, and it changes no schema or API.
+- Import your training history from a GymCoach-native CSV: the symmetric
+  inverse of the history CSV export brings the same columns back in through
+  the hardened import pipeline (streamed size/row caps, Zod on every value,
+  dry-run preview with per-line errors, exact-duplicate skipping,
+  transactional confirm, ownership-scoped exercises). It un-escapes the
+  export's formula-injection guard for a true round-trip, and the Strong and
+  Hevy import paths are unchanged (pinned byte-identical by tests).
 - Multi-user accounts: registration, profiles, per-user data isolation, and
   rate limiting.
 - Workout logging with sets, reps, RIR, warmups, and drop sets.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ on your own key - all self-hosted.
 - **Watch-file import, no cloud** - bring activities in as **TCX, GPX or Garmin
   FIT** (duration, distance, heart rate; no OAuth, no cloud account). FIT imports
   a whole batch at once, and every imported run or ride shows a
-  **heart-rate-over-time chart** on the session detail.
+  **heart-rate-over-time chart** plus its **aerobic decoupling** (how much your
+  pace per heartbeat drifted over the effort) on the session detail.
 
 ### AI coach (bring your own model)
 

--- a/docs/loops/06-orchestration.md
+++ b/docs/loops/06-orchestration.md
@@ -95,3 +95,24 @@ dead task explicitly (TaskStop) or confirm it is gone; then `git status` - commi
 survives in branches/PRs (resume from there), but unexpected working-tree changes are a
 stop-and-reground signal. The replacement tick's prompt should state what is already
 merged so it never redoes or fights prior work.
+
+## Concurrent ticks: one worktree each (lesson L15)
+
+A git checkout is single-writer state: `HEAD`, the index, and the branch pointer are shared
+mutable state. If two ticks run in the **same** working tree at once, they race - one tick's
+`git switch main` or commit can strand or mis-attribute the other's uncommitted work, and it
+can land directly on `main` even when both ticks are otherwise behaving. This actually
+happened on 2026-07-15: a ship tick switched to `main` while a dev tick had uncommitted work
+in the same tree, and an intermediate commit briefly hit `main` (hard-guardrail-1 breach;
+reverted forward, re-shipped as PR #279).
+
+- **Give each concurrently running dev/ship tick its own `git worktree`** (`git worktree
+  add ../wt-<task> <branch>`), so branch checkouts and commits in one tick never touch
+  another tick's tree. Worktrees do not share `node_modules` (lesson L4: `npm ci` +
+  `npm rebuild bcrypt` + `prisma migrate deploy` in a fresh worktree before the gate).
+- **Until worktree isolation is in place, serialize same-checkout ticks** - never overlap
+  two ticks in one tree. This is stricter than the same-file serialization of step 4: any
+  two ticks sharing a tree must not overlap, related or not.
+- **If a commit still lands on `main`, revert forward** (a revert commit restoring `main`'s
+  content), never `git push --force` shared history (it is denied anyway), then re-ship the
+  work through a proper PR.

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -1809,3 +1809,70 @@ network / broad-rm / scope creep - unchanged from 2026-06-15.
 **Filed.** No issues - the one gap was closeable in-cycle (a missing test, not a product
 decision). Code markers: none. The residual high npm advisory (serialize-javascript via the
 next-pwa workbox toolchain) stays human-deferred (a next-pwa major downgrade).
+
+---
+
+## 2026-07-15 - Batch: aerobic decoupling (#278/#268) + GymCoach-native CSV import (#279/#270) - and a shared-worktree main breach
+
+**Context.** Two product ideas from the prior deep-research ideate batch were ready to
+implement: #268 (an aerobic-decoupling readout on imported cardio) and #270 (the symmetric
+inverse of the history CSV export - a GymCoach-native CSV import). Both are clear product
+pluses on the established cardio/import wedge, so the loop implemented and shipped them.
+
+**Decided / shipped.**
+- **#278 (merge b2221f5, closes #268) - aerobic decoupling.** New `trackDecoupling()` in
+  `lib/cardio.ts` splits an imported activity track at its time midpoint and returns
+  `(effFirst - effSecond) / effFirst * 100` where efficiency = speed / mean HR per half;
+  null when the track cannot support it (no cumulative distance, no HR, too few samples, or
+  a degenerate span). A `TrackDecoupling` server component renders one percentage plus a
+  plain-language read (held steady <= ~5 percent, else faded), wired into the history detail
+  page. Display-only, no schema or API change. 23 unit + 5 component tests; fast gate + green
+  CI; independent Opus skeptic READY pre-push and a clean pre-merge review.
+- **#279 (merge 5f92ffb, closes #270) - GymCoach-native CSV import.** New
+  `lib/import/gymcoach-csv.ts` parser for the `HISTORY_CSV_HEADERS` contract: BOM-tolerant,
+  5 MB / 50k-row caps, per-line errors on hostile rows, and it un-escapes the export's
+  formula-injection guard for a true round-trip (the inverse of the export sanitizer). The
+  shared import planner/executor was extended additively (sessionKey grouping so same-day
+  sessions stay apart, plus rir/notes/avgHr/maxHr passthrough); the Strong and Hevy paths
+  stay byte-identical, pinned by tests. New `app/api/import/gymcoach/route.ts` mirrors the
+  Hevy route (Zod, rate bucket, streamed body cap, dry-run preview, ownership-scoped), and
+  the Settings import section gained the source. Tests at every layer (parser unit incl.
+  formula injection + hostile rows, planner unit, route integration incl. a real
+  export -> import round-trip, and an E2E). Full local gate (`verify.sh --full`) + green CI;
+  two-lens (correctness + security) reviews READY.
+
+**INCIDENT - hard guardrail 1 breach (committed to `main` directly), remediated.** During
+this run two concurrent ticks shared the single working tree. The #278 ship tick switched
+the checkout back to `main` while the #270 dev tick still had uncommitted work; the
+intermediate commit `a49e21f` ("feat: import training history from a GymCoach (native) CSV")
+briefly landed on `main` directly - bypassing the PR + pre-merge-review gate. This is a
+breach of hard guardrail 1 ("never commit to `main` directly"), and a different root cause
+than the L14 "branch before editing" slips: here two writers shared one checkout, not one
+writer forgetting to branch. Remediated immediately WITHOUT force-push (force-push to shared
+`main` is itself denied): a revert commit `fe25d66` was pushed so `main`'s content was
+restored exactly to `b2221f5` (CI green), and the work was re-applied on the feature branch
+via cherry-pick and shipped the right way through PR #279 (merge `5f92ffb`). Net effect on
+`main`: `b2221f5` -> `a49e21f` (breach) -> `fe25d66` (revert, content == `b2221f5`) ->
+`5f92ffb` (proper PR merge). Root cause: **concurrent ticks must not share one working
+tree.** Codified as lesson L15 (concurrent stage ticks need isolated git worktrees; until
+the orchestrator spawns dev ticks with worktree isolation, same-checkout ticks must be
+strictly serialized).
+
+**Untrusted external input (trust gate held).** A 5-PR fork stack #272-#276 (author
+`SHAREN`, a non-collaborator, 124-347 files each) was identified and scanned for injection
+patterns (none found). Per the trust gate it was NOT auto-merged; a policy comment was left
+on #272 and the stack awaits human maintainer review. No content from it was implemented or
+laundered into a loop-authored issue.
+
+**Challenged.** #278: independent Opus skeptic READY pre-push + a clean independent pre-merge
+review. #279: two independent lenses (correctness + security) both READY, over an
+untrusted-input parser and a new import route.
+
+**One metric.** Accepted-change rate this batch: 2 merged / 0 abandoned (the intermediate
+direct-to-main commit was reverted and re-shipped as #279, not a separate accepted change).
+Implementing-tick token spend: not recorded this run (dev ticks were Fable per the
+model-routing directive).
+
+**Deferred to human.** The #272-#276 fork stack (human vetting + re-file if any idea is
+worth adopting). Nothing else.
+

--- a/docs/loops/lessons.md
+++ b/docs/loops/lessons.md
@@ -182,3 +182,26 @@ Format per entry: trigger/evidence, the lesson (actionable), and **Status** = `g
 - **Trigger:** twice now (#259 GPX-track on 2026-06-23, and the TCX-track work on 2026-06-30) I committed and pushed a feature DIRECTLY to `main`. Both times the cause was identical: a prior step ended with `git switch main` (to sync / merge a previous PR), then the next task's edits started without a `git switch -c` - so the work landed on `main`, bypassing the PR + pre-merge review gate (a CLAUDE.md rule).
 - **Lesson:** the dangerous moment is the START of a new unit of work that follows a `main` checkout. Make branching the FIRST action of any task that will edit files - `git switch -c <type>/<slug>` before the first Edit/Write, not after. Recovery when it happens anyway: CI runs on push to `main` (so the change is still gated), but run the independent review POST-HOC and fix any finding forward via a real PR; never force-push to "undo" shared `main`. Both slips ended green + reviewed SHIP, but a gate-skip is exactly what the charter forbids - the fix is the habit, not the recovery.
 - **Status:** standing rule. If a turn begins on `main` and will write code, branch first.
+
+### L15 - Concurrent ticks must not share one working tree: isolate with git worktrees, or serialize
+- **Trigger:** 2026-07-15 batch. Two ticks ran against the SAME checkout at once: the #278
+  ship tick did `git switch main` (to sync the merged PR) while the #270 dev tick still had
+  uncommitted work in that same tree. The switch + a stray commit put an intermediate commit
+  (`a49e21f`) directly on `main` - a breach of hard guardrail 1 (never commit to `main`).
+  This is a DIFFERENT cause than L14: L14 is one writer forgetting to branch; L15 is two
+  writers sharing one tree, where even a correctly-branched tick is unsafe because another
+  tick can move `HEAD`/`main` and capture its uncommitted work. Remediated without
+  force-push: revert `fe25d66` restored `main` to `b2221f5` exactly (CI green), work
+  cherry-picked onto a feature branch and shipped as PR #279.
+- **Lesson:** a git checkout is single-writer state. Two ticks in one working tree race on
+  `HEAD`, the index, and the branch pointer - one tick's `git switch`/commit can strand or
+  mis-attribute the other's work onto `main`. The orchestrator must give each concurrently
+  running dev/ship tick its OWN git worktree (`git worktree add`), so branch checkouts and
+  commits never collide; until worktree isolation is in place, same-checkout ticks must be
+  strictly SERIALIZED (never overlap two ticks in one tree). Extends L7/L11 ("one writer per
+  checkout") from same-file and zombie-writer cases to the general concurrent-tick case, and
+  makes the control structural (separate trees) rather than behavioral (remember to branch).
+- **Status:** graduated -> `06-orchestration.md` ("Concurrent ticks: one worktree each"):
+  concurrent dev/ship ticks get isolated `git worktree`s; without isolation, serialize
+  same-checkout ticks. Recovery when a commit still lands on `main`: revert forward (never
+  force-push shared history), then re-ship via a proper PR.

--- a/docs/loops/review-digest.md
+++ b/docs/loops/review-digest.md
@@ -263,3 +263,40 @@ The thrice-flagged local-vs-UTC week-helper skew was fixed for all consumers in 
 **Skim:** #156 (display-only card), #163 (UTC getters, 2-line change, suite verified
 under TZ=America/New_York for the first time), this write-up (demo seed gains a superset
 pairing; all four clips re-recorded at the staleness cap).
+
+---
+
+## 2026-07-15 - batch #278/#279: aerobic decoupling + GymCoach-native CSV import
+
+Merged: #278 (aerobic-decoupling readout on imported cardio, display-only), #279
+(GymCoach-native CSV history import through the shared hardened import pipeline). One
+hard-guardrail-1 breach this batch (an intermediate commit hit `main` directly from a
+shared working tree; reverted forward and re-shipped as #279 - see the autonomy-log entry
+and lesson L15).
+
+**Read first, in order:**
+
+1. **#279 - the new import path and the shared-planner change.** `gh pr diff 279`. Highest
+   risk x impact: an untrusted-input parser (`lib/import/gymcoach-csv.ts`) plus a new
+   ownership-scoped API route (`app/api/import/gymcoach/route.ts`) plus an ADDITIVE change
+   to the shared planner/executor that also feeds the Strong and Hevy imports
+   (`lib/import/strong-import.ts`). Read for two properties: (a) the Strong/Hevy paths stay
+   byte-identical (pinned by the new `strong-import.test.ts` cases), and (b) the parser
+   un-escapes the export's formula-injection guard only for the round-trip and does not
+   re-introduce an injection sink. Security lens already READY; this is the diff to
+   understand fully.
+2. **#278 - the decoupling math.** `gh pr diff 278`. `trackDecoupling()` in `lib/cardio.ts`:
+   midpoint split, per-half efficiency = speed / mean HR, null-guards for degenerate tracks.
+   Display-only (a server component on the history detail page), no schema/API change, so
+   lower risk - but worth a skim to confirm the null-when-unsupportable behavior and that no
+   lifting metric is touched.
+
+**Skim:** this write-up (CHANGELOG + README decoupling bullet, lesson L15, the
+06-orchestration "one worktree each" rule). The #272-#276 fork stack is untrusted and NOT
+merged - do not review it as loop work; it awaits human vetting.
+
+**Media note:** the history detail page gained the decoupling readout, but it is not in the
+captured screenshot set (home/progress/generator/catalog + the 4 flow GIFs), so no shot is
+due for it. The recorded GIFs (dated 2026-06-12) now lag several feature batches; none of
+the new cardio/import work is a clip scenario, so this is noted as lag, not a blocker for a
+docs tick - a periodic re-record is due soon.


### PR DESCRIPTION
Write-up tick for the 2026-07-15 merged batch. Docs and media only; no product code.

## Documents what shipped
- **#278** (merge b2221f5, closes #268) - aerobic decoupling (HR drift) readout on imported cardio sessions (`lib/cardio.ts` `trackDecoupling()` + `TrackDecoupling` component on the history detail page; display-only, no schema/API change).
- **#279** (merge 5f92ffb, closes #270) - GymCoach-native CSV history import (`lib/import/gymcoach-csv.ts` + `app/api/import/gymcoach/route.ts`), the symmetric inverse of the history CSV export, through the shared hardened import pipeline; Strong/Hevy paths pinned byte-identical.

## Changes in this PR
- **CHANGELOG.md** - two Unreleased/Added entries (decoupling, native CSV import).
- **README.md** - the watch-file import feature bullet now names the aerobic-decoupling metric (the CSV-import bullet already shipped in #279).
- **docs/loops/autonomy-log.md** - batch entry, including the honestly-recorded **hard-guardrail-1 breach** (two concurrent ticks shared one working tree; an intermediate commit `a49e21f` briefly hit `main` directly) and its remediation (revert-forward `fe25d66` restoring `main` to `b2221f5`, work re-shipped as PR #279 - no force-push), plus the untrusted `#272-#276` fork stack left for human vetting.
- **docs/loops/lessons.md** - new **L15** (concurrent ticks must not share one working tree), graduated into...
- **docs/loops/06-orchestration.md** - new "Concurrent ticks: one worktree each" rule.
- **docs/loops/review-digest.md** - prioritized comprehension digest for the batch.

## Verification
- `bash scripts/verify.sh` green (docs still go through the gate).
- Every claim checked against the merged diffs.
- English only, regular hyphens (no em/en dashes) in the added content.

Do not merge - the orchestrator ships this as the final merge of the run.