### PR TITLE
fix: give each E2E spec its own client IP so re-runs stop tripping the register rate limit

### DIFF
--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from '@playwright/test';
 
+// Each spec file registers through the app's real per-IP rate limit
+// (register:<ip>, 5 per 60s). A dedicated client IP per file keeps UI signups
+// out of the shared default bucket so back-to-back runs stay green (issue #292).
+test.use({ extraHTTPHeaders: { 'x-forwarded-for': '10.111.1.1' } });
+
 // Auth flow does not require an LLM key, only a migrated database.
 test('a new user can sign up, log out and sign back in', async ({ page }) => {
   const email = `e2e-${Date.now()}@test.dev`;

--- a/tests/e2e/bodyweight.spec.ts
+++ b/tests/e2e/bodyweight.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from '@playwright/test';
 
+// Dedicated client IP so the UI signup does not share the default register
+// rate-limit bucket with other specs (issue #292).
+test.use({ extraHTTPHeaders: { 'x-forwarded-for': '10.111.1.2' } });
+
 // Bodyweight tracking (issue #99): quick-add a measurement on the progress
 // page, see it listed as the current value, then delete it. The card renders
 // even with no training data, so a fresh user is enough.

--- a/tests/e2e/cardio.spec.ts
+++ b/tests/e2e/cardio.spec.ts
@@ -52,7 +52,7 @@ test('a trainee can log a cardio set (duration + distance) in a live session', a
   // unique X-Forwarded-For keeps this spec in its own register rate-limit
   // bucket - the suite's UI signups use up the 5/min per-IP budget.
   const registerRes = await page.request.post('/api/auth/register', {
-    headers: { 'x-forwarded-for': '10.111.0.3' },
+    headers: { 'x-forwarded-for': '10.111.0.13' },
     data: {
       displayName: 'Cardio E2E',
       email: `e2e-cardio-${Date.now()}@test.dev`,

--- a/tests/e2e/deload.spec.ts
+++ b/tests/e2e/deload.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect, type Page } from '@playwright/test';
 
+// Dedicated client IP so the UI signup does not share the default register
+// rate-limit bucket with other specs (issue #292).
+test.use({ extraHTTPHeaders: { 'x-forwarded-for': '10.111.1.3' } });
+
 // One-tap planned deload week (issue #112): the deload recommendation banner
 // gains a "Start a deload week" button; while active the banner shows the end
 // date and an early-exit button. Data is seeded through the authenticated API

--- a/tests/e2e/fit-import.spec.ts
+++ b/tests/e2e/fit-import.spec.ts
@@ -16,7 +16,7 @@ const RECORDS_FIT_B64 =
 
 test('a lifter can import multiple FIT activities at once', async ({ page }) => {
   const registerRes = await page.request.post('/api/auth/register', {
-    headers: { 'x-forwarded-for': '10.111.0.5' },
+    headers: { 'x-forwarded-for': '10.111.0.15' },
     data: {
       displayName: 'FIT E2E',
       email: `e2e-fit-${Date.now()}@test.dev`,

--- a/tests/e2e/goals.spec.ts
+++ b/tests/e2e/goals.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect, type Page } from '@playwright/test';
 
+// Dedicated client IP so the UI signup does not share the default register
+// rate-limit bucket with other specs (issue #292).
+test.use({ extraHTTPHeaders: { 'x-forwarded-for': '10.111.1.4' } });
+
 // Per-exercise target goals (issue #90): set a goal on the progress page,
 // watch the progress bar, reach it, see the achieved badge, remove it.
 // Data is seeded through the authenticated API (the browser context shares

--- a/tests/e2e/gpx-import.spec.ts
+++ b/tests/e2e/gpx-import.spec.ts
@@ -24,7 +24,7 @@ test('a lifter can import a GPX activity as a cardio session', async ({ page }) 
   // register rate-limit bucket (the suite's parallel UI signups use the per-IP
   // 5/min budget).
   const registerRes = await page.request.post('/api/auth/register', {
-    headers: { 'x-forwarded-for': '10.111.0.4' },
+    headers: { 'x-forwarded-for': '10.111.0.14' },
     data: {
       displayName: 'GPX E2E',
       email: `e2e-gpx-${Date.now()}@test.dev`,

--- a/tests/e2e/import.spec.ts
+++ b/tests/e2e/import.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from '@playwright/test';
 
+// Dedicated client IP so the UI signup does not share the default register
+// rate-limit bucket with other specs (issue #292).
+test.use({ extraHTTPHeaders: { 'x-forwarded-for': '10.111.1.5' } });
+
 // Strong CSV import (issue #100): upload an export in settings, check the
 // dry-run preview, confirm, and find the imported session in the history.
 


### PR DESCRIPTION
The five specs that sign up through the UI (auth, bodyweight, deload, goals, import) shared the default `register:<ip>` bucket (5 per 60s), so a second E2E run started inside the same minute went red on unrelated specs (`toHaveURL` stuck on `/signup`, `ECONNRESET` - lesson L17). Each of those files now sets a dedicated `x-forwarded-for` on the browser context via `test.use({ extraHTTPHeaders })`; the app reads it through `clientIp(req)`.

Also dedupes the three client IPs that were accidentally reused across the API-signup specs (gpx-import/supersets on .4, fit-import/supersets on .5, cardio/tcx on .3) - same class of shared-bucket problem.

The register rate limit itself is untouched: the tests stop pretending to be one IP instead of weakening the control.

Closes #292

## How I tested
- `bash scripts/verify.sh` - green
- `bash scripts/verify.sh --full` - green (integration + all 17 E2E specs)
- Immediately re-ran `npm run test:e2e` back to back inside the 60s window: all 17 specs green on the second run (previously red per L17)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018i3bgeAeXBAN5afBhvxW9D