### PR TITLE
docs: write up the progress-photos batch (#281) + localization adoption (#272), lesson L16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Progress photos alongside your body metrics: upload a photo (JPEG, PNG or
+  WebP) and compare any two side by side to see change over time, on the
+  Progress page. Storage is local-only - files live under a configurable,
+  gitignored `UPLOADS_DIR` on the server and are served solely through an
+  ownership-scoped route, never a public static path. Every upload is validated
+  by its magic bytes (not the client's declared content-type), capped in size
+  during a streamed read, and written non-executable. No cloud, no third party.
+- Interface localization: an extensible message-catalog system
+  (`messages/<locale>`) with English and Russian across the app's screens; an
+  unknown locale falls back to English.
 - Aerobic decoupling (HR drift) on an imported cardio session: the history
   detail page now shows how much your pace-per-heartbeat efficiency faded
   between the first and second half of a run or ride, with a plain-language
@@ -293,5 +303,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mapped the popover color token so dropdown menus render opaque instead of
   transparent.
 - Used a literal `DATABASE_URL` in the E2E CI job environment.
+
+### Security
+
+- Session cookies are now `Secure` by default in production; self-hosting over
+  plain HTTP requires an explicit `SESSION_COOKIE_SECURE=false` opt-out.
 
 [Unreleased]: https://github.com/Julien-Au/gymcoach/commits/main

--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ on your own key - all self-hosted.
   navigation and superset-aware rest.
 - **Readiness check-in** - an optional pre-session soreness/readiness prompt that
   auto-regulates the suggested load and says why it held or dropped.
-- **Quality-of-life** - kilograms or pounds per user, multi-user with strict
-  per-user data isolation, and an installable PWA with offline logging.
+- **Quality-of-life** - kilograms or pounds per user, an interface in English or
+  Russian (extensible message catalogs), multi-user with strict per-user data
+  isolation, and an installable PWA with offline logging.
 
 ### Track progress
 
@@ -338,6 +339,8 @@ than CI reaching in to a small VPS.
       session attached)
 - [x] Free-text (AI-parsed) set logging (opt-in "Parse with AI" fills the set
       form from plain language; you confirm before it logs)
+- [x] Progress photos (local-only upload with side-by-side compare)
+- [x] Interface localization (English and Russian, extensible message catalogs)
 
 ## Contributing
 

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -1876,3 +1876,55 @@ model-routing directive).
 **Deferred to human.** The #272-#276 fork stack (human vetting + re-file if any idea is
 worth adopting). Nothing else.
 
+---
+
+## 2026-07-22 - Progress photos, local-only (#269 -> #281), and a human-directed fork adoption (#272)
+
+**Context.** Maintainer tick. Backlog held one actionable, trust-gated issue: #269
+(author JulienAu) - "Progress photos alongside body metrics, local storage, no cloud."
+The five open PRs (#272-#276) were all authored by `SHAREN`, a non-collaborator outside the
+allowlist, so under the ship trust gate none was auto-shipped by the loop.
+
+**Decided + shipped.** #269 implemented and merged as **#281** (squash `53ff6e2`). It is a
+file-upload SECURITY SURFACE, so the reinforced controls were applied end to end: additive
+`ProgressPhoto` model + additive migration (`20260722100000_add_progress_photo`); a raw-body
+upload route that enforces an 8 MiB cap DURING a streamed read (new `readBodyBytesWithCap` in
+`lib/api.ts`, with `readBodyWithCap` refactored to delegate, behavior-identical); a magic-byte
+image sniffer as the SOLE type authority (JPEG/PNG/WebP only - client content-type is never
+trusted); ownership-scoped list/serve/delete routes returning an identical 404 for
+not-found and not-owned (no existence oracle); files written `0o600` under a gitignored,
+configurable `UPLOADS_DIR`, served only through the ownership route (never a static path);
+path containment (`resolveInsideStorageDir`) on every read/write/delete. Tests at every layer
+(sniffer unit + hostile buffers; integration for oversize/415/400/ownership/on-disk state;
+an E2E upload-and-see-it flow). Full local gate `verify.sh --full` green; five green CI checks.
+A fresh rollback baseline `autonomy-baseline-2026-07-22` was tagged before the migration merge.
+
+**Challenged.** Two INDEPENDENT Opus lenses (author was a Fable dev tick, so neither reviewer
+graded its own homework): a correctness/does-it-work lens and a security lens. Both returned
+READY with zero blocking findings; each independently raised the same non-blocking nit (DELETE
+removes the row before the file, so a non-ENOENT `rm` failure would orphan the file) plus minor
+hardening (realpath containment, dir mode `0o700`). Folded into follow-up **#282**, not blocked.
+
+**Human-directed fork adoption (#272).** During this run a CONCURRENT loop session (separate
+checkout) hardened and merged fork PR **#272** (`SHAREN`, `isCrossRepository`, non-collaborator)
+into `main` - "extensible localization + Russian," plus a `Secure`-by-default session-cookie
+hardening (`SESSION_COOKIE_SECURE=false` opt-out) and a from-template route reuse fix. The
+autonomous ship gate FORBIDS the loop merging a fork / non-allowlisted author's PR even on green
+CI, so this tick stopped and surfaced it to the operator rather than acting on it. The operator
+confirmed in-session that the localization adoption was INTENDED (a human-in-the-loop decision),
+so #272 is kept and documented as an authorized exception, not a breach. Recorded so the
+allowlist gate's meaning stays clear: the loop still may not self-merge forks; a human may.
+
+**Infra observation -> #283.** The two concurrent `verify.sh --full` runs contended on the
+SHARED test Postgres (:5434) and dev port (:3031): one run's `TRUNCATE ... CASCADE` reset the
+DB mid-run, producing a spurious E2E failure that was green on an isolated re-run. This is the
+infra twin of L15 (isolated worktrees, but shared test DB/port). Filed #283 (serialize or
+isolate the shared infra); interim rule recorded as lesson L16.
+
+**One metric.** Accepted-change rate this batch (loop-authored): 1 merged / 0 abandoned (#281).
+Docs PR for this write-up separate. Implementing-tick token spend: not recorded (dev tick was
+Fable per the model-routing directive). #272 is a concurrent session's work, not counted here.
+
+**Deferred to human.** #282 (photo-storage hardening) and #283 (shared-infra serialization) are
+filed for a later tick. The remaining SHAREN PRs #273-#276 still await human vetting.
+

--- a/docs/loops/lessons.md
+++ b/docs/loops/lessons.md
@@ -205,3 +205,21 @@ Format per entry: trigger/evidence, the lesson (actionable), and **Status** = `g
   concurrent dev/ship ticks get isolated `git worktree`s; without isolation, serialize
   same-checkout ticks. Recovery when a commit still lands on `main`: revert forward (never
   force-push shared history), then re-ship via a proper PR.
+
+### L16 - Isolated worktrees are not enough: the shared test Postgres (:5434) and dev port (:3031) also need a lock
+- **Trigger:** 2026-07-22 batch. Two loop sessions ran `bash scripts/verify.sh --full` at the
+  same time from SEPARATE git worktrees (so L15 was satisfied - no shared checkout). They still
+  collided on shared INFRA: both point at the one test Postgres on host port 5434 and both bind
+  the dev/E2E server on 3031. One run's `TRUNCATE ... CASCADE` reset the DB while the other was
+  mid-suite, and the port was contended, yielding a spurious E2E failure that was green on an
+  isolated re-run.
+- **Lesson:** worktree isolation fixes the git-state race (L15) but not the runtime-infra race.
+  The integration/E2E tiers assume single-tenant ownership of :5434 and :3031; two concurrent
+  `--full` runs violate that assumption and corrupt each other non-deterministically. The fix is
+  structural (a lock around those tiers, or a per-run unique DB name + free port), not "remember
+  not to overlap."
+- **Status:** graduated -> filed **#283** to serialize-or-isolate the shared test infra. INTERIM
+  rule until #283 lands: the orchestrator must not run two `verify.sh --full` invocations against
+  :5434/:3031 concurrently - serialize them (a green isolated re-run of the failed tier is the
+  tell that a red was this contention, not a regression; acknowledge the actual failing step
+  before re-planning, per L2).

--- a/docs/loops/review-digest.md
+++ b/docs/loops/review-digest.md
@@ -300,3 +300,38 @@ captured screenshot set (home/progress/generator/catalog + the 4 flow GIFs), so 
 due for it. The recorded GIFs (dated 2026-06-12) now lag several feature batches; none of
 the new cardio/import work is a clip scenario, so this is noted as lag, not a blocker for a
 docs tick - a periodic re-record is due soon.
+
+---
+
+## 2026-07-22 - progress photos (#281) + a human-directed fork adoption (#272)
+
+Merged since the last digest: **#281** (progress photos, loop-authored) and **#272**
+(localization + a security hardening, a concurrent session's fork adoption confirmed by the
+operator). Read these first, highest risk x impact:
+
+1. **#272 - the security-relevant slice of the fork adoption.** `gh pr diff 272`. This is
+   EXTERNAL code (author `SHAREN`, a fork) merged by a concurrent session and kept by operator
+   decision - so it deserves your eyes more than loop-authored work, not less. Focus on the two
+   files that are not translation strings: `lib/auth.ts` (session cookies now `Secure` by
+   default in production, with a `SESSION_COOKIE_SECURE=false` opt-out - confirm the opt-out is
+   the only escape hatch and that HTTP self-hosters get a clear default) and
+   `app/api/programs/from-template/route.ts` (rerouted through `buildProgramFromGenerated` so
+   instantiating a template can no longer overwrite user-authored exercise metadata - confirm
+   that reuse is faithful). The `messages/en|ru/*` catalogs are low-risk string data.
+2. **#281 - the file-upload surface.** `gh pr diff 281`. Highest intrinsic risk of the two by
+   design (a new upload endpoint + local file storage + an additive migration). Two independent
+   skeptics (correctness + security) already returned READY, but if you read one loop diff this
+   batch, read this: the sniffer (`lib/progress-photo.ts`, magic-byte allowlist as sole type
+   authority + `resolveInsideStorageDir` containment), the capped streamed read and 404-no-oracle
+   ownership routes (`app/api/progress-photos/**`), and the additive migration. Non-blocking
+   hardening is tracked in #282.
+
+**Skim:** this write-up (CHANGELOG Added: progress photos + localization, Security: cookie
+default; README features/roadmap; lesson L16; autonomy-log). The remaining SHAREN PRs
+#273-#276 are untrusted and NOT merged - do not review them as loop work; they await human
+vetting.
+
+**Media note:** the Progress page gained a photos card, but it renders an empty state until
+demo photos are seeded (`scripts/seed-demo-history.ts` has none yet), so no screenshot re-shoot
+is worthwhile until the demo seed carries a couple of photos - noted as a small demo-media
+follow-up, within the staleness cap.


### PR DESCRIPTION
Documents the progress-photos batch and keeps the self-maintaining narrative current.

## What this documents
- **#281 progress photos** (local-only, no cloud) - CHANGELOG Added + README features/roadmap. The file-upload security surface is called out as the read-first diff in the review digest.
- **#272 localization adoption** - CHANGELOG Added (English/Russian catalogs) + a Security note for the `Secure`-by-default session cookie hardening that shipped with it. This was a concurrent session's fork adoption, kept per an explicit in-session operator decision (a human-in-the-loop exception - the autonomous ship gate still forbids the loop self-merging forks); recorded truthfully as such in the autonomy log.
- **Lesson L16** - isolated git worktrees (L15) do not stop two `verify.sh --full` runs from corrupting the shared test Postgres (:5434) and dev port (:3031). Graduated to follow-up #283 with an interim "serialize concurrent --full runs" rule.
- **Follow-ups filed:** #282 (progress-photo storage hardening from the review nits) and #283 (shared-infra serialization).

Docs only - no product code touched.

## How I tested
`bash scripts/verify.sh` passed (lint, typecheck, unit, build). Checked the diff for em/en-dashes (none) and verified every CHANGELOG/README claim against merged code on `main`.