### PR TITLE
docs: write up the E2E client-IP fix (#294) and retire the stale not-repeatable warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -321,6 +321,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The E2E suite is repeatable back to back: each spec file now signs up from its
+  own client IP (`x-forwarded-for`) instead of sharing the default
+  `register:<ip>` bucket, so a second run started inside the rate limit's 60s
+  window no longer reds unrelated specs. The registration rate limit itself is
+  unchanged.
 - Restoring a backup no longer fails on a file that carries the same saved-gym
   name twice: the first gym of that name is kept and later duplicates are
   skipped, instead of the unique-name constraint aborting the whole restore.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,8 +38,9 @@ through the app's real per-IP rate limit (`register:<ip>`, 5 per 60s), but since
 #294 every spec file sends its own `x-forwarded-for`, so no two specs share a
 bucket and a second `--full` run inside the same minute is green (verified 17/17
 on two consecutive runs). Two residual caveats: the guarantee is bounded, not
-unconditional - on CI (`retries: 2`) a spec that flakes can burn up to three
-registers on its own IP, which is the whole budget for that bucket; and #283
+unconditional - on CI (`retries: 2`) a spec that flakes can burn up to three of
+its bucket's five registers, so a flaky run plus a re-run inside the same minute
+can still trip the limit; and #283
 (two concurrent `verify.sh` runs sharing the test Postgres on :5434 and the dev
 server on :3031) is still open and is a different, unrelated race. History:
 lesson L17, resolved by #294; the concurrency twin is L16.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,13 +33,16 @@ CI (`.github/workflows/ci.yml`) runs lint, typecheck, unit, integration, build
 and E2E on every PR. The default gate mirrors the fast, DB-free part so a loop
 can catch its own regressions locally.
 
-**The E2E tier is not safely repeatable back to back.** Its specs register users
-through the app's real per-IP rate limit (`register:<ip>`, 5 per 60s), so a
-second `--full` run started within the minute reds on signup redirects
-(`toHaveURL` stuck on `/signup`) or `ECONNRESET` - in specs unrelated to the
-change. A red E2E that names auth/signup after a recent run is that budget, not
-a regression: wait out the window and re-run the tier alone before diagnosing
-(lesson L17; the concurrency twin is L16).
+**Back-to-back E2E runs are expected green.** The specs still register users
+through the app's real per-IP rate limit (`register:<ip>`, 5 per 60s), but since
+#294 every spec file sends its own `x-forwarded-for`, so no two specs share a
+bucket and a second `--full` run inside the same minute is green (verified 17/17
+on two consecutive runs). Two residual caveats: the guarantee is bounded, not
+unconditional - on CI (`retries: 2`) a spec that flakes can burn up to three
+registers on its own IP, which is the whole budget for that bucket; and #283
+(two concurrent `verify.sh` runs sharing the test Postgres on :5434 and the dev
+server on :3031) is still open and is a different, unrelated race. History:
+lesson L17, resolved by #294; the concurrency twin is L16.
 
 **Fix the code, never the test.** A red gate is fixed at its cause. Deleting or
 skipping a test, loosening an assertion, or silencing an error to get green is

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -1968,7 +1968,7 @@ cause is gone, not because it was inconvenient.
 
 **Green gate.** `verify.sh` green, `verify.sh --full` green. The acceptance criterion was
 measured rather than asserted: a second `npm run test:e2e` started immediately after the first,
-inside the 60s rate-limit window, was green - 17/17 specs on both runs. Before #294 that second
+inside the 60s rate-limit window, was green - 17/17 tests on both runs. Before #294 that second
 run was the reliable way to red the suite.
 
 **Fix the code, not the test - read carefully.** The tempting fix was to raise or disable

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -1956,3 +1956,38 @@ same interactive session as the shipping and write-up ticks).
 **Deferred.** #283 (serialize the shared test infra), #285 (plate-calculator fallback inventory -
 needs a product call, so it stays for a human), #287 (MCP hardening follow-ups), #292 (E2E signup
 IPs), and the demo-media re-shoot once the demo seed carries progress photos.
+
+
+## 2026-08-20 - single-issue batch: #292 -> PR #294 (the loop closes its own lesson)
+
+**What ran.** One maintainer loop: implement -> ship -> write up. The backlog already held the
+issue, so triage and ideate did not run. #292 was filed by the *previous* batch's lesson L17 -
+the loop hitting a failure mode, recording it, filing it, and then fixing it one batch later. The
+interim rule L17 imposed ("wait out the minute before re-running E2E") is now retired because the
+cause is gone, not because it was inconvenient.
+
+**Green gate.** `verify.sh` green, `verify.sh --full` green. The acceptance criterion was
+measured rather than asserted: a second `npm run test:e2e` started immediately after the first,
+inside the 60s rate-limit window, was green - 17/17 specs on both runs. Before #294 that second
+run was the reliable way to red the suite.
+
+**Fix the code, not the test - read carefully.** The tempting fix was to raise or disable
+`register:<ip>` for the test environment. That would have been the forbidden move in the other
+direction: weakening a real product guardrail so the scoreboard goes green. The defect was the
+suite's assumption that every spec may share one client identity, so the specs were fixed and the
+limit was left exactly as users experience it.
+
+**Docs debt paid.** This write-up also retires the stale text the fix invalidated: the `CLAUDE.md`
+green-gate paragraph that described the tier as not repeatable, and lesson L17's open status
+(appended a resolution note rather than rewriting it - lessons are a log, not a claim about the
+present). Both keep the bounded caveat: CI `retries: 2` means one flaky spec can still burn three
+registers on its own IP, and #283 (concurrent runs sharing :5434/:3031) is a different race, still
+open.
+
+**One metric.** Accepted-change rate this batch: 1 merged / 0 abandoned (#294), plus this docs PR.
+No reverts. Implementing-tick token spend: not recorded separately (dev tick was Fable per the
+model-routing directive).
+
+**Deferred.** #283 (serialize or isolate the shared test infra), #285 (plate-calculator fallback
+inventory - needs a product call), #287 (MCP hardening follow-ups), and the demo-media re-shoot
+once the demo seed carries progress photos.

--- a/docs/loops/lessons.md
+++ b/docs/loops/lessons.md
@@ -239,3 +239,13 @@ Format per entry: trigger/evidence, the lesson (actionable), and **Status** = `g
 - **Status:** graduated -> `CLAUDE.md` (green-gate section) now states the tier is not safely
   repeatable inside a minute and how to read an auth/signup red after a recent run. Filed **#292**
   to make the UI-signup specs use a per-spec client IP so the suite stops sharing one bucket.
+- **Resolved by #294 on 2026-08-20.** The root cause (one shared bucket) is gone: the five specs
+  that sign up through the UI now each set a dedicated `x-forwarded-for` via
+  `test.use({ extraHTTPHeaders })`, and three client IPs accidentally reused across API-signup
+  specs were deduped. The rate limit itself was left untouched (fix the code, not the test).
+  Acceptance was measured, not assumed: a second `npm run test:e2e` started immediately after the
+  first, inside the 60s window, was green 17/17 both runs. `CLAUDE.md` now says back-to-back runs
+  are expected green. Residual caveat kept: the guarantee is bounded, not unconditional - on CI
+  (`retries: 2`) one flaky spec can burn up to three registers on its own IP, the whole budget for
+  that bucket. The interim "wait out the minute" rule is retired; **#283** (concurrent runs sharing
+  :5434/:3031, lesson L16) is a different race and is still open.

--- a/docs/loops/lessons.md
+++ b/docs/loops/lessons.md
@@ -246,6 +246,7 @@ Format per entry: trigger/evidence, the lesson (actionable), and **Status** = `g
   Acceptance was measured, not assumed: a second `npm run test:e2e` started immediately after the
   first, inside the 60s window, was green 17/17 both runs. `CLAUDE.md` now says back-to-back runs
   are expected green. Residual caveat kept: the guarantee is bounded, not unconditional - on CI
-  (`retries: 2`) one flaky spec can burn up to three registers on its own IP, the whole budget for
-  that bucket. The interim "wait out the minute" rule is retired; **#283** (concurrent runs sharing
+  (`retries: 2`) one flaky spec can burn up to three of its bucket's five registers, so a flaky
+  run combined with a re-run inside the same minute can still trip the limit. The interim "wait
+  out the minute" rule is retired; **#283** (concurrent runs sharing
   :5434/:3031, lesson L16) is a different race and is still open.

--- a/docs/loops/review-digest.md
+++ b/docs/loops/review-digest.md
@@ -365,3 +365,31 @@ screenshots are the oldest debt in this repo - but the Progress card renders emp
 seed carries photos, so the shoot is worth doing once, after `scripts/seed-demo-history.ts` seeds
 a couple of demo photos. That is the next media tick, not this one; it is now at the edge of the
 ~3-batch staleness cap.
+
+## 2026-08-20 - E2E signup IPs (#294), the pipeline fix that closes lesson L17
+
+One PR merged since the last digest: **#294** (closes #292, filed by the previous batch's own
+lesson L17). It is test infrastructure only - no product code, no schema, no prompts - but it
+touches the **pipeline**, which is the high-priority tier of the rule above, so it is worth one
+read:
+
+1. **#294 - who the E2E suite looks like to the rate limiter.** `gh pr diff 294`. The five specs
+   that sign up through the UI (auth, bodyweight, deload, goals, import) now each set a dedicated
+   `x-forwarded-for` through `test.use({ extraHTTPHeaders })`, and three IPs that had been reused
+   across API-signup specs were deduped. Read it for one thing: the fix moves the *tests* off the
+   shared bucket and leaves `register:<ip>` (5 per 60s) exactly as users experience it - the gate
+   was fixed at the test's assumption, not by loosening the product's limit. Worth knowing that
+   the suite now depends on the app trusting `x-forwarded-for` in the E2E environment.
+
+**Skim:** this write-up (CHANGELOG Fixed, the rewritten `CLAUDE.md` green-gate paragraph, the
+resolution note on lesson L17, autonomy-log entry).
+
+**Caveat to carry:** back-to-back E2E is green now, but bounded - on CI (`retries: 2`) a single
+flaky spec can spend three of its bucket's five registers. And #283 (two concurrent `verify.sh`
+runs contending on :5434/:3031, lesson L16) is untouched and still open; do not read #294 as
+having fixed that one.
+
+**Media note:** nothing user-visible shipped this batch, so no screenshot or clip work is owed by
+it. The pre-existing debt stands unchanged: the captured pages have drifted since 2026-06-18 and
+the re-shoot is still waiting on `scripts/seed-demo-history.ts` seeding a couple of progress
+photos. It is now past the edge of the ~3-batch staleness cap and should be the next media tick.


### PR DESCRIPTION
Write-up for the batch that merged **#294** (closes #292): each E2E spec file now signs up from its own client IP, so the suite stops sharing the default `register:<ip>` bucket and back-to-back runs stay green.

## What this documents

- **CHANGELOG.md** (Fixed): the E2E suite is repeatable back to back; the registration rate limit itself is unchanged.
- **Stale-docs cleanup that #294 invalidated:**
  - `CLAUDE.md` green-gate section previously warned that the E2E tier is not safely repeatable inside a minute - the exact failure #294 fixed. Rewritten to say back-to-back runs are expected green (verified 17/17 on two consecutive runs), keeping the bounded caveat: on CI (`retries: 2`) one flaky spec can burn up to three registers on its own IP, and #283 (concurrent `verify.sh` runs contending on :5434/:3031) is a different, still-open race.
  - `docs/loops/lessons.md` L17 stated the same now-fixed limitation. Lessons are a log, so the entry is kept and a "Resolved by #294 on 2026-08-20" note is appended with the same residual caveat, rather than rewriting history.
- **docs/loops/review-digest.md**: comprehension digest for the batch - one read (`gh pr diff 294`), why it ranks as pipeline work, and the caveat to carry.
- **docs/loops/autonomy-log.md**: batch entry with the accepted-change metric (1 merged / 0 abandoned, no reverts) and the note that #292 was filed by the previous batch's own lesson L17, so the loop closed a failure mode it had recorded itself.

## Not touched

- **README**: this batch changed test infrastructure only; the README makes no claim the fix invalidates, so it is left alone.
- No product code, no demo media (nothing user-visible shipped; the pre-existing screenshot debt is noted in the digest as the next media tick).

## Gate

`bash scripts/verify.sh` passed (prisma generate + lint + typecheck + unit + build). Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018i3bgeAeXBAN5afBhvxW9D