### PR TITLE
feat: harden progress-photo local storage

### DIFF
--- a/app/api/progress-photos/[id]/route.ts
+++ b/app/api/progress-photos/[id]/route.ts
@@ -9,9 +9,10 @@ interface Params {
 
 // DELETE /api/progress-photos/[id] : remove one photo (row + file).
 // Ownership-scoped: a photo that does not exist and a photo owned by another
-// user both answer 404, so the route leaks no existence information. The row
-// is deleted first (the source of truth); a missing file on disk is tolerated
-// so a half-cleaned uploads dir cannot wedge deletion.
+// user both answer 404, so the route leaks no existence information. The file
+// is unlinked BEFORE the row (issue #282): a missing file is tolerated, but any
+// other unlink failure (EACCES, EIO) must leave the row in place, so the photo
+// stays listed and retryable instead of orphaning bytes no row points at.
 export async function DELETE(_req: Request, props: Params) {
   const params = await props.params;
   try {
@@ -23,8 +24,8 @@ export async function DELETE(_req: Request, props: Params) {
       throw new ApiError(404, 'Photo not found.');
     }
 
-    await db.progressPhoto.delete({ where: { id: photo.id } });
     await deletePhotoFile(photo.storagePath);
+    await db.progressPhoto.delete({ where: { id: photo.id } });
     return NextResponse.json({ ok: true });
   } catch (err) {
     return handleApiError(err);

--- a/lib/progress-photo.test.ts
+++ b/lib/progress-photo.test.ts
@@ -1,9 +1,15 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterAll, beforeAll } from 'vitest';
+import { mkdtemp, mkdir, rm, stat, symlink } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import {
+  deletePhotoFile,
   extensionForMime,
   MAX_PROGRESS_PHOTO_BYTES,
   photoRelativePath,
+  progressPhotoStorageDir,
   sniffImageType,
+  writePhotoFile,
 } from './progress-photo';
 
 // Builders for the accepted signatures, padded with arbitrary payload bytes
@@ -98,5 +104,64 @@ describe('photoRelativePath', () => {
 describe('MAX_PROGRESS_PHOTO_BYTES', () => {
   it('is 8 MiB', () => {
     expect(MAX_PROGRESS_PHOTO_BYTES).toBe(8 * 1024 * 1024);
+  });
+});
+
+
+// Storage containment and file permissions (issue #282). These touch a scratch
+// uploads dir; nothing outside it is created or read.
+describe('photo file storage', () => {
+  let scratch = '';
+  const prevUploadsDir = process.env.UPLOADS_DIR;
+
+  beforeAll(async () => {
+    scratch = await mkdtemp(path.join(os.tmpdir(), 'gymcoach-photo-storage-'));
+    process.env.UPLOADS_DIR = path.join(scratch, 'uploads');
+  });
+
+  afterAll(async () => {
+    if (prevUploadsDir === undefined) delete process.env.UPLOADS_DIR;
+    else process.env.UPLOADS_DIR = prevUploadsDir;
+    if (scratch) await rm(scratch, { recursive: true, force: true });
+  });
+
+  it('writes the file 0o600 and its per-user dir 0o700', async () => {
+    const rel = photoRelativePath('user-1', 'photo-1', 'image/jpeg');
+    await writePhotoFile(rel, Uint8Array.from([0xff, 0xd8, 0xff]));
+
+    const abs = path.join(progressPhotoStorageDir(), rel);
+    expect((await stat(abs)).mode & 0o777).toBe(0o600);
+    expect((await stat(path.dirname(abs))).mode & 0o777).toBe(0o700);
+  });
+
+  it('tightens a per-user dir left behind with looser permissions', async () => {
+    const dir = path.join(progressPhotoStorageDir(), 'user-legacy');
+    await mkdir(dir, { recursive: true, mode: 0o755 });
+
+    await writePhotoFile(
+      photoRelativePath('user-legacy', 'photo-2', 'image/png'),
+      Uint8Array.from([0x89, 0x50, 0x4e, 0x47]),
+    );
+    expect((await stat(dir)).mode & 0o777).toBe(0o700);
+  });
+
+  it('refuses a stored path that escapes the uploads dir', async () => {
+    await expect(writePhotoFile('../escaped.jpg', new Uint8Array(1))).rejects.toThrow(
+      /escapes the uploads dir/,
+    );
+    await expect(deletePhotoFile('/etc/passwd')).rejects.toThrow(/escapes the uploads dir/);
+  });
+
+  it('refuses a path whose directory is a symlink pointing outside', async () => {
+    const outside = path.join(scratch, 'outside');
+    await mkdir(outside, { recursive: true });
+    await mkdir(progressPhotoStorageDir(), { recursive: true });
+    await symlink(outside, path.join(progressPhotoStorageDir(), 'linked-user'));
+
+    // Textually inside the uploads dir, really not: only the realpath check
+    // catches this one.
+    await expect(
+      writePhotoFile('linked-user/photo-3.jpg', new Uint8Array(1)),
+    ).rejects.toThrow(/escapes the uploads dir/);
   });
 });

--- a/lib/progress-photo.ts
+++ b/lib/progress-photo.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 // ============================================================
@@ -83,32 +83,64 @@ export function photoRelativePath(
   return path.join(userId, `${photoId}.${extensionForMime(mime)}`);
 }
 
+// Real path of the deepest component of `target` that exists on disk. A path
+// being written for the first time has no realpath of its own, so containment
+// is checked against the nearest existing ancestor - which is where a symlink
+// would have to sit to redirect the write.
+async function realPathOfNearestExisting(target: string): Promise<string> {
+  let current = target;
+  for (;;) {
+    try {
+      return await realpath(current);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      const parent = path.dirname(current);
+      if (parent === current) return current; // filesystem root
+      current = parent;
+    }
+  }
+}
+
 // Defense-in-depth: resolve a stored relative path against the storage dir
-// and refuse anything that escapes it (absolute paths, ..-traversal).
-function resolveInsideStorageDir(relPath: string): string {
+// and refuse anything that escapes it (absolute paths, ..-traversal). The
+// textual check is followed by a symlink-aware one (issue #282): path.resolve
+// normalizes text only, so a symlinked component would still point outside
+// the uploads dir. Not exploitable today - planting one inside the uploads
+// dir already requires arbitrary write - but it keeps containment true for
+// any future feature that lets a user influence a stored path.
+async function resolveInsideStorageDir(relPath: string): Promise<string> {
   const dir = progressPhotoStorageDir();
   const abs = path.resolve(dir, relPath);
   if (abs !== dir && !abs.startsWith(dir + path.sep)) {
     throw new Error('Progress-photo path escapes the uploads dir.');
   }
+  const realDir = await realPathOfNearestExisting(dir);
+  const realAbs = await realPathOfNearestExisting(abs);
+  if (realAbs !== realDir && !realAbs.startsWith(realDir + path.sep)) {
+    throw new Error('Progress-photo path escapes the uploads dir.');
+  }
   return abs;
 }
 
-// Writes the photo bytes, creating the per-user dir as needed. Mode 0o600:
-// owner read/write only, never executable.
+// Writes the photo bytes, creating the per-user dir as needed. Mode 0o600 on
+// the file and 0o700 on its dir: owner-only, never executable. The dir mode is
+// applied with an explicit chmod because mkdir's mode is masked by the process
+// umask and does not touch a dir created by an earlier version.
 export async function writePhotoFile(
   relPath: string,
   bytes: Uint8Array,
 ): Promise<void> {
-  const abs = resolveInsideStorageDir(relPath);
-  await mkdir(path.dirname(abs), { recursive: true });
+  const abs = await resolveInsideStorageDir(relPath);
+  const dir = path.dirname(abs);
+  await mkdir(dir, { recursive: true, mode: 0o700 });
+  await chmod(dir, 0o700);
   await writeFile(abs, bytes, { mode: 0o600 });
 }
 
 // Reads the photo bytes; null when the file is missing on disk (the serving
 // route turns that into a 404 rather than a 500).
 export async function readPhotoFile(relPath: string): Promise<Uint8Array | null> {
-  const abs = resolveInsideStorageDir(relPath);
+  const abs = await resolveInsideStorageDir(relPath);
   try {
     return new Uint8Array(await readFile(abs));
   } catch (err) {
@@ -118,8 +150,9 @@ export async function readPhotoFile(relPath: string): Promise<Uint8Array | null>
 }
 
 // Removes the photo file; a missing file is fine (force: true), so deleting a
-// row whose file is already gone still succeeds.
+// row whose file is already gone still succeeds. Anything else (EACCES, EIO)
+// throws, so the caller can keep the row rather than orphan the file.
 export async function deletePhotoFile(relPath: string): Promise<void> {
-  const abs = resolveInsideStorageDir(relPath);
+  const abs = await resolveInsideStorageDir(relPath);
   await rm(abs, { force: true });
 }

--- a/tests/integration/progress-photos-delete-failure.test.ts
+++ b/tests/integration/progress-photos-delete-failure.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { db } from '@/lib/db';
+import { getCurrentUserId } from '@/lib/auth';
+
+// Delete ordering on the progress-photo route (issue #282): the file is
+// unlinked before its row, so an unlink failure that is NOT "already gone"
+// leaves the row in place. Without that ordering the row would be deleted and
+// the bytes would orphan on disk with nothing pointing at them.
+
+vi.mock('@/lib/auth', () => ({ getCurrentUserId: vi.fn() }));
+const mockUserId = vi.mocked(getCurrentUserId);
+
+// vi.hoisted so the mock function exists before the module factory runs.
+const { deleteFileMock } = vi.hoisted(() => ({ deleteFileMock: vi.fn() }));
+vi.mock('@/lib/progress-photo', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/progress-photo')>();
+  return { ...actual, deletePhotoFile: deleteFileMock };
+});
+
+import { DELETE as deletePhoto } from '@/app/api/progress-photos/[id]/route';
+
+beforeEach(() => {
+  mockUserId.mockReset();
+  deleteFileMock.mockReset();
+});
+
+async function seedPhoto(email: string) {
+  const user = await db.user.create({ data: { email, passwordHash: 'x' } });
+  const photo = await db.progressPhoto.create({
+    data: {
+      userId: user.id,
+      storagePath: `${user.id}/photo.jpg`,
+      mimeType: 'image/jpeg',
+      byteSize: 128,
+      takenAt: new Date('2026-07-01T00:00:00.000Z'),
+    },
+  });
+  return { user, photo };
+}
+
+function req(id: string) {
+  return {
+    request: new Request(`http://test.local/api/progress-photos/${id}`, { method: 'DELETE' }),
+    props: { params: Promise.resolve({ id }) },
+  };
+}
+
+describe('DELETE /api/progress-photos/[id] - file deletion failure (issue #282)', () => {
+  it('keeps the row when unlinking the file fails for a reason other than ENOENT', async () => {
+    const { user, photo } = await seedPhoto('eacces@test.dev');
+    mockUserId.mockResolvedValue(user.id);
+    deleteFileMock.mockRejectedValue(
+      Object.assign(new Error('permission denied'), { code: 'EACCES' }),
+    );
+
+    const { request, props } = req(photo.id);
+    const res = await deletePhoto(request, props);
+
+    expect(res.status).toBe(500);
+    // Still listed, so the user can retry instead of losing track of the file.
+    expect(await db.progressPhoto.findUnique({ where: { id: photo.id } })).not.toBeNull();
+  });
+
+  it('deletes the row once the file is gone', async () => {
+    const { user, photo } = await seedPhoto('ok@test.dev');
+    mockUserId.mockResolvedValue(user.id);
+    deleteFileMock.mockResolvedValue(undefined);
+
+    const { request, props } = req(photo.id);
+    const res = await deletePhoto(request, props);
+
+    expect(res.status).toBe(200);
+    expect(deleteFileMock).toHaveBeenCalledWith(photo.storagePath);
+    expect(await db.progressPhoto.findUnique({ where: { id: photo.id } })).toBeNull();
+  });
+});


### PR DESCRIPTION
Follow-up to #269 / #281: the three non-blocking hardening items the correctness and security reviews raised on the photo storage path.

## Changes
- **Delete ordering** (`app/api/progress-photos/[id]/route.ts`): unlink the file *before* deleting the row. A missing file is still tolerated, but any other unlink failure (EACCES, EIO) now leaves the row in place, so the photo stays listed and retryable instead of orphaning bytes no row points at.
- **Symlink containment** (`lib/progress-photo.ts`): `resolveInsideStorageDir` keeps its textual check and adds a `realpath`-based one against the deepest existing component of the target (a path being written for the first time has no realpath of its own). `path.resolve` normalizes text only, so a symlinked component would previously have passed.
- **Per-user dir mode**: created with `0o700` and an explicit `chmod`, which also tightens a dir left behind at `0o755` by an earlier version. Files stay `0o600`.

Out of scope per the issue: EXIF stripping (needs a native dep) and photo bytes in the JSON backup.

Closes #282

## How I tested
- New unit tests in `lib/progress-photo.test.ts`: file `0o600` / dir `0o700`, a legacy `0o755` dir gets tightened, `..`-escape and absolute paths are refused, and a per-user dir that is a symlink out of the uploads dir is refused (the case only the realpath check catches).
- New integration test `tests/integration/progress-photos-delete-failure.test.ts`: a non-ENOENT unlink failure returns 500 and keeps the row; the happy path still deletes both. Confirmed it reproduces the old behavior - with the ordering reverted, the first case fails.
- `bash scripts/verify.sh --full` passed (lint, typecheck, unit, build, integration on :5434, E2E 17/17). Two intermediate E2E runs tripped the register rate limit (5/min per IP) from running the suite back to back; spaced out, the suite is green - which is issue #283's territory, not this change.