### PR TITLE
fix: harden the MCP endpoint and bound the codex-lb request wait

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,8 +67,9 @@ NEXTAUTH_URL=http://localhost:3030
 # Set this when NEXTAUTH_URL points to a LAN address behind a reverse proxy.
 MCP_PUBLIC_URL=
 # Optional MCP endpoint hardening (issue #287). Comma-separated exact-match
-# allowlists; when either is set the MCP transport enables DNS rebinding
-# protection and CORS echoes only allowlisted origins instead of *.
+# allowlists; setting either enables DNS rebinding protection on the MCP
+# transport. CORS keys off MCP_ALLOWED_ORIGINS alone: when it is set, CORS
+# echoes only allowlisted origins instead of *; hosts-only keeps CORS at *.
 # MCP_ALLOWED_ORIGINS=https://gym.example.com
 # MCP_ALLOWED_HOSTS=gym.example.com,gym.example.com:3030
 NODE_ENV=development

--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,11 @@ NEXTAUTH_URL=http://localhost:3030
 # Public HTTPS origin used when generating ChatGPT connector URLs.
 # Set this when NEXTAUTH_URL points to a LAN address behind a reverse proxy.
 MCP_PUBLIC_URL=
+# Optional MCP endpoint hardening (issue #287). Comma-separated exact-match
+# allowlists; when either is set the MCP transport enables DNS rebinding
+# protection and CORS echoes only allowlisted origins instead of *.
+# MCP_ALLOWED_ORIGINS=https://gym.example.com
+# MCP_ALLOWED_HOSTS=gym.example.com,gym.example.com:3030
 NODE_ENV=development
 # Local dir for user uploads (progress-photo files); gitignored, back it up.
 UPLOADS_DIR=./uploads

--- a/app/mcp/route.ts
+++ b/app/mcp/route.ts
@@ -1,21 +1,15 @@
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
 import { authenticateMcpRequest } from '@/lib/mcp/auth';
+import { corsHeadersFor, mcpCorsPolicyFromEnv } from '@/lib/mcp/cors';
 import { createGymCoachMcpServer } from '@/lib/mcp/server';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-const CORS_HEADERS = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
-  'Access-Control-Allow-Headers':
-    'Content-Type, Authorization, X-GymCoach-Token, MCP-Protocol-Version, MCP-Session-Id, Last-Event-ID',
-  'Access-Control-Expose-Headers': 'MCP-Protocol-Version, MCP-Session-Id',
-};
-
-function withCors(response: Response): Response {
+function withCors(req: Request, response: Response): Response {
   const headers = new Headers(response.headers);
-  for (const [key, value] of Object.entries(CORS_HEADERS)) headers.set(key, value);
+  const cors = corsHeadersFor(mcpCorsPolicyFromEnv(), req.headers.get('origin'));
+  for (const [key, value] of Object.entries(cors)) headers.set(key, value);
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,
@@ -27,6 +21,7 @@ async function handle(req: Request): Promise<Response> {
   const principal = await authenticateMcpRequest(req);
   if (!principal) {
     return withCors(
+      req,
       Response.json(
         { jsonrpc: '2.0', error: { code: -32001, message: 'Unauthorized' }, id: null },
         { status: 401 },
@@ -34,16 +29,27 @@ async function handle(req: Request): Promise<Response> {
     );
   }
 
+  // With an allowlist configured the transport rejects requests whose Host or
+  // Origin header is not allowlisted (DNS rebinding protection); unset keeps
+  // the historical open behavior for existing deployments (issue #287).
+  const { allowedOrigins, allowedHosts } = mcpCorsPolicyFromEnv();
   const transport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator: undefined,
     enableJsonResponse: true,
+    ...(allowedOrigins || allowedHosts
+      ? {
+          enableDnsRebindingProtection: true,
+          ...(allowedHosts ? { allowedHosts } : {}),
+          ...(allowedOrigins ? { allowedOrigins } : {}),
+        }
+      : {}),
   });
   const server = createGymCoachMcpServer({
     principal,
     baseUrl: new URL(req.url).origin,
   });
   await server.connect(transport);
-  return withCors(await transport.handleRequest(req));
+  return withCors(req, await transport.handleRequest(req));
 }
 
 export async function POST(req: Request) {
@@ -58,6 +64,9 @@ export async function DELETE(req: Request) {
   return handle(req);
 }
 
-export async function OPTIONS() {
-  return new Response(null, { status: 204, headers: CORS_HEADERS });
+export async function OPTIONS(req: Request) {
+  return new Response(null, {
+    status: 204,
+    headers: corsHeadersFor(mcpCorsPolicyFromEnv(), req.headers.get('origin')),
+  });
 }

--- a/lib/llm/codex-lb.test.ts
+++ b/lib/llm/codex-lb.test.ts
@@ -80,6 +80,35 @@ describe('CodexLbProvider', () => {
     ).rejects.toMatchObject({ status: 429 });
   });
 
+  it('aborts a hung upstream after the timeout and maps it to a 504', async () => {
+    process.env.CODEX_LB_API_KEY = 'test-key';
+    vi.useFakeTimers();
+    try {
+      // A fetch that never resolves on its own and only rejects when the
+      // provider's timeout fires its abort signal.
+      const fetchMock = vi.fn(
+        (_url: string, init: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init.signal?.addEventListener('abort', () =>
+              reject(new DOMException('This operation was aborted', 'AbortError')),
+            );
+          }),
+      );
+      vi.stubGlobal('fetch', fetchMock);
+
+      const pending = new CodexLbProvider().complete({
+        system: 'S',
+        messages: [{ role: 'user', content: 'x' }],
+      });
+      const assertion = expect(pending).rejects.toMatchObject({ status: 504 });
+      await vi.advanceTimersByTimeAsync(120_000);
+      await assertion;
+      expect((fetchMock.mock.calls[0]![1] as RequestInit).signal).toBeInstanceOf(AbortSignal);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('throws on an empty successful response', async () => {
     process.env.CODEX_LB_API_KEY = 'test-key';
     vi.stubGlobal(

--- a/lib/llm/codex-lb.ts
+++ b/lib/llm/codex-lb.ts
@@ -8,6 +8,11 @@ import {
 const DEFAULT_BASE_URL = 'http://127.0.0.1:8317/v1';
 const DEFAULT_MODEL = 'gpt-5.6-sol';
 const DEFAULT_MAX_TOKENS = 8000;
+// Bounds the wait for response headers so a hung upstream cannot stall the
+// request forever (issue #287). Non-streaming responses only send headers
+// after the full generation, so this must cover a whole completion; the timer
+// is cleared once headers arrive, leaving started streams uncapped.
+const REQUEST_TIMEOUT_MS = 120_000;
 
 interface ResponsesApiContent {
   type?: string;
@@ -99,6 +104,8 @@ export class CodexLbProvider implements LlmProvider {
       throw new LlmError(503, 'CODEX_LB_API_KEY is not configured.');
     }
 
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
     let response: Response;
     try {
       response = await fetch(`${this.baseUrl}/responses`, {
@@ -108,12 +115,21 @@ export class CodexLbProvider implements LlmProvider {
           Authorization: `Bearer ${this.apiKey}`,
         },
         body: JSON.stringify(this.buildBody(req, stream)),
+        signal: controller.signal,
       });
     } catch (error) {
+      if (controller.signal.aborted) {
+        throw new LlmError(
+          504,
+          `codex-lb timed out after ${Math.round(REQUEST_TIMEOUT_MS / 1000)}s.`,
+        );
+      }
       throw new LlmError(
         502,
         `Network failure to codex-lb: ${error instanceof Error ? error.message : 'unknown'}`,
       );
+    } finally {
+      clearTimeout(timer);
     }
 
     if (!response.ok) {

--- a/lib/mcp/cors.test.ts
+++ b/lib/mcp/cors.test.ts
@@ -57,5 +57,7 @@ describe('corsHeadersFor', () => {
     expect(corsHeadersFor(policy, 'https://evil.test')['Access-Control-Allow-Origin']).toBeUndefined();
     expect(corsHeadersFor(policy, null)['Access-Control-Allow-Origin']).toBeUndefined();
     expect(corsHeadersFor(policy, null)['Access-Control-Allow-Methods']).toContain('POST');
+    // The deny branch still varies on Origin so caches never reuse it.
+    expect(corsHeadersFor(policy, 'https://evil.test').Vary).toBe('Origin');
   });
 });

--- a/lib/mcp/cors.test.ts
+++ b/lib/mcp/cors.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { corsHeadersFor, mcpCorsPolicyFromEnv, parseAllowList } from './cors';
+
+describe('parseAllowList', () => {
+  it('returns undefined for unset, empty and comma-only values', () => {
+    expect(parseAllowList(undefined)).toBeUndefined();
+    expect(parseAllowList('')).toBeUndefined();
+    expect(parseAllowList(' , ,')).toBeUndefined();
+  });
+
+  it('splits on commas and trims entries', () => {
+    expect(parseAllowList(' https://a.test , https://b.test ')).toEqual([
+      'https://a.test',
+      'https://b.test',
+    ]);
+  });
+});
+
+describe('mcpCorsPolicyFromEnv', () => {
+  it('reads both allowlists from the environment', () => {
+    const policy = mcpCorsPolicyFromEnv({
+      MCP_ALLOWED_ORIGINS: 'https://chat.example',
+      MCP_ALLOWED_HOSTS: 'gym.example:3030',
+    });
+    expect(policy).toEqual({
+      allowedOrigins: ['https://chat.example'],
+      allowedHosts: ['gym.example:3030'],
+    });
+  });
+
+  it('leaves both undefined when the env vars are unset', () => {
+    expect(mcpCorsPolicyFromEnv({})).toEqual({
+      allowedOrigins: undefined,
+      allowedHosts: undefined,
+    });
+  });
+});
+
+describe('corsHeadersFor', () => {
+  it('answers * when no origin allowlist is configured', () => {
+    const headers = corsHeadersFor({}, 'https://anywhere.test');
+    expect(headers['Access-Control-Allow-Origin']).toBe('*');
+    expect(headers.Vary).toBeUndefined();
+  });
+
+  it('echoes an allowlisted origin and varies on Origin', () => {
+    const headers = corsHeadersFor(
+      { allowedOrigins: ['https://chat.example'] },
+      'https://chat.example',
+    );
+    expect(headers['Access-Control-Allow-Origin']).toBe('https://chat.example');
+    expect(headers.Vary).toBe('Origin');
+  });
+
+  it('omits Access-Control-Allow-Origin for a non-allowlisted or missing origin', () => {
+    const policy = { allowedOrigins: ['https://chat.example'] };
+    expect(corsHeadersFor(policy, 'https://evil.test')['Access-Control-Allow-Origin']).toBeUndefined();
+    expect(corsHeadersFor(policy, null)['Access-Control-Allow-Origin']).toBeUndefined();
+    expect(corsHeadersFor(policy, null)['Access-Control-Allow-Methods']).toContain('POST');
+  });
+});

--- a/lib/mcp/cors.ts
+++ b/lib/mcp/cors.ts
@@ -1,0 +1,60 @@
+// CORS and allowlist policy for the MCP HTTP endpoint (issue #287).
+//
+// By default the endpoint keeps its historical open posture: CORS answers
+// Access-Control-Allow-Origin: * and the transport does no Host/Origin
+// checking (auth is bearer-token based, no cookies). Self-hosters can opt in
+// to hardening by setting MCP_ALLOWED_ORIGINS and/or MCP_ALLOWED_HOSTS
+// (comma-separated, exact-match values): the transport then enables DNS
+// rebinding protection with those allowlists, and CORS echoes only an
+// allowlisted request origin instead of *.
+
+export interface McpCorsPolicy {
+  allowedOrigins?: string[];
+  allowedHosts?: string[];
+}
+
+// Parses a comma-separated allowlist env value; undefined when unset/empty.
+export function parseAllowList(value: string | undefined): string[] | undefined {
+  const items = value
+    ?.split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+  return items && items.length > 0 ? items : undefined;
+}
+
+export function mcpCorsPolicyFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): McpCorsPolicy {
+  return {
+    allowedOrigins: parseAllowList(env.MCP_ALLOWED_ORIGINS),
+    allowedHosts: parseAllowList(env.MCP_ALLOWED_HOSTS),
+  };
+}
+
+const BASE_CORS_HEADERS = {
+  'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+  'Access-Control-Allow-Headers':
+    'Content-Type, Authorization, X-GymCoach-Token, MCP-Protocol-Version, MCP-Session-Id, Last-Event-ID',
+  'Access-Control-Expose-Headers': 'MCP-Protocol-Version, MCP-Session-Id',
+};
+
+// Resolves the CORS headers for a request. With no origin allowlist the
+// endpoint stays wide open (*). With one, the request's Origin is echoed back
+// only when allowlisted (exact match, like the SDK's DNS rebinding check);
+// otherwise no Access-Control-Allow-Origin header is emitted at all.
+export function corsHeadersFor(
+  policy: McpCorsPolicy,
+  requestOrigin: string | null,
+): Record<string, string> {
+  if (!policy.allowedOrigins) {
+    return { ...BASE_CORS_HEADERS, 'Access-Control-Allow-Origin': '*' };
+  }
+  if (requestOrigin && policy.allowedOrigins.includes(requestOrigin)) {
+    return {
+      ...BASE_CORS_HEADERS,
+      'Access-Control-Allow-Origin': requestOrigin,
+      Vary: 'Origin',
+    };
+  }
+  return { ...BASE_CORS_HEADERS };
+}

--- a/lib/mcp/cors.ts
+++ b/lib/mcp/cors.ts
@@ -56,5 +56,7 @@ export function corsHeadersFor(
       Vary: 'Origin',
     };
   }
-  return { ...BASE_CORS_HEADERS };
+  // Vary on the deny branch too, so a shared or preflight cache never reuses
+  // a no-allow-origin response for a later allowlisted origin.
+  return { ...BASE_CORS_HEADERS, Vary: 'Origin' };
 }

--- a/lib/mcp/server.ts
+++ b/lib/mcp/server.ts
@@ -114,7 +114,6 @@ export function createGymCoachMcpServer({ principal, baseUrl }: ServerOptions): 
         db.user.findUnique({
           where: { id: principal.userId },
           select: {
-            email: true,
             unit: true,
             activeGym: {
               include: {


### PR DESCRIPTION
Implements the three defense-in-depth follow-ups from the #276/#272 reviews:

1. **Transport allowlist (opt-in):** new `MCP_ALLOWED_ORIGINS` / `MCP_ALLOWED_HOSTS` env vars (comma-separated, exact match, documented in `.env.example`). When either is set, the MCP Streamable HTTP transport enables `enableDnsRebindingProtection` with those allowlists, and CORS echoes only an allowlisted request origin (with `Vary: Origin`) instead of `Access-Control-Allow-Origin: *`. Unset keeps today's open behavior so existing self-hosted deployments do not break. Policy logic lives in `lib/mcp/cors.ts` with colocated unit tests.
2. **PII trim:** `get_training_context` no longer selects the token owner's email; the tool payload never needed it.
3. **codex-lb timeout:** the provider fetch now carries an AbortController signal (120s to response headers, cleared once headers arrive so started streams stay uncapped). A timeout maps to `LlmError(504)` instead of hanging forever. Unit-tested with fake timers.

No user-facing change expected.

Closes #287

## How I tested
- `bash scripts/verify.sh` - green
- `bash scripts/verify.sh --full` - green (integration + 17/17 E2E)
- New unit tests: `lib/mcp/cors.test.ts` (allowlist parsing + CORS resolution) and the codex-lb 504-on-timeout case

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018i3bgeAeXBAN5afBhvxW9D