### PR TITLE
fix: normalize gym weight arrays and tolerate duplicate gym names on backup import

### DIFF
--- a/app/api/backup/route.ts
+++ b/app/api/backup/route.ts
@@ -21,6 +21,7 @@ import {
 } from '@/lib/cardio';
 import { MAX_SUPERSET_GROUP, MIN_SUPERSET_GROUP } from '@/lib/supersets';
 import { sorenessSchema } from '@/lib/schemas/readiness';
+import { gymWeightListSchema } from '@/lib/schemas/gym';
 
 // ============================================================
 // Backup / Import JSON (LOT 11, completed by issue #168)
@@ -442,15 +443,17 @@ const importSchema = z.object({
     .array(
       z.object({
         name: z.string().trim().min(1).max(80),
-        dumbbellWeights: z.array(z.number().min(0.1).max(5000)).max(200),
-        plateWeights: z.array(z.number().min(0.1).max(5000)).max(200),
-        barWeights: z.array(z.number().min(0.1).max(5000)).max(200),
+        // Same normalization as the gym API (rounded, deduped, sorted), so an
+        // imported file cannot store a weight array the UI would never write.
+        dumbbellWeights: gymWeightListSchema,
+        plateWeights: gymWeightListSchema,
+        barWeights: gymWeightListSchema,
         exerciseConfigs: z
           .array(
             z.object({
               exerciseName: z.string().max(120),
               isAvailable: z.boolean(),
-              weightOptions: z.array(z.number().min(0.1).max(5000)).max(200),
+              weightOptions: gymWeightListSchema,
             }),
           )
           .max(2000),
@@ -587,9 +590,13 @@ export async function POST(req: Request) {
         }
 
         // 4. Saved gyms are recreated after exercises so per-exercise
-        // availability can be linked by exercise name.
+        // availability can be linked by exercise name. Gym names are unique
+        // per user, so a hand-edited file carrying the same name twice would
+        // abort the whole restore: keep the first occurrence and skip the
+        // rest instead of failing.
         const gymIdByName = new Map<string, string>();
         for (const gym of payload.gyms ?? []) {
+          if (gymIdByName.has(gym.name)) continue;
           const configs = gym.exerciseConfigs.flatMap((config) => {
             const exerciseId = exerciseIdByName.get(config.exerciseName);
             return exerciseId

--- a/lib/schemas/gym.test.ts
+++ b/lib/schemas/gym.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { gymCreateSchema } from '@/lib/schemas/gym';
+import { gymCreateSchema, gymWeightListSchema } from '@/lib/schemas/gym';
 
 describe('gym schemas', () => {
   it('normalizes duplicate and unsorted inventory values', () => {
@@ -14,5 +14,13 @@ describe('gym schemas', () => {
 
   it('rejects non-positive inventory values', () => {
     expect(gymCreateSchema.safeParse({ name: 'Gym', dumbbellWeights: [0] }).success).toBe(false);
+  });
+});
+
+describe('gymWeightListSchema', () => {
+  // Shared with the backup restore path (issue #286), which must store the
+  // same shape as the gym API.
+  it('rounds to two decimals, dedupes and sorts', () => {
+    expect(gymWeightListSchema.parse([20, 10, 12.499, 10])).toEqual([10, 12.5, 20]);
   });
 });

--- a/lib/schemas/gym.ts
+++ b/lib/schemas/gym.ts
@@ -1,6 +1,9 @@
 import { z } from 'zod';
 
-const weightList = z
+// Shared by the gym API and the backup restore path: any weight array that
+// reaches the database is rounded to 2 decimals, deduped and sorted ascending,
+// so a hand-edited or legacy file cannot store a shape the UI never produces.
+export const gymWeightListSchema = z
   .array(z.coerce.number().min(0.1).max(5000))
   .max(200)
   .transform((values) =>
@@ -10,14 +13,14 @@ const weightList = z
 export const gymExerciseConfigSchema = z.object({
   exerciseId: z.string().min(1),
   isAvailable: z.boolean().default(true),
-  weightOptions: weightList.default([]),
+  weightOptions: gymWeightListSchema.default([]),
 });
 
 export const gymCreateSchema = z.object({
   name: z.string().trim().min(1).max(80),
-  dumbbellWeights: weightList.default([]),
-  plateWeights: weightList.default([]),
-  barWeights: weightList.default([]),
+  dumbbellWeights: gymWeightListSchema.default([]),
+  plateWeights: gymWeightListSchema.default([]),
+  barWeights: gymWeightListSchema.default([]),
   exerciseConfigs: z.array(gymExerciseConfigSchema).max(2000).default([]),
   makeActive: z.boolean().default(false),
 });

--- a/tests/integration/backup-route.test.ts
+++ b/tests/integration/backup-route.test.ts
@@ -614,3 +614,74 @@ describe('POST /api/backup - malformed and oversized input (issue #168)', () => 
     expect(await db.bodyweightEntry.count({ where: { userId: user.id } })).toBe(0);
   });
 });
+
+describe('POST /api/backup - gym normalization on import (issue #286)', () => {
+  it('normalizes gym weight arrays and skips duplicate gym names instead of failing', async () => {
+    const user = await db.user.create({
+      data: { email: 'gyms@test.dev', passwordHash: 'x' },
+    });
+    actAs(user.id);
+
+    // Hand-edited file: unsorted / duplicated / over-precise weights, and the
+    // same gym name twice (which the @@unique([userId, name]) constraint would
+    // otherwise reject, aborting the whole restore).
+    const res = await postBackup(
+      jsonReq({
+        payload: {
+          version: 3,
+          profile: { activeGymName: 'Home' },
+          exercises: [
+            {
+              name: 'Bench Press',
+              muscleGroup: 'CHEST',
+              category: 'COMPOUND',
+              defaultRestSec: 120,
+            },
+          ],
+          programs: [],
+          sessions: [],
+          gyms: [
+            {
+              name: ' Home ',
+              dumbbellWeights: [20, 10, 12.499, 10],
+              plateWeights: [],
+              barWeights: [20],
+              exerciseConfigs: [
+                {
+                  exerciseName: 'Bench Press',
+                  isAvailable: true,
+                  weightOptions: [60, 40, 60],
+                },
+              ],
+            },
+            {
+              name: 'Home',
+              dumbbellWeights: [5],
+              plateWeights: [],
+              barWeights: [],
+              exerciseConfigs: [],
+            },
+          ],
+        },
+        confirmReplace: true,
+      }),
+    );
+    expect(res.status).toBe(200);
+
+    const gyms = await db.gym.findMany({
+      where: { userId: user.id },
+      include: { exerciseConfigs: true },
+    });
+    expect(gyms).toHaveLength(1);
+    const gym = gyms[0]!;
+    // First occurrence wins, with the same normalization the gym API applies.
+    expect(gym.name).toBe('Home');
+    expect(gym.dumbbellWeights).toEqual([10, 12.5, 20]);
+    expect(gym.barWeights).toEqual([20]);
+    expect(gym.exerciseConfigs[0]!.weightOptions).toEqual([40, 60]);
+
+    // The active gym still resolves to the surviving row.
+    const profile = await db.user.findUnique({ where: { id: user.id } });
+    expect(profile?.activeGymId).toBe(gym.id);
+  });
+});


### PR DESCRIPTION
The backup restore path stored gym weight arrays exactly as they appeared in the file, while `gymCreateSchema` rounds, dedupes and sorts them - so an imported gym could hold a shape the UI never writes. Worse, a backup carrying two gyms with the same name aborted the whole restore transaction on `@@unique([userId, name])`.

## Changes
- `lib/schemas/gym.ts`: export the shared `gymWeightListSchema` (round to 2 decimals, dedupe, sort) that `gymCreateSchema` already used.
- `app/api/backup/route.ts`: parse `dumbbellWeights` / `plateWeights` / `barWeights` / `exerciseConfigs[].weightOptions` with that same schema on import.
- `app/api/backup/route.ts`: keep the first occurrence of a gym name and skip later duplicates instead of failing the restore. `activeGymName` still resolves to the surviving row.

Closes #286

## How I tested
- New integration test `POST /api/backup - gym normalization on import (issue #286)`: a payload with unsorted / duplicated / over-precise weights and the same gym name twice restores with 200, one gym, normalized arrays, and the active gym pointing at it. Confirmed it reproduces the bug: with the fix reverted the same test gets a 409.
- New unit test for `gymWeightListSchema` in `lib/schemas/gym.test.ts`.
- `bash scripts/verify.sh` passed (prisma generate + lint + typecheck + unit + build).
- `npm run test:integration -- tests/integration/backup-route.test.ts` -> 11 passed, against the test Postgres on :5434.