### PR TITLE
docs: write up the #290 + #291 batch and lesson L17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -321,6 +321,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Restoring a backup no longer fails on a file that carries the same saved-gym
+  name twice: the first gym of that name is kept and later duplicates are
+  skipped, instead of the unique-name constraint aborting the whole restore.
+  Imported gym weight arrays are also normalized (rounded, deduped, sorted)
+  exactly as the gym editor does, so a hand-edited file cannot store a shape
+  the app would never write.
 - Neutralized leading formula characters in the CSV history export so
   imported exercise names or notes cannot plant spreadsheet formulas
   (CSV/DDE injection) in an exported file.
@@ -330,6 +336,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Hardened progress-photo storage: deleting a photo now unlinks the file before
+  its row, so an unlink failure other than "already gone" keeps the photo
+  listed instead of orphaning bytes; path containment resolves symlinks
+  (`realpath`) on top of the textual check; and per-user directories are
+  `0o700` (files stay `0o600`), including directories created by an earlier
+  version.
 - Session cookies are now `Secure` by default in production; self-hosting over
   plain HTTP requires an explicit `SESSION_COOKIE_SECURE=false` opt-out.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,14 @@ CI (`.github/workflows/ci.yml`) runs lint, typecheck, unit, integration, build
 and E2E on every PR. The default gate mirrors the fast, DB-free part so a loop
 can catch its own regressions locally.
 
+**The E2E tier is not safely repeatable back to back.** Its specs register users
+through the app's real per-IP rate limit (`register:<ip>`, 5 per 60s), so a
+second `--full` run started within the minute reds on signup redirects
+(`toHaveURL` stuck on `/signup`) or `ECONNRESET` - in specs unrelated to the
+change. A red E2E that names auth/signup after a recent run is that budget, not
+a regression: wait out the window and re-run the tier alone before diagnosing
+(lesson L17; the concurrency twin is L16).
+
 **Fix the code, never the test.** A red gate is fixed at its cause. Deleting or
 skipping a test, loosening an assertion, or silencing an error to get green is
 forbidden - it improves the scoreboard, not the code. A diff that weakens a test

--- a/README.md
+++ b/README.md
@@ -237,8 +237,11 @@ All configuration is done through environment variables. See `.env.example` for 
 Progress photos are stored as plain files on the server's local filesystem,
 under `UPLOADS_DIR` (default `./uploads`, gitignored) - no cloud, no third
 party. Images are served only through an ownership-scoped API route, never as
-a public static path. If you self-host with Docker, mount that directory as a
-volume and include it in your backups alongside the database.
+a public static path. Files are written owner-only (`0o600`) inside per-user
+directories created `0o700`, and every stored path is re-resolved (symlinks
+included) inside the uploads dir before it is read, written or deleted. If you
+self-host with Docker, mount that directory as a volume and include it in your
+backups alongside the database.
 
 ## Testing
 

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -1928,3 +1928,31 @@ Fable per the model-routing directive). #272 is a concurrent session's work, not
 **Deferred to human.** #282 (photo-storage hardening) and #283 (shared-infra serialization) are
 filed for a later tick. The remaining SHAREN PRs #273-#276 still await human vetting.
 
+
+## 2026-07-27 - follow-up batch: #286 -> PR #290, #282 -> PR #291
+
+**What ran.** One interactive `/loop` in dynamic pacing (self-scheduled ticks, no cron), acting
+as the maintainer loop: ship -> implement -> ship -> write up. Backlog was already full (five
+issues filed by the previous batch's reviews), so triage and ideate did not run. Both PRs were
+authored, gated and merged by the loop; both close issues the previous batch's skeptics filed,
+which is the review->issue->PR->merge circuit closing on itself for the first time.
+
+**Green gate.** #290: fast gate + the backup integration suite (11 passed). #291: `--full`,
+including E2E. In both cases the new test was first confirmed to FAIL against the unfixed code
+(409 on the duplicate-gym restore; row deleted despite the unlink error), so the tests are
+regression tests, not decoration.
+
+**Feedback-blindness check (L2).** The `--full` gate went red twice on E2E specs unrelated to the
+change, and the tempting read was "flaky infra, re-run". The actual cause was self-inflicted: the
+suite's signups share one per-IP register bucket (5/min), and re-running to confirm the flake is
+what starved the next run. Acknowledged the failing step before re-planning, spaced the run out,
+got 17/17, and CI passed first try on both PRs. Graduated as lesson **L17** into `CLAUDE.md`, with
+**#292** filed to stop the specs sharing one IP.
+
+**One metric.** Accepted-change rate this batch: 2 merged / 0 abandoned (#290, #291), plus this
+docs PR. No reverts. Implementing-tick token spend: not recorded separately (both ticks ran in the
+same interactive session as the shipping and write-up ticks).
+
+**Deferred.** #283 (serialize the shared test infra), #285 (plate-calculator fallback inventory -
+needs a product call, so it stays for a human), #287 (MCP hardening follow-ups), #292 (E2E signup
+IPs), and the demo-media re-shoot once the demo seed carries progress photos.

--- a/docs/loops/lessons.md
+++ b/docs/loops/lessons.md
@@ -223,3 +223,19 @@ Format per entry: trigger/evidence, the lesson (actionable), and **Status** = `g
   :5434/:3031 concurrently - serialize them (a green isolated re-run of the failed tier is the
   tell that a red was this contention, not a regression; acknowledge the actual failing step
   before re-planning, per L2).
+
+### L17 - The E2E tier is not repeatable back to back: the app's own register rate limit reds unrelated specs
+- **Trigger:** 2026-07-27 batch (#282). One tick ran `verify.sh --full` and then, to confirm a
+  flake, re-ran the E2E tier twice more within a couple of minutes. Different specs failed each
+  time (`measurements` on `ECONNRESET`, then `auth` + `deload` stuck on `/signup`) while the
+  change under test touched only progress-photo storage. CI, running the suite once, was green
+  on the first try.
+- **Lesson:** the E2E specs sign up through the real API, which enforces `register:<ip>` at 5 per
+  60s. A suite run consumes most of that budget, so a second run inside the window starves the
+  specs that sign up through the UI (the ones that cannot set a distinct `x-forwarded-for`). This
+  is self-inflicted: re-running "to check the flake" is exactly what causes the next red, and the
+  moving target of which spec fails is the tell. Distinct from L16 - that is two CONCURRENT runs
+  contending on shared infra; this is one session running SEQUENTIALLY too fast.
+- **Status:** graduated -> `CLAUDE.md` (green-gate section) now states the tier is not safely
+  repeatable inside a minute and how to read an auth/signup red after a recent run. Filed **#292**
+  to make the UI-signup specs use a per-spec client IP so the suite stops sharing one bucket.

--- a/docs/loops/review-digest.md
+++ b/docs/loops/review-digest.md
@@ -335,3 +335,33 @@ vetting.
 demo photos are seeded (`scripts/seed-demo-history.ts` has none yet), so no screenshot re-shoot
 is worthwhile until the demo seed carries a couple of photos - noted as a small demo-media
 follow-up, within the staleness cap.
+
+## 2026-07-27 - backup gym import (#290) + progress-photo storage hardening (#291)
+
+Merged since the last digest: **#290** and **#291** (both loop-authored, from follow-up issues
+the previous batch's reviews filed), plus **#288** (docs thanking the fork contributor) and
+**#289** (CI: more headroom for the Docker smoke job on a cold cache). Read these first:
+
+1. **#291 - the file-storage security surface.** `gh pr diff 291`. It changes the containment
+   check that every photo read, write and delete goes through (`lib/progress-photo.ts`): the
+   textual `startsWith` check now has a `realpath` companion resolved against the deepest
+   existing component of the target. Read it for the case where the storage dir itself does not
+   exist yet (containment then compares two identical ancestors - intended, nothing to escape)
+   and for the delete-ordering swap in `app/api/progress-photos/[id]/route.ts`, which trades
+   "row gone, file orphaned" for "file gone, row retryable".
+2. **#290 - the restore path.** `gh pr diff 290`. Backup restore runs in one transaction over a
+   user's whole dataset, so a change to what it accepts is worth a look: gym weight arrays are
+   now parsed with the same schema the gym API uses (which also means `z.coerce.number()`, so a
+   numeric string in a hand-edited file is now accepted rather than rejected), and duplicate gym
+   names are skipped instead of aborting the restore. Both are covered by an integration test
+   that was confirmed to fail without the fix.
+
+**Skim:** this write-up (CHANGELOG Fixed + Security, README uploads paragraph, lesson L17, the
+new `CLAUDE.md` note on re-running the E2E tier), #288 and #289.
+
+**Media note:** still no re-shoot. The captured pages HAVE drifted since 2026-06-18 (the catalog
+and logger now show exercise technique media, the Progress page has a photos card), so the
+screenshots are the oldest debt in this repo - but the Progress card renders empty until the demo
+seed carries photos, so the shoot is worth doing once, after `scripts/seed-demo-history.ts` seeds
+a couple of demo photos. That is the next media tick, not this one; it is now at the edge of the
+~3-batch staleness cap.


### PR DESCRIPTION
Content loop for the batch that merged today: #290 (backup gym import) and #291 (progress-photo storage hardening), plus #288/#289 which landed after the last write-up.

## Changes
- **CHANGELOG**: one Fixed entry for the duplicate-gym-name restore failure and gym weight normalization; one Security entry for the photo-storage hardening (delete ordering, realpath containment, `0o700` per-user dirs).
- **README**: the operator "Progress photos / uploads" paragraph now states the real on-disk posture (`0o600` files, `0o700` dirs, symlink-resolving containment). No feature/roadmap change - this batch shipped a fix and hardening, not a new capability.
- **CLAUDE.md + lesson L17**: the E2E tier is not safely repeatable inside a minute, because its specs share the app's real `register:<ip>` rate limit (5/60s). This cost two false reds this batch; the note says how to read an auth/signup red after a recent run. Filed #292 to give the UI-signup specs their own client IP.
- **docs/loops/review-digest.md**: prioritized reading list for the batch (#291 first - it changes the containment check every photo read/write/delete goes through; then #290's restore path, including that it now accepts numeric strings via `z.coerce.number()`).
- **docs/loops/autonomy-log.md**: batch entry with the accepted-change metric (2 merged / 0 abandoned) and the feedback-blindness note on the E2E reds.

Intentionally left out: no demo-media re-shoot. The captured pages have drifted (exercise media, photos card) but the Progress card renders empty until `scripts/seed-demo-history.ts` seeds demo photos, so the shoot is worth doing once, next tick - recorded in the digest's media note.

## How I tested
- `bash scripts/verify.sh` passed (docs-only change, but the working agreement is the working agreement).
- Every claim checked against the merged diffs of #290 and #291.