### PR TITLE
feat: progress photos alongside body metrics (local storage, no cloud)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,3 +54,5 @@ OPENROUTER_APP_URL=http://localhost:3030
 # --- App ---
 NEXTAUTH_URL=http://localhost:3030
 NODE_ENV=development
+# Local dir for user uploads (progress-photo files); gitignored, back it up.
+UPLOADS_DIR=./uploads

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ playwright/.cache/
 # Media: intermediate recordings (the committed GIFs/MP4s live in docs/)
 docs/media/raw/
 
+# User uploads (progress photos): local files, never committed
+/uploads/
+
 # Turbo / Vercel
 .turbo/
 .vercel/

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,11 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/prisma ./prisma
 COPY --from=builder --chown=nextjs:nodejs /app/prisma.config.ts ./prisma.config.ts
 
+# Uploads dir (progress photos, issue #269): pre-created and owned by the app
+# user so a named volume mounted here inherits writable ownership.
+RUN mkdir -p /app/uploads && chown nextjs:nodejs /app/uploads
+ENV UPLOADS_DIR=/app/uploads
+
 USER nextjs
 EXPOSE 3000
 ENV PORT=3000

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ on your own key - all self-hosted.
   10% until it expires.
 - **Goals and body comp** - per-exercise goals (weight x reps) with a progress
   bar, bodyweight tracking, and body measurements - each with a trend.
+- **Progress photos** - upload photos alongside your body metrics and compare
+  any two side by side. Stored locally on your server, visible only to you.
 - **Home dashboard** - a coach-insight card surfaces the single most important
   signal right now (due deload, stalled lift, fresh PR, or your weekly streak),
   with no AI call.
@@ -226,6 +228,14 @@ The demo account credentials come from `.env` (`USER_EMAIL` and `USER_PASSWORD`)
 ## Configuration
 
 All configuration is done through environment variables. See `.env.example` for the full list (database, JWT secret, demo account, and the AI provider keys).
+
+### Progress photos / uploads
+
+Progress photos are stored as plain files on the server's local filesystem,
+under `UPLOADS_DIR` (default `./uploads`, gitignored) - no cloud, no third
+party. Images are served only through an ownership-scoped API route, never as
+a public static path. If you self-host with Docker, mount that directory as a
+volume and include it in your backups alongside the database.
 
 ## Testing
 

--- a/app/(app)/progress/page.tsx
+++ b/app/(app)/progress/page.tsx
@@ -32,6 +32,7 @@ import { ConsistencyCard } from '@/components/progress/consistency-card';
 import { DeloadBanner } from '@/components/progress/deload-banner';
 import { BodyweightCard } from '@/components/progress/bodyweight-card';
 import { MeasurementsCard } from '@/components/progress/measurements-card';
+import { PhotosCard } from '@/components/progress/photos-card';
 import { ConditioningCard } from '@/components/progress/conditioning-card';
 import { RecordsCard } from '@/components/progress/records-card';
 
@@ -361,6 +362,16 @@ export default async function ProgressPage(
     select: { id: true, site: true, valueCm: true, measuredAt: true },
   });
 
+  // Progress photos (issue #269): ALL of the user's photos (not just the
+  // 12-week window - a before/after compare wants the full timeline), newest
+  // first. Only metadata crosses the boundary; the bytes stay behind the
+  // ownership-scoped image route.
+  const progressPhotos = await db.progressPhoto.findMany({
+    where: { userId: auth.userId },
+    orderBy: { takenAt: 'desc' },
+    select: { id: true, takenAt: true, note: true },
+  });
+
   // Conditioning card (issue #135, display-only): weekly cardio minutes /
   // distance / sessions over the last 8 weeks, derived from the cardio sets
   // already fetched for the window. The card stays hidden until the user has
@@ -459,6 +470,14 @@ export default async function ProgressPage(
             measuredAt: e.measuredAt.toISOString(),
           }))}
           unit={unit}
+        />
+
+        <PhotosCard
+          photos={progressPhotos.map((p) => ({
+            id: p.id,
+            takenAt: p.takenAt.toISOString(),
+            note: p.note,
+          }))}
         />
 
         {conditioningWeeks && (

--- a/app/api/progress-photos/[id]/image/route.ts
+++ b/app/api/progress-photos/[id]/image/route.ts
@@ -1,0 +1,48 @@
+import { db } from '@/lib/db';
+import { ApiError, handleApiError, requireApiUserId } from '@/lib/api';
+import { readPhotoFile } from '@/lib/progress-photo';
+
+interface Params {
+  params: Promise<{ id: string }>;
+}
+
+// GET /api/progress-photos/[id]/image : the photo bytes, owner only.
+// This is the ONLY way photo bytes leave the box - the uploads dir is never
+// exposed as a public static path. Ownership-scoped: not-found and
+// not-yours both answer 404 (no existence leak). Headers:
+// - Content-Type is the STORED, sniffed mime (an allowlisted image type,
+//   never client input) and X-Content-Type-Options: nosniff pins it.
+// - Content-Disposition: inline renders in <img> tags.
+// - Cache-Control: private, no-store keeps body photos out of shared caches.
+export async function GET(_req: Request, props: Params) {
+  const params = await props.params;
+  try {
+    const userId = await requireApiUserId();
+    const photo = await db.progressPhoto.findUnique({
+      where: { id: params.id },
+    });
+    if (!photo || photo.userId !== userId) {
+      throw new ApiError(404, 'Photo not found.');
+    }
+
+    const bytes = await readPhotoFile(photo.storagePath);
+    if (!bytes) {
+      // Row exists but the file is gone from disk (operator moved/lost the
+      // uploads dir): a clean 404, not a 500.
+      throw new ApiError(404, 'Photo file not found.');
+    }
+
+    return new Response(new Uint8Array(bytes), {
+      status: 200,
+      headers: {
+        'Content-Type': photo.mimeType,
+        'Content-Length': String(bytes.byteLength),
+        'Content-Disposition': 'inline',
+        'Cache-Control': 'private, no-store',
+        'X-Content-Type-Options': 'nosniff',
+      },
+    });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/app/api/progress-photos/[id]/route.ts
+++ b/app/api/progress-photos/[id]/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { ApiError, handleApiError, requireApiUserId } from '@/lib/api';
+import { deletePhotoFile } from '@/lib/progress-photo';
+
+interface Params {
+  params: Promise<{ id: string }>;
+}
+
+// DELETE /api/progress-photos/[id] : remove one photo (row + file).
+// Ownership-scoped: a photo that does not exist and a photo owned by another
+// user both answer 404, so the route leaks no existence information. The row
+// is deleted first (the source of truth); a missing file on disk is tolerated
+// so a half-cleaned uploads dir cannot wedge deletion.
+export async function DELETE(_req: Request, props: Params) {
+  const params = await props.params;
+  try {
+    const userId = await requireApiUserId();
+    const photo = await db.progressPhoto.findUnique({
+      where: { id: params.id },
+    });
+    if (!photo || photo.userId !== userId) {
+      throw new ApiError(404, 'Photo not found.');
+    }
+
+    await db.progressPhoto.delete({ where: { id: photo.id } });
+    await deletePhotoFile(photo.storagePath);
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/app/api/progress-photos/route.ts
+++ b/app/api/progress-photos/route.ts
@@ -1,0 +1,108 @@
+import { randomUUID } from 'node:crypto';
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import {
+  ApiError,
+  handleApiError,
+  readBodyBytesWithCap,
+  requireApiUserId,
+} from '@/lib/api';
+import {
+  deletePhotoFile,
+  MAX_PROGRESS_PHOTO_BYTES,
+  photoRelativePath,
+  sniffImageType,
+  writePhotoFile,
+} from '@/lib/progress-photo';
+import { progressPhotoUploadQuerySchema } from '@/lib/schemas/progress-photo';
+
+// Metadata the API exposes about a photo. storagePath (server filesystem
+// layout) and the bytes themselves are deliberately never returned here; the
+// bytes are only served by the ownership-scoped image route.
+const PHOTO_SELECT = {
+  id: true,
+  takenAt: true,
+  note: true,
+  mimeType: true,
+  byteSize: true,
+} as const;
+
+// GET /api/progress-photos : the caller's own photos, newest first.
+export async function GET() {
+  try {
+    const userId = await requireApiUserId();
+    const photos = await db.progressPhoto.findMany({
+      where: { userId },
+      orderBy: { takenAt: 'desc' },
+      select: PHOTO_SELECT,
+    });
+    return NextResponse.json(photos);
+  } catch (err) {
+    return handleApiError(err);
+  }
+}
+
+// POST /api/progress-photos?takenAt=<ISO>&note=<text> : upload one photo.
+// The body is the RAW image bytes (not multipart), so the 8 MiB cap is
+// enforced WHILE reading the stream (413 past it, before buffering more).
+// Security controls (issue #269):
+// - The accepted type is decided by magic-byte sniffing over a jpeg/png/webp
+//   allowlist; the client Content-Type header is ignored entirely.
+// - The row is always created under the authenticated user; the file lands
+//   under a per-user dir inside the gitignored uploads dir, mode 0o600.
+// - If the DB write fails after the file was written, the file is removed
+//   again so no orphan bytes accumulate on disk.
+export async function POST(req: Request) {
+  try {
+    const userId = await requireApiUserId();
+
+    const url = new URL(req.url);
+    const parsedQuery = progressPhotoUploadQuerySchema.safeParse({
+      takenAt: url.searchParams.get('takenAt') ?? undefined,
+      note: url.searchParams.get('note') ?? undefined,
+    });
+    if (!parsedQuery.success) {
+      throw new ApiError(
+        400,
+        parsedQuery.error.issues[0]?.message ?? 'Invalid photo metadata',
+      );
+    }
+    const { takenAt, note } = parsedQuery.data;
+
+    const bytes = await readBodyBytesWithCap(req, MAX_PROGRESS_PHOTO_BYTES);
+    if (bytes.length === 0) {
+      throw new ApiError(400, 'Empty request body: send the image bytes.');
+    }
+    const mime = sniffImageType(bytes);
+    if (!mime) {
+      throw new ApiError(415, 'Unsupported image type. Use JPEG, PNG or WebP.');
+    }
+
+    // The id doubles as the filename, so it is generated up front. cuid ids
+    // and UUIDs coexist fine in the TEXT primary key column.
+    const id = randomUUID();
+    const storagePath = photoRelativePath(userId, id, mime);
+    await writePhotoFile(storagePath, bytes);
+    try {
+      const photo = await db.progressPhoto.create({
+        data: {
+          id,
+          userId,
+          ...(takenAt ? { takenAt: new Date(takenAt) } : {}),
+          storagePath,
+          mimeType: mime,
+          byteSize: bytes.length,
+          note: note ? note : null,
+        },
+        select: PHOTO_SELECT,
+      });
+      return NextResponse.json(photo, { status: 201 });
+    } catch (err) {
+      // The file was written but the row was not: remove the orphan file.
+      await deletePhotoFile(storagePath).catch(() => {});
+      throw err;
+    }
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/components/progress/photos-card.tsx
+++ b/components/progress/photos-card.tsx
@@ -1,0 +1,244 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { Camera, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+// One progress photo, as serialized at the Server Component boundary. The
+// bytes are only reachable through the ownership-scoped image route.
+export interface ProgressPhotoView {
+  id: string;
+  takenAt: string; // ISO
+  note: string | null;
+}
+
+interface Props {
+  // The user's photos, newest first.
+  photos: ProgressPhotoView[];
+}
+
+function shortDate(iso: string) {
+  return new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+  }).format(new Date(iso));
+}
+
+function imageUrl(id: string) {
+  return `/api/progress-photos/${id}/image`;
+}
+
+// Progress-photos card (issue #269): upload a photo (stored locally on the
+// server, served only to its owner), browse the gallery, delete, and compare
+// two photos side by side to see visual progress.
+export function PhotosCard({ photos }: Props) {
+  const router = useRouter();
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [note, setNote] = useState('');
+  const [takenAt, setTakenAt] = useState('');
+  const [busy, setBusy] = useState(false);
+  // Before/after compare: ids of the two selected photos. Defaults pick the
+  // oldest and newest so one click shows the widest span.
+  const [beforeId, setBeforeId] = useState('');
+  const [afterId, setAfterId] = useState('');
+
+  const oldest = photos[photos.length - 1];
+  const newest = photos[0];
+  const before = photos.find((p) => p.id === (beforeId || oldest?.id));
+  const after = photos.find((p) => p.id === (afterId || newest?.id));
+
+  async function upload() {
+    const file = fileRef.current?.files?.[0];
+    if (!file) {
+      toast.error('Choose a photo first.');
+      return;
+    }
+    setBusy(true);
+    try {
+      const params = new URLSearchParams();
+      if (takenAt) {
+        params.set('takenAt', new Date(`${takenAt}T12:00:00`).toISOString());
+      }
+      if (note.trim()) params.set('note', note.trim());
+      const queryString = params.toString();
+      const query = queryString ? `?${queryString}` : '';
+      // Raw bytes as the body (not multipart): the server caps the size while
+      // reading and decides the real type from the magic bytes.
+      const res = await fetch(`/api/progress-photos${query}`, {
+        method: 'POST',
+        headers: { 'Content-Type': file.type || 'application/octet-stream' },
+        body: file,
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as { error?: string } | null;
+        toast.error(data?.error ?? 'Could not upload the photo.');
+        return;
+      }
+      toast.success('Photo added.');
+      setNote('');
+      setTakenAt('');
+      if (fileRef.current) fileRef.current.value = '';
+      router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function deletePhoto(photo: ProgressPhotoView) {
+    if (!confirm(`Delete the photo of ${shortDate(photo.takenAt)}?`)) return;
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/progress-photos/${photo.id}`, {
+        method: 'DELETE',
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => null)) as { error?: string } | null;
+        toast.error(data?.error ?? 'Could not delete the photo.');
+        return;
+      }
+      toast.success('Photo deleted.');
+      router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <h2 className="flex items-center gap-2 text-base font-semibold">
+          <Camera className="size-4" />
+          Progress photos
+        </h2>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {/* Upload: photo file + optional date and note */}
+        <form
+          className="flex flex-wrap items-end gap-2"
+          onSubmit={(e) => {
+            e.preventDefault();
+            void upload();
+          }}
+        >
+          <div className="min-w-40 flex-1 space-y-1">
+            <Label htmlFor="progress-photo-file">Photo</Label>
+            <Input
+              id="progress-photo-file"
+              ref={fileRef}
+              type="file"
+              accept="image/jpeg,image/png,image/webp"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="progress-photo-date">Date</Label>
+            <Input
+              id="progress-photo-date"
+              type="date"
+              value={takenAt}
+              onChange={(e) => setTakenAt(e.target.value)}
+            />
+          </div>
+          <div className="min-w-32 flex-1 space-y-1">
+            <Label htmlFor="progress-photo-note">Note (optional)</Label>
+            <Input
+              id="progress-photo-note"
+              value={note}
+              maxLength={500}
+              placeholder="e.g. end of cut"
+              onChange={(e) => setNote(e.target.value)}
+            />
+          </div>
+          <Button type="submit" disabled={busy}>
+            {busy ? 'Uploading...' : 'Upload'}
+          </Button>
+        </form>
+
+        {photos.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No progress photos yet. Photos are stored locally on your server
+            and only visible to you. Upload the first one to start the timeline.
+          </p>
+        ) : (
+          <>
+            {/* Gallery: newest first, deletable */}
+            <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-5">
+              {photos.map((p) => (
+                <figure key={p.id} className="group relative">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={imageUrl(p.id)}
+                    alt={`Progress photo of ${shortDate(p.takenAt)}${p.note ? ` - ${p.note}` : ''}`}
+                    className="aspect-square w-full rounded-md border object-cover"
+                    loading="lazy"
+                  />
+                  <figcaption className="mt-1 truncate text-xs text-muted-foreground">
+                    {shortDate(p.takenAt)}
+                  </figcaption>
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="icon"
+                    className="absolute right-1 top-1 size-7 opacity-80"
+                    aria-label={`Delete photo of ${shortDate(p.takenAt)}`}
+                    onClick={() => void deletePhoto(p)}
+                    disabled={busy}
+                  >
+                    <Trash2 className="size-3.5" />
+                  </Button>
+                </figure>
+              ))}
+            </div>
+
+            {/* Before/after side-by-side compare */}
+            {photos.length >= 2 && (
+              <div className="flex flex-col gap-2">
+                <h3 className="text-sm font-medium">Compare</h3>
+                <div className="grid grid-cols-2 gap-3">
+                  {(
+                    [
+                      { label: 'Before', photo: before, value: beforeId || oldest?.id || '', set: setBeforeId },
+                      { label: 'After', photo: after, value: afterId || newest?.id || '', set: setAfterId },
+                    ] as const
+                  ).map(({ label, photo, value, set }) => (
+                    <div key={label} className="flex flex-col gap-1">
+                      <Label htmlFor={`progress-photo-${label.toLowerCase()}`}>
+                        {label}
+                      </Label>
+                      <select
+                        id={`progress-photo-${label.toLowerCase()}`}
+                        className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                        value={value}
+                        onChange={(e) => set(e.target.value)}
+                      >
+                        {photos.map((p) => (
+                          <option key={p.id} value={p.id}>
+                            {shortDate(p.takenAt)}
+                            {p.note ? ` - ${p.note}` : ''}
+                          </option>
+                        ))}
+                      </select>
+                      {photo && (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          src={imageUrl(photo.id)}
+                          alt={`${label} photo of ${shortDate(photo.takenAt)}`}
+                          className="w-full rounded-md border object-contain"
+                        />
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -51,6 +51,11 @@ services:
       OPENROUTER_APP_URL: ${OPENROUTER_APP_URL}
       NEXTAUTH_URL: ${NEXTAUTH_URL}
       NODE_ENV: production
+      # Progress-photo files (issue #269): kept on the named volume below so
+      # they survive container rebuilds. Back it up alongside the database.
+      UPLOADS_DIR: /app/uploads
+    volumes:
+      - uploads:/app/uploads
     # Applique les migrations Prisma puis lance Next.js standalone.
     # `migrate deploy` est idempotent : sans nouvelle migration, c'est un no-op.
     # On invoque le bundle Prisma directement (le shim .bin perd ses .wasm
@@ -86,3 +91,4 @@ services:
 
 volumes:
   postgres-data:
+  uploads:

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -49,17 +49,17 @@ export async function parseJsonBody<T extends z.ZodTypeAny>(
   return parsed.data;
 }
 
-// Reads the request body as text while enforcing a hard byte cap DURING the
-// read. The Content-Length header is attacker-controlled (absent on chunked
-// bodies, or malformed), and App Router route handlers have no built-in body
-// size limit, so `req.json()` would buffer an arbitrarily large body into
-// memory before any schema check runs. Aborts with 413 as soon as the
-// cumulative byte count exceeds the cap.
-export async function readBodyWithCap(
+// Reads the request body as raw bytes while enforcing a hard byte cap DURING
+// the read. The Content-Length header is attacker-controlled (absent on
+// chunked bodies, or malformed), and App Router route handlers have no
+// built-in body size limit, so `req.json()` / `req.arrayBuffer()` would
+// buffer an arbitrarily large body into memory before any check runs. Aborts
+// with 413 as soon as the cumulative byte count exceeds the cap.
+export async function readBodyBytesWithCap(
   req: Request,
   maxBytes: number,
-): Promise<string> {
-  if (!req.body) return '';
+): Promise<Uint8Array> {
+  if (!req.body) return new Uint8Array(0);
   const reader = req.body.getReader();
   const chunks: Uint8Array[] = [];
   let received = 0;
@@ -86,7 +86,15 @@ export async function readBodyWithCap(
     merged.set(chunk, offset);
     offset += chunk.byteLength;
   }
-  return new TextDecoder().decode(merged);
+  return merged;
+}
+
+// Text variant of readBodyBytesWithCap, for JSON/CSV/XML bodies.
+export async function readBodyWithCap(
+  req: Request,
+  maxBytes: number,
+): Promise<string> {
+  return new TextDecoder().decode(await readBodyBytesWithCap(req, maxBytes));
 }
 
 export function handleApiError(err: unknown): NextResponse {

--- a/lib/progress-photo.test.ts
+++ b/lib/progress-photo.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extensionForMime,
+  MAX_PROGRESS_PHOTO_BYTES,
+  photoRelativePath,
+  sniffImageType,
+} from './progress-photo';
+
+// Builders for the accepted signatures, padded with arbitrary payload bytes
+// so the buffers look like the start of a real file, not just a bare header.
+function jpegBytes(extra = 16): Uint8Array {
+  return Uint8Array.from([0xff, 0xd8, 0xff, 0xe0, ...Array(extra).fill(0x42)]);
+}
+function pngBytes(extra = 16): Uint8Array {
+  return Uint8Array.from([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    ...Array(extra).fill(0x42),
+  ]);
+}
+function webpBytes(extra = 16): Uint8Array {
+  // 'RIFF' + 4 size bytes + 'WEBP' + payload.
+  return Uint8Array.from([
+    0x52, 0x49, 0x46, 0x46, 0x1a, 0x00, 0x00, 0x00,
+    0x57, 0x45, 0x42, 0x50, ...Array(extra).fill(0x42),
+  ]);
+}
+
+describe('sniffImageType', () => {
+  it('detects JPEG from its FF D8 FF signature', () => {
+    expect(sniffImageType(jpegBytes())).toBe('image/jpeg');
+  });
+
+  it('detects PNG from its 8-byte signature', () => {
+    expect(sniffImageType(pngBytes())).toBe('image/png');
+  });
+
+  it('detects WebP from RIFF....WEBP', () => {
+    expect(sniffImageType(webpBytes())).toBe('image/webp');
+  });
+
+  it('rejects plain text', () => {
+    expect(sniffImageType(new TextEncoder().encode('hello, not an image'))).toBeNull();
+  });
+
+  it('rejects a PDF (%PDF- magic)', () => {
+    expect(sniffImageType(new TextEncoder().encode('%PDF-1.7 ...'))).toBeNull();
+  });
+
+  it('rejects a GIF (GIF89a magic) - not in the allowlist', () => {
+    expect(sniffImageType(new TextEncoder().encode('GIF89a\x01\x00\x01\x00'))).toBeNull();
+  });
+
+  it('rejects an SVG (scriptable image, not in the allowlist)', () => {
+    expect(sniffImageType(new TextEncoder().encode('<svg xmlns="..."></svg>'))).toBeNull();
+  });
+
+  it('rejects empty and 1-byte buffers without throwing', () => {
+    expect(sniffImageType(new Uint8Array(0))).toBeNull();
+    expect(sniffImageType(Uint8Array.from([0xff]))).toBeNull();
+  });
+
+  it('rejects truncated headers (PNG cut at 7 bytes, WebP cut before WEBP)', () => {
+    expect(sniffImageType(pngBytes().slice(0, 7))).toBeNull();
+    // 'RIFF' + size but cut before the 'WEBP' tag at bytes 8..11.
+    expect(sniffImageType(webpBytes().slice(0, 11))).toBeNull();
+  });
+
+  it('rejects RIFF containers that are not WebP (e.g. WAVE audio)', () => {
+    const wave = Uint8Array.from([
+      0x52, 0x49, 0x46, 0x46, 0x1a, 0x00, 0x00, 0x00,
+      0x57, 0x41, 0x56, 0x45, // 'WAVE'
+    ]);
+    expect(sniffImageType(wave)).toBeNull();
+  });
+
+  it('is not fooled by a signature placed past offset 0 (disguised bytes)', () => {
+    const disguised = Uint8Array.from([0x00, ...jpegBytes()]);
+    expect(sniffImageType(disguised)).toBeNull();
+  });
+});
+
+describe('extensionForMime', () => {
+  it('maps each allowed mime to its extension', () => {
+    expect(extensionForMime('image/jpeg')).toBe('jpg');
+    expect(extensionForMime('image/png')).toBe('png');
+    expect(extensionForMime('image/webp')).toBe('webp');
+  });
+});
+
+describe('photoRelativePath', () => {
+  it('builds <userId>/<photoId>.<ext>', () => {
+    expect(photoRelativePath('user1', 'photo1', 'image/png')).toBe(
+      'user1/photo1.png',
+    );
+  });
+});
+
+describe('MAX_PROGRESS_PHOTO_BYTES', () => {
+  it('is 8 MiB', () => {
+    expect(MAX_PROGRESS_PHOTO_BYTES).toBe(8 * 1024 * 1024);
+  });
+});

--- a/lib/progress-photo.ts
+++ b/lib/progress-photo.ts
@@ -1,0 +1,125 @@
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+// ============================================================
+// Progress-photo storage (issue #269)
+// ============================================================
+// Local-only file storage for progress photos, plus the content sniffing the
+// upload route relies on. Security posture:
+// - The accepted formats are a hard ALLOWLIST (jpeg/png/webp), decided by the
+//   file's magic bytes only - the client-declared Content-Type is never
+//   trusted, so a disguised extension or spoofed header changes nothing.
+// - Files are written non-executable (0o600) under a gitignored uploads dir,
+//   which is never exposed as a public static path; every read goes through
+//   an ownership-scoped API route.
+// - Stored paths are RELATIVE to the storage dir and re-resolved on every
+//   access with a containment check, so a corrupted/hostile DB value can
+//   never escape the uploads dir.
+
+export type ProgressPhotoMime = 'image/jpeg' | 'image/png' | 'image/webp';
+
+// 8 MiB: generous for a phone photo, small enough to buffer in memory. The
+// upload route enforces this DURING the body read (413 past the cap).
+export const MAX_PROGRESS_PHOTO_BYTES = 8 * 1024 * 1024;
+export const MAX_PROGRESS_PHOTO_NOTE = 500;
+
+// Magic-byte detection over the accepted image formats. Anything that does
+// not match one of the three signatures - including GIF, PDF, SVG, plain
+// text, or a truncated header - returns null and must be rejected.
+export function sniffImageType(bytes: Uint8Array): ProgressPhotoMime | null {
+  // JPEG: FF D8 FF
+  if (
+    bytes.length >= 3 &&
+    bytes[0] === 0xff &&
+    bytes[1] === 0xd8 &&
+    bytes[2] === 0xff
+  ) {
+    return 'image/jpeg';
+  }
+  // PNG: 89 50 4E 47 0D 0A 1A 0A
+  const pngSig = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+  if (bytes.length >= 8 && pngSig.every((b, i) => bytes[i] === b)) {
+    return 'image/png';
+  }
+  // WebP: 'RIFF' at 0..3 and 'WEBP' at 8..11 (4..7 is the chunk size).
+  const riff = [0x52, 0x49, 0x46, 0x46]; // 'RIFF'
+  const webp = [0x57, 0x45, 0x42, 0x50]; // 'WEBP'
+  if (
+    bytes.length >= 12 &&
+    riff.every((b, i) => bytes[i] === b) &&
+    webp.every((b, i) => bytes[8 + i] === b)
+  ) {
+    return 'image/webp';
+  }
+  return null;
+}
+
+export function extensionForMime(mime: ProgressPhotoMime): 'jpg' | 'png' | 'webp' {
+  switch (mime) {
+    case 'image/jpeg':
+      return 'jpg';
+    case 'image/png':
+      return 'png';
+    case 'image/webp':
+      return 'webp';
+  }
+}
+
+// Root dir for progress-photo files: <UPLOADS_DIR>/progress-photos, resolved
+// at call time so tests can point UPLOADS_DIR at a scratch dir. Defaults to
+// ./uploads (gitignored) for self-hosters who do not configure it.
+export function progressPhotoStorageDir(): string {
+  return path.resolve(process.env.UPLOADS_DIR ?? './uploads', 'progress-photos');
+}
+
+// Storage path of one photo, RELATIVE to progressPhotoStorageDir(). Both ids
+// are server-generated (cuid/uuid), but resolveInsideStorageDir re-checks
+// containment anyway.
+export function photoRelativePath(
+  userId: string,
+  photoId: string,
+  mime: ProgressPhotoMime,
+): string {
+  return path.join(userId, `${photoId}.${extensionForMime(mime)}`);
+}
+
+// Defense-in-depth: resolve a stored relative path against the storage dir
+// and refuse anything that escapes it (absolute paths, ..-traversal).
+function resolveInsideStorageDir(relPath: string): string {
+  const dir = progressPhotoStorageDir();
+  const abs = path.resolve(dir, relPath);
+  if (abs !== dir && !abs.startsWith(dir + path.sep)) {
+    throw new Error('Progress-photo path escapes the uploads dir.');
+  }
+  return abs;
+}
+
+// Writes the photo bytes, creating the per-user dir as needed. Mode 0o600:
+// owner read/write only, never executable.
+export async function writePhotoFile(
+  relPath: string,
+  bytes: Uint8Array,
+): Promise<void> {
+  const abs = resolveInsideStorageDir(relPath);
+  await mkdir(path.dirname(abs), { recursive: true });
+  await writeFile(abs, bytes, { mode: 0o600 });
+}
+
+// Reads the photo bytes; null when the file is missing on disk (the serving
+// route turns that into a 404 rather than a 500).
+export async function readPhotoFile(relPath: string): Promise<Uint8Array | null> {
+  const abs = resolveInsideStorageDir(relPath);
+  try {
+    return new Uint8Array(await readFile(abs));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+// Removes the photo file; a missing file is fine (force: true), so deleting a
+// row whose file is already gone still succeeds.
+export async function deletePhotoFile(relPath: string): Promise<void> {
+  const abs = resolveInsideStorageDir(relPath);
+  await rm(abs, { force: true });
+}

--- a/lib/schemas/progress-photo.test.ts
+++ b/lib/schemas/progress-photo.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { progressPhotoUploadQuerySchema } from './progress-photo';
+
+describe('progressPhotoUploadQuerySchema', () => {
+  it('accepts an empty query (both fields optional)', () => {
+    const parsed = progressPhotoUploadQuerySchema.safeParse({});
+    expect(parsed.success).toBe(true);
+    expect(parsed.success && parsed.data.takenAt).toBeUndefined();
+    expect(parsed.success && parsed.data.note).toBeUndefined();
+  });
+
+  it('accepts a valid ISO takenAt and trims the note', () => {
+    const parsed = progressPhotoUploadQuerySchema.safeParse({
+      takenAt: '2026-07-01T08:00:00.000Z',
+      note: '  end of cut  ',
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.takenAt).toBe('2026-07-01T08:00:00.000Z');
+      expect(parsed.data.note).toBe('end of cut');
+    }
+  });
+
+  it('rejects an unparseable takenAt', () => {
+    expect(
+      progressPhotoUploadQuerySchema.safeParse({ takenAt: 'not-a-date' }).success,
+    ).toBe(false);
+  });
+
+  it('rejects a takenAt outside the Postgres-safe year range', () => {
+    // Parses in JS Date but would 500 deep in Prisma (year 275760).
+    expect(
+      progressPhotoUploadQuerySchema.safeParse({
+        takenAt: '+275760-09-13T00:00:00.000Z',
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects a note longer than 500 characters', () => {
+    expect(
+      progressPhotoUploadQuerySchema.safeParse({ note: 'x'.repeat(501) }).success,
+    ).toBe(false);
+  });
+
+  it('accepts a note of exactly 500 characters', () => {
+    expect(
+      progressPhotoUploadQuerySchema.safeParse({ note: 'x'.repeat(500) }).success,
+    ).toBe(true);
+  });
+});

--- a/lib/schemas/progress-photo.ts
+++ b/lib/schemas/progress-photo.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+import { MAX_PROGRESS_PHOTO_NOTE } from '@/lib/progress-photo';
+
+// Progress-photo upload metadata (issue #269). The image itself travels as
+// the RAW request body (so the size cap applies while reading it); only the
+// metadata rides in the query string and is validated here.
+//
+// takenAt must parse AND fall in a sane year range: JS Date.parse accepts
+// dates far outside PostgreSQL's timestamp range (e.g. year 275760), which
+// would pass a bare parse check and then throw deep in Prisma as a 500
+// (same guard as the backup import schema).
+const takenAtString = z
+  .string()
+  .max(40)
+  .refine(
+    (s) => {
+      const t = Date.parse(s);
+      if (Number.isNaN(t)) return false;
+      const year = new Date(t).getUTCFullYear();
+      return year >= 1 && year <= 9999;
+    },
+    { message: 'Invalid or out-of-range takenAt date' },
+  );
+
+export const progressPhotoUploadQuerySchema = z.object({
+  // When absent the photo is stamped "now" server-side.
+  takenAt: takenAtString.optional(),
+  note: z.string().trim().max(MAX_PROGRESS_PHOTO_NOTE).optional(),
+});
+
+export type ProgressPhotoUploadQuery = z.infer<
+  typeof progressPhotoUploadQuerySchema
+>;

--- a/prisma/migrations/20260722100000_add_progress_photo/migration.sql
+++ b/prisma/migrations/20260722100000_add_progress_photo/migration.sql
@@ -1,0 +1,23 @@
+-- Additive migration (issue #269): local-only progress photos. New table +
+-- index only; no change to existing tables. The image bytes live on the local
+-- filesystem (UPLOADS_DIR); this table holds the ownership-scoped metadata.
+
+-- CreateTable
+CREATE TABLE "ProgressPhoto" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "takenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "storagePath" TEXT NOT NULL,
+    "mimeType" TEXT NOT NULL,
+    "byteSize" INTEGER NOT NULL,
+    "note" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ProgressPhoto_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ProgressPhoto_userId_takenAt_idx" ON "ProgressPhoto"("userId", "takenAt");
+
+-- AddForeignKey
+ALTER TABLE "ProgressPhoto" ADD CONSTRAINT "ProgressPhoto_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,6 +49,7 @@ model User {
   bodyweightEntries BodyweightEntry[]
   bodyMeasurements BodyMeasurement[]
   volumeTargets VolumeTarget[]
+  progressPhotos ProgressPhoto[]
 }
 
 enum Sex {
@@ -345,6 +346,28 @@ enum BodyMeasurementSite {
   THIGH_RIGHT
   CALF_LEFT
   CALF_RIGHT
+}
+
+// Progress photo metadata (issue #269, additive): the visual companion to
+// bodyweight and tape-measure tracking. The image bytes live on the LOCAL
+// filesystem (under UPLOADS_DIR, gitignored, never a public static path) and
+// only this row's storagePath points at them; every read goes through an
+// ownership-scoped API route. mimeType is the SNIFFED type (magic bytes, an
+// allowlist of jpeg/png/webp), never the client-declared one.
+model ProgressPhoto {
+  id          String   @id @default(cuid())
+  userId      String
+  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  takenAt     DateTime @default(now())
+  // Path of the image file RELATIVE to the progress-photo storage dir
+  // (<userId>/<photoId>.<ext>), so a relocated UPLOADS_DIR keeps working.
+  storagePath String
+  mimeType    String
+  byteSize    Int
+  note        String?
+  createdAt   DateTime @default(now())
+
+  @@index([userId, takenAt])
 }
 
 model CoachSession {

--- a/tests/e2e/progress-photos.spec.ts
+++ b/tests/e2e/progress-photos.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+
+// Progress photos (issue #269): upload a photo on the progress page and see
+// it in the gallery. The card renders even with no training data, so a fresh
+// user is enough. The fixture is a real 1x1 PNG generated from base64, so the
+// magic-byte sniff on the server accepts it and the browser can render it.
+
+const TINY_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+test('a lifter can upload a progress photo and see it in the gallery', async ({
+  page,
+}) => {
+  // Register through the API with a unique X-Forwarded-For so this spec keeps
+  // its own per-IP register rate-limit bucket (the suite's parallel signups
+  // otherwise exhaust the 5/min budget), mirroring the other specs.
+  const registerRes = await page.request.post('/api/auth/register', {
+    headers: { 'x-forwarded-for': '10.111.0.10' },
+    data: {
+      displayName: 'Photos E2E',
+      email: `e2e-photos-${Date.now()}@test.dev`,
+      password: 'supersecret',
+    },
+  });
+  expect(registerRes.ok()).toBeTruthy();
+
+  await page.goto('/progress');
+  // Scope to the Progress photos card (the page has several cards).
+  const card = page
+    .locator('div.rounded-xl', {
+      has: page.getByRole('heading', { name: 'Progress photos' }),
+    })
+    .first();
+  await expect(card.getByRole('heading', { name: 'Progress photos' })).toBeVisible();
+  await expect(card.getByText(/no progress photos yet/i)).toBeVisible();
+
+  // Upload the tiny PNG with a note.
+  await card.getByLabel('Photo').setInputFiles({
+    name: 'front.png',
+    mimeType: 'image/png',
+    buffer: TINY_PNG,
+  });
+  await card.getByLabel(/note/i).fill('e2e upload');
+  await card.getByRole('button', { name: 'Upload', exact: true }).click();
+
+  // The thumbnail appears, served through the ownership-scoped image route.
+  const thumbnail = card.locator('img[src*="/api/progress-photos/"]').first();
+  await expect(thumbnail).toBeVisible();
+  await expect(card.getByText(/no progress photos yet/i)).toBeHidden();
+
+  // Delete it again (accepting the confirm dialog): back to the empty state.
+  page.on('dialog', (dialog) => void dialog.accept());
+  await card.getByRole('button', { name: /delete photo of/i }).click();
+  await expect(card.getByText(/no progress photos yet/i)).toBeVisible();
+});

--- a/tests/integration/progress-photos-route.test.ts
+++ b/tests/integration/progress-photos-route.test.ts
@@ -1,0 +1,347 @@
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import { mkdtemp, rm, stat, readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { db } from '@/lib/db';
+import { getCurrentUserId } from '@/lib/auth';
+
+// Progress-photo routes (issue #269): a file-upload security surface, so this
+// suite covers the hostile paths (oversize, wrong/disguised type, bad
+// metadata) and the ownership boundary (a user can never read or delete
+// another user's photo) on top of the happy paths.
+
+// Auth is read through getCurrentUserId (via requireApiUserId in @/lib/api).
+vi.mock('@/lib/auth', () => ({ getCurrentUserId: vi.fn() }));
+const mockUserId = vi.mocked(getCurrentUserId);
+
+import { GET as listPhotos, POST as uploadPhoto } from '@/app/api/progress-photos/route';
+import { DELETE as deletePhoto } from '@/app/api/progress-photos/[id]/route';
+import { GET as getImage } from '@/app/api/progress-photos/[id]/image/route';
+import { MAX_PROGRESS_PHOTO_BYTES } from '@/lib/progress-photo';
+
+let uploadsDir = '';
+const prevUploadsDir = process.env.UPLOADS_DIR;
+
+beforeAll(async () => {
+  // A fresh scratch dir per run so tests never touch a real uploads dir and
+  // never collide with a previous run.
+  uploadsDir = await mkdtemp(path.join(os.tmpdir(), 'gymcoach-photos-test-'));
+  process.env.UPLOADS_DIR = uploadsDir;
+});
+
+afterAll(async () => {
+  if (prevUploadsDir === undefined) delete process.env.UPLOADS_DIR;
+  else process.env.UPLOADS_DIR = prevUploadsDir;
+  if (uploadsDir) await rm(uploadsDir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  mockUserId.mockReset();
+});
+
+function actAs(userId: string) {
+  mockUserId.mockResolvedValue(userId);
+}
+
+// Minimal buffers with the correct magic bytes for each accepted format.
+function jpegBytes(extra = 32): Uint8Array<ArrayBuffer> {
+  return Uint8Array.from([0xff, 0xd8, 0xff, 0xe0, ...Array(extra).fill(0x42)]);
+}
+function pngBytes(extra = 32): Uint8Array<ArrayBuffer> {
+  return Uint8Array.from([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    ...Array(extra).fill(0x42),
+  ]);
+}
+function webpBytes(extra = 32): Uint8Array<ArrayBuffer> {
+  return Uint8Array.from([
+    0x52, 0x49, 0x46, 0x46, 0x1a, 0x00, 0x00, 0x00,
+    0x57, 0x45, 0x42, 0x50, ...Array(extra).fill(0x42),
+  ]);
+}
+
+function uploadReq(bytes: Uint8Array<ArrayBuffer>, query = ''): Request {
+  return new Request(`http://test.local/api/progress-photos${query}`, {
+    method: 'POST',
+    // Deliberately lies about the type on some calls: the server must decide
+    // from the magic bytes, never from this header.
+    headers: { 'Content-Type': 'application/octet-stream' },
+    body: bytes,
+  });
+}
+
+function idParams(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+async function seedUsers() {
+  const [a, b] = await Promise.all([
+    db.user.create({ data: { email: 'owner@test.dev', passwordHash: 'x' } }),
+    db.user.create({ data: { email: 'stranger@test.dev', passwordHash: 'x' } }),
+  ]);
+  return { a, b };
+}
+
+describe('POST /api/progress-photos - valid uploads', () => {
+  it.each([
+    ['JPEG', jpegBytes(), 'image/jpeg', 'jpg'],
+    ['PNG', pngBytes(), 'image/png', 'png'],
+    ['WebP', webpBytes(), 'image/webp', 'webp'],
+  ] as const)(
+    'accepts a %s upload: 201, row persisted, file on disk',
+    async (_label, bytes, mime, ext) => {
+      const { a } = await seedUsers();
+      actAs(a.id);
+
+      const res = await uploadPhoto(uploadReq(bytes));
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.mimeType).toBe(mime);
+      expect(body.byteSize).toBe(bytes.length);
+      // The server filesystem layout never leaks to the client.
+      expect(body.storagePath).toBeUndefined();
+
+      const row = await db.progressPhoto.findUnique({ where: { id: body.id } });
+      expect(row).not.toBeNull();
+      expect(row!.userId).toBe(a.id);
+      expect(row!.mimeType).toBe(mime);
+      expect(row!.storagePath).toBe(`${a.id}/${body.id}.${ext}`);
+
+      const abs = path.join(uploadsDir, 'progress-photos', row!.storagePath);
+      expect(existsSync(abs)).toBe(true);
+      expect(new Uint8Array(await readFile(abs))).toEqual(bytes);
+      // Written non-executable, owner-only (0o600).
+      const mode = (await stat(abs)).mode & 0o777;
+      expect(mode).toBe(0o600);
+    },
+  );
+
+  it('stores takenAt and the trimmed note from the query string', async () => {
+    const { a } = await seedUsers();
+    actAs(a.id);
+
+    const takenAt = '2026-07-01T08:00:00.000Z';
+    const res = await uploadPhoto(
+      uploadReq(
+        jpegBytes(),
+        `?takenAt=${encodeURIComponent(takenAt)}&note=${encodeURIComponent('  end of cut ')}`,
+      ),
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.takenAt).toBe(takenAt);
+    expect(body.note).toBe('end of cut');
+  });
+});
+
+describe('POST /api/progress-photos - hostile uploads', () => {
+  it('rejects a body past the 8 MiB cap with 413 and stores nothing', async () => {
+    const { a } = await seedUsers();
+    actAs(a.id);
+
+    const oversized = new Uint8Array(MAX_PROGRESS_PHOTO_BYTES + 1);
+    oversized.set([0xff, 0xd8, 0xff]); // valid JPEG magic, still too big
+    const res = await uploadPhoto(uploadReq(oversized));
+    expect(res.status).toBe(413);
+    expect(await db.progressPhoto.count()).toBe(0);
+  });
+
+  it.each([
+    ['PDF magic', new TextEncoder().encode('%PDF-1.7 not an image')],
+    ['plain text', new TextEncoder().encode('just some text pretending')],
+    ['GIF magic', new TextEncoder().encode('GIF89a\x01\x00\x01\x00rest')],
+  ] as const)('rejects %s with 415', async (_label, bytes) => {
+    const { a } = await seedUsers();
+    actAs(a.id);
+
+    const res = await uploadPhoto(uploadReq(bytes));
+    expect(res.status).toBe(415);
+    expect((await res.json()).error).toMatch(/unsupported image type/i);
+    expect(await db.progressPhoto.count()).toBe(0);
+  });
+
+  it('rejects a disguised upload (text bytes, image/png Content-Type header)', async () => {
+    const { a } = await seedUsers();
+    actAs(a.id);
+
+    const res = await uploadPhoto(
+      new Request('http://test.local/api/progress-photos', {
+        method: 'POST',
+        headers: { 'Content-Type': 'image/png' }, // lies
+        body: new TextEncoder().encode('<script>alert(1)</script>'),
+      }),
+    );
+    expect(res.status).toBe(415);
+  });
+
+  it('rejects an empty body with 400', async () => {
+    const { a } = await seedUsers();
+    actAs(a.id);
+
+    const res = await uploadPhoto(
+      new Request('http://test.local/api/progress-photos', { method: 'POST' }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a note longer than 500 chars with 400 (before reading the body)', async () => {
+    const { a } = await seedUsers();
+    actAs(a.id);
+
+    const res = await uploadPhoto(
+      uploadReq(jpegBytes(), `?note=${'x'.repeat(501)}`),
+    );
+    expect(res.status).toBe(400);
+    expect(await db.progressPhoto.count()).toBe(0);
+  });
+
+  it.each([
+    ['unparseable', 'not-a-date'],
+    ['out of the Postgres range', '+275760-09-13T00:00:00.000Z'],
+  ] as const)('rejects a takenAt that is %s with 400', async (_label, takenAt) => {
+    const { a } = await seedUsers();
+    actAs(a.id);
+
+    const res = await uploadPhoto(
+      uploadReq(jpegBytes(), `?takenAt=${encodeURIComponent(takenAt)}`),
+    );
+    expect(res.status).toBe(400);
+    expect(await db.progressPhoto.count()).toBe(0);
+  });
+
+  it('rejects an unauthenticated upload with 401', async () => {
+    mockUserId.mockResolvedValue(null);
+    const res = await uploadPhoto(uploadReq(jpegBytes()));
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /api/progress-photos - own photos only, newest first', () => {
+  it('lists only the caller rows, ordered by takenAt desc, without storagePath', async () => {
+    const { a, b } = await seedUsers();
+
+    actAs(a.id);
+    await uploadPhoto(uploadReq(jpegBytes(), '?takenAt=2026-06-01T00:00:00.000Z'));
+    await uploadPhoto(uploadReq(pngBytes(), '?takenAt=2026-07-01T00:00:00.000Z'));
+    actAs(b.id);
+    await uploadPhoto(uploadReq(webpBytes(), '?takenAt=2026-06-15T00:00:00.000Z'));
+
+    actAs(a.id);
+    const res = await listPhotos();
+    expect(res.status).toBe(200);
+    const rows = await res.json();
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r: { takenAt: string }) => r.takenAt)).toEqual([
+      '2026-07-01T00:00:00.000Z',
+      '2026-06-01T00:00:00.000Z',
+    ]);
+    for (const row of rows) {
+      expect(row.storagePath).toBeUndefined();
+    }
+  });
+});
+
+describe('GET /api/progress-photos/[id]/image - ownership-scoped serving', () => {
+  it('returns the stored bytes with the sniffed Content-Type and no-store headers for the owner', async () => {
+    const { a } = await seedUsers();
+    actAs(a.id);
+    const bytes = pngBytes(64);
+    const { id } = await (await uploadPhoto(uploadReq(bytes))).json();
+
+    const res = await getImage(
+      new Request(`http://test.local/api/progress-photos/${id}/image`),
+      idParams(id),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('image/png');
+    expect(res.headers.get('Content-Disposition')).toBe('inline');
+    expect(res.headers.get('Cache-Control')).toBe('private, no-store');
+    expect(res.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    expect(new Uint8Array(await res.arrayBuffer())).toEqual(bytes);
+  });
+
+  it("answers 404 (not 403) when user B requests user A's image", async () => {
+    const { a, b } = await seedUsers();
+    actAs(a.id);
+    const { id } = await (await uploadPhoto(uploadReq(jpegBytes()))).json();
+
+    actAs(b.id);
+    const res = await getImage(
+      new Request(`http://test.local/api/progress-photos/${id}/image`),
+      idParams(id),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('answers 404 for a missing id and for a row whose file is gone from disk', async () => {
+    const { a } = await seedUsers();
+    actAs(a.id);
+
+    const missing = await getImage(
+      new Request('http://test.local/api/progress-photos/nope/image'),
+      idParams('nope'),
+    );
+    expect(missing.status).toBe(404);
+
+    const { id } = await (await uploadPhoto(uploadReq(jpegBytes()))).json();
+    const row = await db.progressPhoto.findUnique({ where: { id } });
+    await rm(path.join(uploadsDir, 'progress-photos', row!.storagePath));
+    const gone = await getImage(
+      new Request(`http://test.local/api/progress-photos/${id}/image`),
+      idParams(id),
+    );
+    expect(gone.status).toBe(404);
+  });
+});
+
+describe('DELETE /api/progress-photos/[id] - ownership-scoped delete', () => {
+  it('lets the owner delete a photo: row and file both removed', async () => {
+    const { a } = await seedUsers();
+    actAs(a.id);
+    const { id } = await (await uploadPhoto(uploadReq(jpegBytes()))).json();
+    const row = await db.progressPhoto.findUnique({ where: { id } });
+    const abs = path.join(uploadsDir, 'progress-photos', row!.storagePath);
+    expect(existsSync(abs)).toBe(true);
+
+    const res = await deletePhoto(
+      new Request('http://test.local', { method: 'DELETE' }),
+      idParams(id),
+    );
+    expect(res.status).toBe(200);
+    expect(await db.progressPhoto.findUnique({ where: { id } })).toBeNull();
+    expect(existsSync(abs)).toBe(false);
+  });
+
+  it("answers 404 and keeps row + file when user B deletes user A's photo", async () => {
+    const { a, b } = await seedUsers();
+    actAs(a.id);
+    const { id } = await (await uploadPhoto(uploadReq(jpegBytes()))).json();
+    const row = await db.progressPhoto.findUnique({ where: { id } });
+    const abs = path.join(uploadsDir, 'progress-photos', row!.storagePath);
+
+    actAs(b.id);
+    const res = await deletePhoto(
+      new Request('http://test.local', { method: 'DELETE' }),
+      idParams(id),
+    );
+    expect(res.status).toBe(404);
+    expect(await db.progressPhoto.findUnique({ where: { id } })).not.toBeNull();
+    expect(existsSync(abs)).toBe(true);
+  });
+
+  it('still deletes the row when the file is already gone from disk', async () => {
+    const { a } = await seedUsers();
+    actAs(a.id);
+    const { id } = await (await uploadPhoto(uploadReq(jpegBytes()))).json();
+    const row = await db.progressPhoto.findUnique({ where: { id } });
+    await rm(path.join(uploadsDir, 'progress-photos', row!.storagePath));
+
+    const res = await deletePhoto(
+      new Request('http://test.local', { method: 'DELETE' }),
+      idParams(id),
+    );
+    expect(res.status).toBe(200);
+    expect(await db.progressPhoto.findUnique({ where: { id } })).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #269

## Summary

Local-only progress photos alongside the existing body metrics - no cloud, no OAuth, data stays on the self-hosted box.

- **Additive migration** `20260722100000_add_progress_photo`: new `ProgressPhoto` table (userId, takenAt, storagePath, mimeType, byteSize, note) + `User` back-relation; no change to existing tables.
- **Upload** `POST /api/progress-photos`: raw image bytes as the body, metadata (`takenAt`, `note`) as Zod-validated query params.
- **List** `GET /api/progress-photos`: own photos only, newest first, metadata only.
- **Serve** `GET /api/progress-photos/[id]/image`: the only way bytes leave the box.
- **Delete** `DELETE /api/progress-photos/[id]`: row + file, tolerant of an already-missing file.
- **UI**: a "Progress photos" card on the progress page - upload with optional date/note, thumbnail gallery with per-photo delete (confirm), a before/after side-by-side compare, and an empty state.
- **Self-hosting**: files live under `UPLOADS_DIR` (default `./uploads`, gitignored); documented in the README; the prod Docker deployment pre-creates `/app/uploads` owned by the app user and mounts a named volume so photos survive rebuilds.

## Security controls (file upload is a hostile surface)

- **Magic-byte allowlist**: the stored type is decided by sniffing the first bytes (JPEG `FF D8 FF`, PNG 8-byte signature, WebP `RIFF....WEBP`); only jpeg/png/webp are accepted, and the client `Content-Type` header is ignored entirely (415 otherwise). GIF/PDF/SVG/text/truncated headers are rejected.
- **Streaming size cap**: the 8 MiB cap is enforced WHILE reading the body (`readBodyBytesWithCap`, a byte-level refactor of the existing `readBodyWithCap` with identical text behavior), so an attacker cannot balloon memory before validation - 413 mid-read.
- **Ownership-scoped serving**: not-found and not-owned both answer 404 (no existence leak); images are served with the stored sniffed mime, `X-Content-Type-Options: nosniff`, `Content-Disposition: inline`, and `Cache-Control: private, no-store`. The uploads dir is never exposed as a static path.
- **Non-executable local storage**: files are written mode `0o600` under `<UPLOADS_DIR>/progress-photos/<userId>/<photoId>.<ext>`; stored paths are relative and re-resolved with a containment check so even a corrupted DB value cannot escape the uploads dir.
- **Postgres-safe dates**: `takenAt` is bounded to years 1..9999 (same guard as the backup import), so a hostile date is a clean 400, not a Prisma 500.
- **Rollback on failure**: if the DB write fails after the file was written, the file is deleted again.

## How I tested

`bash scripts/verify.sh --full` passes:

- prisma generate, lint, typecheck: pass
- unit tests: 875 passed (81 files) - includes new sniffing + schema suites
- production build: pass
- integration tests: 220 passed (24 files) - includes the new `progress-photos-route` suite: valid JPEG/PNG/WebP uploads (row + file + 0o600 mode asserted), oversize 413, wrong/disguised type 415, bad metadata 400, and the ownership boundary on serve/delete/list (user B gets 404, rows/files untouched)
- E2E: 17 passed - includes a new spec uploading a real 1x1 PNG on the progress page, asserting the thumbnail renders through the ownership-scoped route, then deleting it

Note: the E2E tier inside the first `--full` invocation failed for an environmental reason - a concurrent verify run from another loop tick truncated the shared test database on :5434 mid-run. With the environment quiet, the identical tier command (`npm run test:e2e`) passes 17/17 in a single invocation; every other tier was green in the original `--full` run.

Not included (deliberate): photos are not part of the JSON backup export (they are files, not rows); the README documents backing up the uploads dir alongside the database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
