### PR TITLE
Physical gym equipment inventory

### DIFF
--- a/app/api/backup/route.ts
+++ b/app/api/backup/route.ts
@@ -23,7 +23,11 @@ import {
 import { MAX_SUPERSET_GROUP, MIN_SUPERSET_GROUP } from '@/lib/supersets';
 import { sorenessSchema } from '@/lib/schemas/readiness';
 import { gymWeightListSchema } from '@/lib/schemas/gym';
-import { GYM_EQUIPMENT_IMAGE_MIME_TYPES, decodeGymEquipmentImage } from '@/lib/gym-equipment';
+import {
+  GYM_EQUIPMENT_IMAGE_MIME_TYPES,
+  MAX_GYM_EQUIPMENT_PER_GYM,
+  decodeGymEquipmentImage,
+} from '@/lib/gym-equipment';
 
 // ============================================================
 // Backup / Import JSON (LOT 11, completed by issue #168)
@@ -295,7 +299,14 @@ export async function GET() {
     };
 
     const filename = `gymcoach-backup-${new Date().toISOString().slice(0, 10)}.json`;
-    return new NextResponse(JSON.stringify(dump, null, 2), {
+    const serialized = JSON.stringify(dump, null, 2);
+    if (Buffer.byteLength(serialized, 'utf8') > MAX_BACKUP_BYTES) {
+      throw new ApiError(
+        413,
+        'This backup is larger than the maximum restorable backup size. Reduce uploaded gym equipment images and try again.',
+      );
+    }
+    return new NextResponse(serialized, {
       headers: {
         'Content-Type': 'application/json; charset=utf-8',
         'Content-Disposition': `attachment; filename="${filename}"`,
@@ -493,7 +504,7 @@ const importSchema = z.object({
               exerciseNames: z.array(z.string().max(120)).max(100),
             }),
           )
-          .max(1000)
+          .max(MAX_GYM_EQUIPMENT_PER_GYM)
           .optional(),
         exerciseConfigs: z
           .array(
@@ -578,6 +589,35 @@ export async function POST(req: Request) {
     const { payload } = await parseJsonBody(req, importBodySchema, {
       maxBytes: MAX_BACKUP_BYTES,
     });
+
+    // Validate and decode equipment images before taking purge locks so a
+    // malformed or hand-edited backup fails before any replacement work starts.
+    const preparedEquipmentByGymName = new Map<
+      string,
+      Array<{
+        item: NonNullable<NonNullable<(typeof payload.gyms)>[number]['equipment']>[number];
+        decoded: ReturnType<typeof decodeGymEquipmentImage> | null;
+      }>
+    >();
+    const seenGymNames = new Set<string>();
+    for (const gym of payload.gyms ?? []) {
+      if (seenGymNames.has(gym.name)) continue;
+      seenGymNames.add(gym.name);
+      const seenEquipmentNames = new Set<string>();
+      const prepared = [] as NonNullable<ReturnType<typeof preparedEquipmentByGymName.get>>;
+      for (const item of gym.equipment ?? []) {
+        const equipmentNameKey = item.name.toLocaleLowerCase('en-US');
+        if (seenEquipmentNames.has(equipmentNameKey)) {
+          throw new ApiError(400, `Duplicate gym equipment name in backup: ${item.name}`);
+        }
+        seenEquipmentNames.add(equipmentNameKey);
+        const decoded = item.imageBase64
+          ? decodeGymEquipmentImage(item.imageBase64, item.imageMimeType ?? undefined)
+          : null;
+        prepared.push({ item, decoded });
+      }
+      preparedEquipmentByGymName.set(gym.name, prepared);
+    }
 
     await db.$transaction(
       async (tx) => {
@@ -666,38 +706,41 @@ export async function POST(req: Request) {
               exerciseConfigs: { createMany: { data: configs } },
             },
           });
-          for (const item of gym.equipment ?? []) {
-            const decoded = item.imageBase64
-              ? decodeGymEquipmentImage(item.imageBase64, item.imageMimeType ?? undefined)
-              : null;
-            const equipment = await tx.gymEquipment.create({
-              data: {
-                gymId: created.id,
-                name: item.name,
-                equipmentType: item.equipmentType,
-                description: item.description ?? null,
-                manufacturer: item.manufacturer ?? null,
-                modelName: item.modelName ?? null,
-                quantity: item.quantity,
-                weightOptions: item.weightOptions,
-                imageUrl: decoded ? null : (item.imageUrl ?? null),
-                imageData: decoded?.bytes,
-                imageMimeType: decoded?.mimeType ?? null,
-              },
-            });
-            const exerciseIds = [
+          const preparedEquipment = preparedEquipmentByGymName.get(gym.name) ?? [];
+          const createdEquipment =
+            preparedEquipment.length > 0
+              ? await tx.gymEquipment.createManyAndReturn({
+                  data: preparedEquipment.map(({ item, decoded }) => ({
+                    gymId: created.id,
+                    name: item.name,
+                    equipmentType: item.equipmentType,
+                    description: item.description ?? null,
+                    manufacturer: item.manufacturer ?? null,
+                    modelName: item.modelName ?? null,
+                    quantity: item.quantity,
+                    weightOptions: item.weightOptions,
+                    imageUrl: decoded ? null : (item.imageUrl ?? null),
+                    imageData: decoded?.bytes,
+                    imageMimeType: decoded?.mimeType ?? null,
+                  })),
+                  select: { id: true, name: true },
+                })
+              : [];
+          const equipmentIdByName = new Map(createdEquipment.map((item) => [item.name, item.id]));
+          const equipmentExerciseLinks = preparedEquipment.flatMap(({ item }) => {
+            const equipmentId = equipmentIdByName.get(item.name);
+            if (!equipmentId) return [];
+            return [
               ...new Set(
                 item.exerciseNames.flatMap((name) => {
                   const exerciseId = exerciseIdByName.get(name);
                   return exerciseId ? [exerciseId] : [];
                 }),
               ),
-            ];
-            if (exerciseIds.length > 0) {
-              await tx.gymEquipmentExercise.createMany({
-                data: exerciseIds.map((exerciseId) => ({ equipmentId: equipment.id, exerciseId })),
-              });
-            }
+            ].map((exerciseId) => ({ equipmentId, exerciseId }));
+          });
+          if (equipmentExerciseLinks.length > 0) {
+            await tx.gymEquipmentExercise.createMany({ data: equipmentExerciseLinks });
           }
           gymIdByName.set(gym.name, created.id);
         }

--- a/app/api/backup/route.ts
+++ b/app/api/backup/route.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import {
@@ -22,6 +23,7 @@ import {
 import { MAX_SUPERSET_GROUP, MIN_SUPERSET_GROUP } from '@/lib/supersets';
 import { sorenessSchema } from '@/lib/schemas/readiness';
 import { gymWeightListSchema } from '@/lib/schemas/gym';
+import { GYM_EQUIPMENT_IMAGE_MIME_TYPES, decodeGymEquipmentImage } from '@/lib/gym-equipment';
 
 // ============================================================
 // Backup / Import JSON (LOT 11, completed by issue #168)
@@ -43,6 +45,8 @@ import { gymWeightListSchema } from '@/lib/schemas/gym';
 //   usesBodyweight.
 // - Program / Workout / ProgramExercise: all user content incl supersetGroup.
 // - Session / Set: all user content incl durationSec, distanceM, avgHr.
+// - Saved Gym profiles plus physical GymEquipment, equipment-to-exercise links,
+//   and uploaded/external equipment images.
 // - CoachSession, ExerciseGoal, BodyweightEntry, ReadinessCheckin,
 //   Conversation / Message: all user content.
 //
@@ -53,7 +57,7 @@ import { gymWeightListSchema } from '@/lib/schemas/gym';
 // - Program.createdAt / Program.updatedAt and Exercise.createdAt (server-side
 //   bookkeeping with no user-facing meaning; reset to the import time).
 
-const VERSION = 3;
+const VERSION = 4;
 
 // Hard cap on the import body size, enforced while reading the stream (the
 // Content-Length header is attacker-controlled). Generous: a decade of daily
@@ -139,6 +143,10 @@ export async function GET() {
         where: { userId },
         orderBy: { createdAt: 'asc' },
         include: {
+          equipment: {
+            orderBy: { name: 'asc' },
+            include: { exerciseLinks: { include: { exercise: { select: { name: true } } } } },
+          },
           exerciseConfigs: { include: { exercise: { select: { name: true } } } },
         },
       }),
@@ -176,6 +184,19 @@ export async function GET() {
         dumbbellWeights: gym.dumbbellWeights,
         plateWeights: gym.plateWeights,
         barWeights: gym.barWeights,
+        equipment: gym.equipment.map((item) => ({
+          name: item.name,
+          equipmentType: item.equipmentType,
+          description: item.description,
+          manufacturer: item.manufacturer,
+          modelName: item.modelName,
+          quantity: item.quantity,
+          weightOptions: item.weightOptions,
+          imageUrl: item.imageUrl,
+          imageMimeType: item.imageMimeType,
+          imageBase64: item.imageData ? Buffer.from(item.imageData).toString('base64') : null,
+          exerciseNames: item.exerciseLinks.map((link) => link.exercise.name),
+        })),
         exerciseConfigs: gym.exerciseConfigs.map((config) => ({
           exerciseName: config.exercise.name,
           isAvailable: config.isAvailable,
@@ -448,6 +469,32 @@ const importSchema = z.object({
         dumbbellWeights: gymWeightListSchema,
         plateWeights: gymWeightListSchema,
         barWeights: gymWeightListSchema,
+        equipment: z
+          .array(
+            z.object({
+              name: z.string().trim().min(1).max(120),
+              equipmentType: z.nativeEnum(EquipmentType),
+              description: z.string().max(4000).nullable().optional(),
+              manufacturer: z.string().max(120).nullable().optional(),
+              modelName: z.string().max(120).nullable().optional(),
+              quantity: z.number().int().min(1).max(100),
+              weightOptions: gymWeightListSchema,
+              imageUrl: z
+                .string()
+                .url()
+                .max(2048)
+                .nullable()
+                .optional()
+                .refine((value) => value == null || value.startsWith('https://'), {
+                  message: 'Equipment image URL must use HTTPS.',
+                }),
+              imageMimeType: z.enum(GYM_EQUIPMENT_IMAGE_MIME_TYPES).nullable().optional(),
+              imageBase64: z.string().max(7_100_000).nullable().optional(),
+              exerciseNames: z.array(z.string().max(120)).max(100),
+            }),
+          )
+          .max(1000)
+          .optional(),
         exerciseConfigs: z
           .array(
             z.object({
@@ -619,6 +666,39 @@ export async function POST(req: Request) {
               exerciseConfigs: { createMany: { data: configs } },
             },
           });
+          for (const item of gym.equipment ?? []) {
+            const decoded = item.imageBase64
+              ? decodeGymEquipmentImage(item.imageBase64, item.imageMimeType ?? undefined)
+              : null;
+            const equipment = await tx.gymEquipment.create({
+              data: {
+                gymId: created.id,
+                name: item.name,
+                equipmentType: item.equipmentType,
+                description: item.description ?? null,
+                manufacturer: item.manufacturer ?? null,
+                modelName: item.modelName ?? null,
+                quantity: item.quantity,
+                weightOptions: item.weightOptions,
+                imageUrl: decoded ? null : (item.imageUrl ?? null),
+                imageData: decoded?.bytes,
+                imageMimeType: decoded?.mimeType ?? null,
+              },
+            });
+            const exerciseIds = [
+              ...new Set(
+                item.exerciseNames.flatMap((name) => {
+                  const exerciseId = exerciseIdByName.get(name);
+                  return exerciseId ? [exerciseId] : [];
+                }),
+              ),
+            ];
+            if (exerciseIds.length > 0) {
+              await tx.gymEquipmentExercise.createMany({
+                data: exerciseIds.map((exerciseId) => ({ equipmentId: equipment.id, exerciseId })),
+              });
+            }
+          }
           gymIdByName.set(gym.name, created.id);
         }
         const activeGymId = payload.profile?.activeGymName

--- a/app/api/backup/route.ts
+++ b/app/api/backup/route.ts
@@ -67,11 +67,23 @@ const VERSION = 4;
 // Content-Length header is attacker-controlled). Generous: a decade of daily
 // training exports to a few MB.
 const MAX_BACKUP_BYTES = 50 * 1024 * 1024;
+const BACKUP_TOO_LARGE_MESSAGE =
+  'This backup is larger than the maximum restorable backup size. Reduce uploaded gym equipment images and try again.';
 
 // GET /api/backup: returns an exportable JSON.
 export async function GET() {
   try {
     const userId = await requireApiUserId();
+
+    const [imageBudget] = await db.$queryRaw<Array<{ encodedBytes: bigint }>>`
+      SELECT COALESCE(SUM(4 * CEIL(OCTET_LENGTH(e."imageData")::numeric / 3)), 0)::bigint AS "encodedBytes"
+      FROM "GymEquipment" e
+      INNER JOIN "Gym" g ON g.id = e."gymId"
+      WHERE g."userId" = ${userId} AND e."imageData" IS NOT NULL
+    `;
+    if ((imageBudget?.encodedBytes ?? 0n) >= BigInt(MAX_BACKUP_BYTES)) {
+      throw new ApiError(413, BACKUP_TOO_LARGE_MESSAGE);
+    }
 
     const [
       user,
@@ -301,10 +313,7 @@ export async function GET() {
     const filename = `gymcoach-backup-${new Date().toISOString().slice(0, 10)}.json`;
     const serialized = JSON.stringify(dump, null, 2);
     if (Buffer.byteLength(serialized, 'utf8') > MAX_BACKUP_BYTES) {
-      throw new ApiError(
-        413,
-        'This backup is larger than the maximum restorable backup size. Reduce uploaded gym equipment images and try again.',
-      );
+      throw new ApiError(413, BACKUP_TOO_LARGE_MESSAGE);
     }
     return new NextResponse(serialized, {
       headers: {

--- a/app/api/gym-equipment/[id]/image/route.ts
+++ b/app/api/gym-equipment/[id]/image/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+import { handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
+import { getOwnedGymEquipmentImage, setOwnedGymEquipmentImage } from '@/lib/gym-equipment';
+import { gymEquipmentImageSchema } from '@/lib/schemas/gym-equipment';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+interface Params {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(_req: Request, props: Params) {
+  try {
+    const userId = await requireApiUserId();
+    const { id } = await props.params;
+    const image = await getOwnedGymEquipmentImage(userId, id);
+    if (image.kind === 'external') return NextResponse.redirect(image.url);
+    return new Response(image.bytes, {
+      headers: {
+        'Content-Type': image.mimeType,
+        'Content-Length': String(image.bytes.byteLength),
+        'Cache-Control': 'private, max-age=3600',
+        'Last-Modified': image.updatedAt.toUTCString(),
+        'X-Content-Type-Options': 'nosniff',
+      },
+    });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}
+
+export async function PUT(req: Request, props: Params) {
+  try {
+    const userId = await requireApiUserId();
+    const { id } = await props.params;
+    const input = await parseJsonBody(req, gymEquipmentImageSchema, { maxBytes: 7_110_000 });
+    const equipment = await setOwnedGymEquipmentImage(userId, id, input);
+    return NextResponse.json({ equipment });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}
+
+export async function DELETE(_req: Request, props: Params) {
+  try {
+    const userId = await requireApiUserId();
+    const { id } = await props.params;
+    const equipment = await setOwnedGymEquipmentImage(userId, id, { clear: true });
+    return NextResponse.json({ equipment });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/app/api/gym-equipment/[id]/route.ts
+++ b/app/api/gym-equipment/[id]/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
+import { db } from '@/lib/db';
+import { deleteOwnedGymEquipment, upsertOwnedGymEquipment } from '@/lib/gym-equipment';
+import { gymEquipmentUpsertSchema } from '@/lib/schemas/gym-equipment';
+
+interface Params {
+  params: Promise<{ id: string }>;
+}
+
+export async function PUT(req: Request, props: Params) {
+  try {
+    const userId = await requireApiUserId();
+    const { id } = await props.params;
+    const existing = await db.gymEquipment.findFirst({
+      where: { id, gym: { userId } },
+      select: { id: true, gymId: true },
+    });
+    if (!existing) return NextResponse.json({ error: 'Gym equipment not found.' }, { status: 404 });
+    const input = await parseJsonBody(req, gymEquipmentUpsertSchema);
+    const saved = await upsertOwnedGymEquipment(userId, existing.gymId, {
+      equipmentId: existing.id,
+      ...input,
+    });
+    return NextResponse.json(saved);
+  } catch (err) {
+    return handleApiError(err);
+  }
+}
+
+export async function DELETE(_req: Request, props: Params) {
+  try {
+    const userId = await requireApiUserId();
+    const { id } = await props.params;
+    await deleteOwnedGymEquipment(userId, id);
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/app/api/gym-equipment/[id]/route.ts
+++ b/app/api/gym-equipment/[id]/route.ts
@@ -1,19 +1,26 @@
 import { NextResponse } from 'next/server';
-import { handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
+import { ApiError, handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
 import { db } from '@/lib/db';
 import { deleteOwnedGymEquipment, upsertOwnedGymEquipment } from '@/lib/gym-equipment';
-import { gymEquipmentUpsertSchema } from '@/lib/schemas/gym-equipment';
+import { databaseIdSchema, gymEquipmentUpsertSchema } from '@/lib/schemas/gym-equipment';
 
 interface Params {
   params: Promise<{ id: string }>;
+}
+
+function parseEquipmentId(id: string): string {
+  const parsed = databaseIdSchema.safeParse(id);
+  if (!parsed.success) throw new ApiError(400, 'Invalid equipment id.');
+  return parsed.data;
 }
 
 export async function PUT(req: Request, props: Params) {
   try {
     const userId = await requireApiUserId();
     const { id } = await props.params;
+    const equipmentId = parseEquipmentId(id);
     const existing = await db.gymEquipment.findFirst({
-      where: { id, gym: { userId } },
+      where: { id: equipmentId, gym: { userId } },
       select: { id: true, gymId: true },
     });
     if (!existing) return NextResponse.json({ error: 'Gym equipment not found.' }, { status: 404 });
@@ -32,7 +39,8 @@ export async function DELETE(_req: Request, props: Params) {
   try {
     const userId = await requireApiUserId();
     const { id } = await props.params;
-    await deleteOwnedGymEquipment(userId, id);
+    const equipmentId = parseEquipmentId(id);
+    await deleteOwnedGymEquipment(userId, equipmentId);
     return NextResponse.json({ ok: true });
   } catch (err) {
     return handleApiError(err);

--- a/app/api/gym-equipment/[id]/route.ts
+++ b/app/api/gym-equipment/[id]/route.ts
@@ -19,8 +19,8 @@ export async function PUT(req: Request, props: Params) {
     if (!existing) return NextResponse.json({ error: 'Gym equipment not found.' }, { status: 404 });
     const input = await parseJsonBody(req, gymEquipmentUpsertSchema);
     const saved = await upsertOwnedGymEquipment(userId, existing.gymId, {
-      equipmentId: existing.id,
       ...input,
+      equipmentId: existing.id,
     });
     return NextResponse.json(saved);
   } catch (err) {

--- a/app/api/gyms/[id]/equipment/route.ts
+++ b/app/api/gyms/[id]/equipment/route.ts
@@ -7,11 +7,11 @@ interface Params {
   params: Promise<{ id: string }>;
 }
 
-export async function GET(req: Request, props: Params) {
+export async function GET(_req: Request, props: Params) {
   try {
     const userId = await requireApiUserId();
     const { id } = await props.params;
-    return NextResponse.json({ equipment: await listOwnedGymEquipment(userId, id, req.url) });
+    return NextResponse.json({ equipment: await listOwnedGymEquipment(userId, id) });
   } catch (err) {
     return handleApiError(err);
   }

--- a/app/api/gyms/[id]/equipment/route.ts
+++ b/app/api/gyms/[id]/equipment/route.ts
@@ -1,17 +1,24 @@
 import { NextResponse } from 'next/server';
-import { handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
+import { ApiError, handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
 import { listOwnedGymEquipment, upsertOwnedGymEquipment } from '@/lib/gym-equipment';
-import { gymEquipmentUpsertSchema } from '@/lib/schemas/gym-equipment';
+import { databaseIdSchema, gymEquipmentUpsertSchema } from '@/lib/schemas/gym-equipment';
 
 interface Params {
   params: Promise<{ id: string }>;
+}
+
+function parseGymId(id: string): string {
+  const parsed = databaseIdSchema.safeParse(id);
+  if (!parsed.success) throw new ApiError(400, 'Invalid gym id.');
+  return parsed.data;
 }
 
 export async function GET(_req: Request, props: Params) {
   try {
     const userId = await requireApiUserId();
     const { id } = await props.params;
-    return NextResponse.json({ equipment: await listOwnedGymEquipment(userId, id) });
+    const gymId = parseGymId(id);
+    return NextResponse.json({ equipment: await listOwnedGymEquipment(userId, gymId) });
   } catch (err) {
     return handleApiError(err);
   }
@@ -21,8 +28,9 @@ export async function POST(req: Request, props: Params) {
   try {
     const userId = await requireApiUserId();
     const { id } = await props.params;
+    const gymId = parseGymId(id);
     const input = await parseJsonBody(req, gymEquipmentUpsertSchema);
-    const saved = await upsertOwnedGymEquipment(userId, id, input);
+    const saved = await upsertOwnedGymEquipment(userId, gymId, input);
     return NextResponse.json(saved, { status: saved.created ? 201 : 200 });
   } catch (err) {
     return handleApiError(err);

--- a/app/api/gyms/[id]/equipment/route.ts
+++ b/app/api/gyms/[id]/equipment/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
+import { listOwnedGymEquipment, upsertOwnedGymEquipment } from '@/lib/gym-equipment';
+import { gymEquipmentUpsertSchema } from '@/lib/schemas/gym-equipment';
+
+interface Params {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(req: Request, props: Params) {
+  try {
+    const userId = await requireApiUserId();
+    const { id } = await props.params;
+    return NextResponse.json({ equipment: await listOwnedGymEquipment(userId, id, req.url) });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}
+
+export async function POST(req: Request, props: Params) {
+  try {
+    const userId = await requireApiUserId();
+    const { id } = await props.params;
+    const input = await parseJsonBody(req, gymEquipmentUpsertSchema);
+    const saved = await upsertOwnedGymEquipment(userId, id, input);
+    return NextResponse.json(saved, { status: 201 });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/app/api/gyms/[id]/equipment/route.ts
+++ b/app/api/gyms/[id]/equipment/route.ts
@@ -23,7 +23,7 @@ export async function POST(req: Request, props: Params) {
     const { id } = await props.params;
     const input = await parseJsonBody(req, gymEquipmentUpsertSchema);
     const saved = await upsertOwnedGymEquipment(userId, id, input);
-    return NextResponse.json(saved, { status: 201 });
+    return NextResponse.json(saved, { status: saved.created ? 201 : 200 });
   } catch (err) {
     return handleApiError(err);
   }

--- a/lib/gym-equipment.test.ts
+++ b/lib/gym-equipment.test.ts
@@ -1,0 +1,36 @@
+import { Buffer } from 'node:buffer';
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_GYM_EQUIPMENT_IMAGE_BYTES,
+  decodeGymEquipmentImage,
+} from './gym-equipment';
+
+const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+describe('decodeGymEquipmentImage', () => {
+  it('rejects bytes whose magic signature does not match the declared MIME type', () => {
+    expect(() =>
+      decodeGymEquipmentImage(Buffer.from('not a png').toString('base64'), 'image/png'),
+    ).toThrow('Uploaded bytes do not match the declared image type.');
+  });
+
+  it('rejects an over-cap payload before decoding it', () => {
+    const tooLarge = 'A'.repeat(Math.ceil((MAX_GYM_EQUIPMENT_IMAGE_BYTES * 4) / 3) + 17);
+    expect(() => decodeGymEquipmentImage(tooLarge, 'image/png')).toThrow(
+      'Uploaded equipment image is larger than 5 MB.',
+    );
+  });
+
+  it('rejects a declared MIME type that disagrees with the data URL', () => {
+    const dataUrl = `data:image/png;base64,${PNG.toString('base64')}`;
+    expect(() => decodeGymEquipmentImage(dataUrl, 'image/jpeg')).toThrow(
+      'The declared image MIME type does not match the data URL.',
+    );
+  });
+
+  it('rejects invalid base64', () => {
+    expect(() => decodeGymEquipmentImage('%%%not-base64%%%', 'image/png')).toThrow(
+      'Invalid base64 image data.',
+    );
+  });
+});

--- a/lib/gym-equipment.ts
+++ b/lib/gym-equipment.ts
@@ -58,7 +58,7 @@ const equipmentSelection = {
   },
 } as const;
 
-export async function listOwnedGymEquipment(userId: string, gymId: string, baseUrl: string) {
+export async function listOwnedGymEquipment(userId: string, gymId: string) {
   await requireOwnedGym(userId, gymId);
   const equipment = await db.gymEquipment.findMany({
     where: { gymId },
@@ -70,10 +70,7 @@ export async function listOwnedGymEquipment(userId: string, gymId: string, baseU
     image: item.imageMimeType
       ? {
           kind: 'uploaded' as const,
-          url: new URL(
-            `/api/gym-equipment/${item.id}/image?v=${item.updatedAt.getTime()}`,
-            baseUrl,
-          ).toString(),
+          url: `/api/gym-equipment/${item.id}/image?v=${item.updatedAt.getTime()}`,
           mimeType: item.imageMimeType,
         }
       : item.imageUrl
@@ -203,7 +200,10 @@ export async function upsertOwnedGymEquipment(
     return saved;
   });
 
-  const saved = await db.gymEquipment.findUnique({ where: { id: item.id }, select: equipmentSelection });
+  const saved = await db.gymEquipment.findUnique({
+    where: { id: item.id },
+    select: equipmentSelection,
+  });
   if (!saved) throw new ApiError(500, 'Gym equipment could not be read after saving.');
 
   const mismatchedExercises = exercises
@@ -241,7 +241,9 @@ export async function getOwnedGymEquipmentImage(userId: string, equipmentId: str
   if (!equipment) throw new ApiError(404, 'Gym equipment not found.');
 
   if (equipment.imageData && equipment.imageMimeType) {
-    if (!GYM_EQUIPMENT_IMAGE_MIME_TYPES.includes(equipment.imageMimeType as GymEquipmentImageMimeType)) {
+    if (
+      !GYM_EQUIPMENT_IMAGE_MIME_TYPES.includes(equipment.imageMimeType as GymEquipmentImageMimeType)
+    ) {
       throw new ApiError(500, 'Gym equipment image has an unsupported MIME type.');
     }
     return {
@@ -263,8 +265,9 @@ export async function setOwnedGymEquipmentImage(
   input: SetGymEquipmentImageInput,
 ) {
   const equipment = await requireOwnedEquipment(userId, equipmentId);
-  const modes = [input.clear === true, input.imageUrl != null, input.imageBase64 != null].filter(Boolean)
-    .length;
+  const modes = [input.clear === true, input.imageUrl != null, input.imageBase64 != null].filter(
+    Boolean,
+  ).length;
   if (modes !== 1) {
     throw new ApiError(400, 'Choose exactly one image action: clear, imageUrl, or imageBase64.');
   }
@@ -282,7 +285,14 @@ export async function setOwnedGymEquipmentImage(
   return db.gymEquipment.update({
     where: { id: equipment.id },
     data,
-    select: { id: true, gymId: true, name: true, imageUrl: true, imageMimeType: true, updatedAt: true },
+    select: {
+      id: true,
+      gymId: true,
+      name: true,
+      imageUrl: true,
+      imageMimeType: true,
+      updatedAt: true,
+    },
   });
 }
 

--- a/lib/gym-equipment.ts
+++ b/lib/gym-equipment.ts
@@ -1,0 +1,338 @@
+import { Buffer } from 'node:buffer';
+import { ApiError } from '@/lib/api';
+import { db } from '@/lib/db';
+import type { EquipmentType } from '@/lib/prisma-client';
+
+export const GYM_EQUIPMENT_IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'] as const;
+export type GymEquipmentImageMimeType = (typeof GYM_EQUIPMENT_IMAGE_MIME_TYPES)[number];
+export const MAX_GYM_EQUIPMENT_IMAGE_BYTES = 5 * 1024 * 1024;
+
+export interface UpsertGymEquipmentInput {
+  equipmentId?: string;
+  name: string;
+  equipmentType: EquipmentType;
+  description?: string | null;
+  manufacturer?: string | null;
+  modelName?: string | null;
+  quantity?: number;
+  weightOptions?: number[];
+  exerciseIds?: string[];
+  markExercisesAvailable?: boolean;
+}
+
+export interface SetGymEquipmentImageInput {
+  clear?: boolean;
+  imageUrl?: string;
+  imageBase64?: string;
+  mimeType?: GymEquipmentImageMimeType;
+}
+
+const equipmentSelection = {
+  id: true,
+  gymId: true,
+  name: true,
+  equipmentType: true,
+  description: true,
+  manufacturer: true,
+  modelName: true,
+  quantity: true,
+  weightOptions: true,
+  imageUrl: true,
+  imageMimeType: true,
+  createdAt: true,
+  updatedAt: true,
+  exerciseLinks: {
+    orderBy: { exercise: { name: 'asc' as const } },
+    include: {
+      exercise: {
+        select: {
+          id: true,
+          name: true,
+          muscleGroup: true,
+          category: true,
+          equipmentType: true,
+        },
+      },
+    },
+  },
+} as const;
+
+export async function listOwnedGymEquipment(userId: string, gymId: string, baseUrl: string) {
+  await requireOwnedGym(userId, gymId);
+  const equipment = await db.gymEquipment.findMany({
+    where: { gymId },
+    orderBy: { name: 'asc' },
+    select: equipmentSelection,
+  });
+  return equipment.map((item) => ({
+    ...item,
+    image: item.imageMimeType
+      ? {
+          kind: 'uploaded' as const,
+          url: new URL(
+            `/api/gym-equipment/${item.id}/image?v=${item.updatedAt.getTime()}`,
+            baseUrl,
+          ).toString(),
+          mimeType: item.imageMimeType,
+        }
+      : item.imageUrl
+        ? { kind: 'external' as const, url: item.imageUrl, mimeType: null }
+        : null,
+    exerciseLinks: item.exerciseLinks.map((link) => link.exercise),
+  }));
+}
+
+export async function upsertOwnedGymEquipment(
+  userId: string,
+  gymId: string,
+  input: UpsertGymEquipmentInput,
+) {
+  await requireOwnedGym(userId, gymId);
+  const requestedExerciseIds = input.exerciseIds ? [...new Set(input.exerciseIds)] : undefined;
+  const current = input.equipmentId
+    ? await db.gymEquipment.findFirst({
+        where: { id: input.equipmentId, gymId },
+        select: {
+          id: true,
+          equipmentType: true,
+          weightOptions: true,
+          exerciseLinks: { select: { exerciseId: true } },
+        },
+      })
+    : await db.gymEquipment.findFirst({
+        where: { gymId, name: { equals: input.name, mode: 'insensitive' } },
+        select: {
+          id: true,
+          equipmentType: true,
+          weightOptions: true,
+          exerciseLinks: { select: { exerciseId: true } },
+        },
+      });
+  if (input.equipmentId && !current) throw new ApiError(404, 'Gym equipment not found.');
+
+  const exerciseIds =
+    requestedExerciseIds ?? current?.exerciseLinks.map((link) => link.exerciseId) ?? [];
+  const exercises = exerciseIds.length
+    ? await db.exercise.findMany({
+        where: { userId, id: { in: exerciseIds } },
+        select: { id: true, name: true, equipmentType: true },
+      })
+    : [];
+  if (exercises.length !== exerciseIds.length) {
+    throw new ApiError(400, 'One or more exercise IDs do not belong to the trainee.');
+  }
+
+  const equipmentTypeChanged = current != null && current.equipmentType !== input.equipmentType;
+  const shouldSyncExerciseConfigs =
+    requestedExerciseIds !== undefined || input.weightOptions !== undefined || equipmentTypeChanged;
+  const effectiveWeightOptions = input.weightOptions ?? current?.weightOptions ?? [];
+
+  const item = await db.$transaction(async (tx) => {
+    const saved = current
+      ? await tx.gymEquipment.update({
+          where: { id: current.id },
+          data: {
+            name: input.name,
+            equipmentType: input.equipmentType,
+            description: input.description,
+            manufacturer: input.manufacturer,
+            modelName: input.modelName,
+            quantity: input.quantity,
+            weightOptions: input.weightOptions,
+          },
+        })
+      : await tx.gymEquipment.create({
+          data: {
+            gymId,
+            name: input.name,
+            equipmentType: input.equipmentType,
+            description: input.description,
+            manufacturer: input.manufacturer,
+            modelName: input.modelName,
+            quantity: input.quantity ?? 1,
+            weightOptions: input.weightOptions ?? [],
+          },
+        });
+
+    if (requestedExerciseIds !== undefined) {
+      await tx.gymEquipmentExercise.deleteMany({ where: { equipmentId: saved.id } });
+      if (requestedExerciseIds.length > 0) {
+        await tx.gymEquipmentExercise.createMany({
+          data: requestedExerciseIds.map((exerciseId) => ({ equipmentId: saved.id, exerciseId })),
+        });
+      }
+    }
+
+    // Keep the already-accepted GymExerciseConfig model in sync as a compatibility
+    // projection. Later equipment-first workout code can use the physical item
+    // directly, while current upstream screens immediately see linked exercises
+    // as available and retain their machine/cable load options.
+    if (input.markExercisesAvailable !== false && shouldSyncExerciseConfigs) {
+      const useItemWeights = ['MACHINE', 'CABLE', 'OTHER'].includes(input.equipmentType);
+      for (const exercise of exercises) {
+        await tx.gymExerciseConfig.upsert({
+          where: { gymId_exerciseId: { gymId, exerciseId: exercise.id } },
+          update: {
+            isAvailable: true,
+            ...(useItemWeights
+              ? { weightOptions: effectiveWeightOptions }
+              : equipmentTypeChanged
+                ? { weightOptions: [] }
+                : {}),
+          },
+          create: {
+            gymId,
+            exerciseId: exercise.id,
+            isAvailable: true,
+            weightOptions: useItemWeights ? effectiveWeightOptions : [],
+          },
+        });
+      }
+    }
+    return saved;
+  });
+
+  const saved = await db.gymEquipment.findUnique({ where: { id: item.id }, select: equipmentSelection });
+  if (!saved) throw new ApiError(500, 'Gym equipment could not be read after saving.');
+
+  const mismatchedExercises = exercises
+    .filter(
+      (exercise) =>
+        exercise.equipmentType !== 'OTHER' &&
+        input.equipmentType !== 'OTHER' &&
+        exercise.equipmentType !== input.equipmentType,
+    )
+    .map((exercise) => ({
+      id: exercise.id,
+      name: exercise.name,
+      exerciseEquipmentType: exercise.equipmentType,
+    }));
+
+  return { equipment: saved, mismatchedExercises };
+}
+
+export async function deleteOwnedGymEquipment(userId: string, equipmentId: string) {
+  const equipment = await requireOwnedEquipment(userId, equipmentId);
+  await db.gymEquipment.delete({ where: { id: equipment.id } });
+}
+
+export async function getOwnedGymEquipmentImage(userId: string, equipmentId: string) {
+  const equipment = await db.gymEquipment.findFirst({
+    where: { id: equipmentId, gym: { userId } },
+    select: {
+      id: true,
+      imageUrl: true,
+      imageData: true,
+      imageMimeType: true,
+      updatedAt: true,
+    },
+  });
+  if (!equipment) throw new ApiError(404, 'Gym equipment not found.');
+
+  if (equipment.imageData && equipment.imageMimeType) {
+    if (!GYM_EQUIPMENT_IMAGE_MIME_TYPES.includes(equipment.imageMimeType as GymEquipmentImageMimeType)) {
+      throw new ApiError(500, 'Gym equipment image has an unsupported MIME type.');
+    }
+    return {
+      kind: 'uploaded' as const,
+      bytes: Buffer.from(equipment.imageData),
+      mimeType: equipment.imageMimeType as GymEquipmentImageMimeType,
+      updatedAt: equipment.updatedAt,
+    };
+  }
+  if (equipment.imageUrl) {
+    return { kind: 'external' as const, url: equipment.imageUrl, updatedAt: equipment.updatedAt };
+  }
+  throw new ApiError(404, 'Gym equipment image not found.');
+}
+
+export async function setOwnedGymEquipmentImage(
+  userId: string,
+  equipmentId: string,
+  input: SetGymEquipmentImageInput,
+) {
+  const equipment = await requireOwnedEquipment(userId, equipmentId);
+  const modes = [input.clear === true, input.imageUrl != null, input.imageBase64 != null].filter(Boolean)
+    .length;
+  if (modes !== 1) {
+    throw new ApiError(400, 'Choose exactly one image action: clear, imageUrl, or imageBase64.');
+  }
+
+  const data = input.clear
+    ? { imageUrl: null, imageData: null, imageMimeType: null }
+    : input.imageUrl
+      ? { imageUrl: input.imageUrl, imageData: null, imageMimeType: null }
+      : (() => {
+          const decoded = decodeGymEquipmentImage(input.imageBase64!, input.mimeType);
+          return { imageUrl: null, imageData: decoded.bytes, imageMimeType: decoded.mimeType };
+        })();
+
+  return db.gymEquipment.update({
+    where: { id: equipment.id },
+    data,
+    select: { id: true, gymId: true, name: true, imageUrl: true, imageMimeType: true, updatedAt: true },
+  });
+}
+
+export function decodeGymEquipmentImage(
+  raw: string,
+  declaredMimeType?: GymEquipmentImageMimeType,
+): { bytes: Uint8Array<ArrayBuffer>; mimeType: GymEquipmentImageMimeType } {
+  const dataUrl = /^data:(image\/(?:jpeg|png|webp));base64,(.+)$/s.exec(raw.trim());
+  const mimeType = (dataUrl?.[1] ?? declaredMimeType) as GymEquipmentImageMimeType | undefined;
+  if (!mimeType || !GYM_EQUIPMENT_IMAGE_MIME_TYPES.includes(mimeType)) {
+    throw new ApiError(400, 'Uploaded equipment image must be JPEG, PNG, or WebP.');
+  }
+  if (dataUrl && declaredMimeType && dataUrl[1] !== declaredMimeType) {
+    throw new ApiError(400, 'The declared image MIME type does not match the data URL.');
+  }
+
+  const base64 = (dataUrl?.[2] ?? raw).replace(/\s/g, '');
+  if (base64.length > Math.ceil((MAX_GYM_EQUIPMENT_IMAGE_BYTES * 4) / 3) + 16) {
+    throw new ApiError(400, 'Uploaded equipment image is larger than 5 MB.');
+  }
+  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(base64)) throw new ApiError(400, 'Invalid base64 image data.');
+  const buffer = Buffer.from(base64, 'base64');
+  if (buffer.length === 0) throw new ApiError(400, 'Uploaded equipment image is empty.');
+  if (buffer.length > MAX_GYM_EQUIPMENT_IMAGE_BYTES) {
+    throw new ApiError(400, 'Uploaded equipment image is larger than 5 MB.');
+  }
+  if (!matchesImageSignature(buffer, mimeType)) {
+    throw new ApiError(400, 'Uploaded bytes do not match the declared image type.');
+  }
+  const bytes = new Uint8Array(new ArrayBuffer(buffer.length));
+  bytes.set(buffer);
+  return { bytes, mimeType };
+}
+
+async function requireOwnedGym(userId: string, gymId: string) {
+  const gym = await db.gym.findFirst({ where: { id: gymId, userId }, select: { id: true } });
+  if (!gym) throw new ApiError(404, 'Gym not found.');
+  return gym;
+}
+
+async function requireOwnedEquipment(userId: string, equipmentId: string) {
+  const equipment = await db.gymEquipment.findFirst({
+    where: { id: equipmentId, gym: { userId } },
+    select: { id: true, gymId: true },
+  });
+  if (!equipment) throw new ApiError(404, 'Gym equipment not found.');
+  return equipment;
+}
+
+function matchesImageSignature(buffer: Buffer, mimeType: GymEquipmentImageMimeType): boolean {
+  if (mimeType === 'image/jpeg') {
+    return buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff;
+  }
+  if (mimeType === 'image/png') {
+    return (
+      buffer.length >= 8 &&
+      buffer.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))
+    );
+  }
+  return (
+    buffer.length >= 12 &&
+    buffer.subarray(0, 4).toString('ascii') === 'RIFF' &&
+    buffer.subarray(8, 12).toString('ascii') === 'WEBP'
+  );
+}

--- a/lib/gym-equipment.ts
+++ b/lib/gym-equipment.ts
@@ -108,15 +108,6 @@ export async function upsertOwnedGymEquipment(
       });
   if (input.equipmentId && !current) throw new ApiError(404, 'Gym equipment not found.');
   const created = current == null;
-  if (created) {
-    const equipmentCount = await db.gymEquipment.count({ where: { gymId } });
-    if (equipmentCount >= MAX_GYM_EQUIPMENT_PER_GYM) {
-      throw new ApiError(
-        400,
-        'A gym can contain at most ' + MAX_GYM_EQUIPMENT_PER_GYM + ' physical equipment items.',
-      );
-    }
-  }
 
   const exerciseIds =
     requestedExerciseIds ?? current?.exerciseLinks.map((link) => link.exerciseId) ?? [];
@@ -136,6 +127,19 @@ export async function upsertOwnedGymEquipment(
   const effectiveWeightOptions = input.weightOptions ?? current?.weightOptions ?? [];
 
   const item = await db.$transaction(async (tx) => {
+    if (created) {
+      // Serialize creations per gym so concurrent requests cannot both observe
+      // the same pre-limit count and exceed MAX_GYM_EQUIPMENT_PER_GYM.
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${gymId}))`;
+      const equipmentCount = await tx.gymEquipment.count({ where: { gymId } });
+      if (equipmentCount >= MAX_GYM_EQUIPMENT_PER_GYM) {
+        throw new ApiError(
+          400,
+          'A gym can contain at most ' + MAX_GYM_EQUIPMENT_PER_GYM + ' physical equipment items.',
+        );
+      }
+    }
+
     const saved = current
       ? await tx.gymEquipment.update({
           where: { id: current.id },

--- a/lib/gym-equipment.ts
+++ b/lib/gym-equipment.ts
@@ -6,6 +6,7 @@ import type { EquipmentType } from '@/lib/prisma-client';
 export const GYM_EQUIPMENT_IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'] as const;
 export type GymEquipmentImageMimeType = (typeof GYM_EQUIPMENT_IMAGE_MIME_TYPES)[number];
 export const MAX_GYM_EQUIPMENT_IMAGE_BYTES = 5 * 1024 * 1024;
+export const MAX_GYM_EQUIPMENT_PER_GYM = 1000;
 
 export interface UpsertGymEquipmentInput {
   equipmentId?: string;
@@ -109,6 +110,16 @@ export async function upsertOwnedGymEquipment(
         },
       });
   if (input.equipmentId && !current) throw new ApiError(404, 'Gym equipment not found.');
+  const created = current == null;
+  if (created) {
+    const equipmentCount = await db.gymEquipment.count({ where: { gymId } });
+    if (equipmentCount >= MAX_GYM_EQUIPMENT_PER_GYM) {
+      throw new ApiError(
+        400,
+        'A gym can contain at most ' + MAX_GYM_EQUIPMENT_PER_GYM + ' physical equipment items.',
+      );
+    }
+  }
 
   const exerciseIds =
     requestedExerciseIds ?? current?.exerciseLinks.map((link) => link.exerciseId) ?? [];
@@ -208,7 +219,7 @@ export async function upsertOwnedGymEquipment(
       exerciseEquipmentType: exercise.equipmentType,
     }));
 
-  return { equipment: saved, mismatchedExercises };
+  return { equipment: saved, mismatchedExercises, created };
 }
 
 export async function deleteOwnedGymEquipment(userId: string, equipmentId: string) {
@@ -258,14 +269,15 @@ export async function setOwnedGymEquipmentImage(
     throw new ApiError(400, 'Choose exactly one image action: clear, imageUrl, or imageBase64.');
   }
 
+  const decoded = input.imageBase64
+    ? decodeGymEquipmentImage(input.imageBase64, input.mimeType)
+    : null;
+
   const data = input.clear
     ? { imageUrl: null, imageData: null, imageMimeType: null }
     : input.imageUrl
       ? { imageUrl: input.imageUrl, imageData: null, imageMimeType: null }
-      : (() => {
-          const decoded = decodeGymEquipmentImage(input.imageBase64!, input.mimeType);
-          return { imageUrl: null, imageData: decoded.bytes, imageMimeType: decoded.mimeType };
-        })();
+      : { imageUrl: null, imageData: decoded!.bytes, imageMimeType: decoded!.mimeType };
 
   return db.gymEquipment.update({
     where: { id: equipment.id },

--- a/lib/schemas/gym-equipment.test.ts
+++ b/lib/schemas/gym-equipment.test.ts
@@ -4,6 +4,7 @@ import { gymEquipmentImageSchema, gymEquipmentUpsertSchema } from './gym-equipme
 describe('gym equipment schemas', () => {
   it('normalizes a complete equipment input without inventing omitted update fields', () => {
     const parsed = gymEquipmentUpsertSchema.parse({
+      equipmentId: ' equipment-1 ',
       name: '  Cable station  ',
       equipmentType: 'CABLE',
       quantity: 2,
@@ -12,6 +13,7 @@ describe('gym equipment schemas', () => {
     });
 
     expect(parsed).toMatchObject({
+      equipmentId: 'equipment-1',
       name: 'Cable station',
       quantity: 2,
       weightOptions: [10, 20],
@@ -30,9 +32,9 @@ describe('gym equipment schemas', () => {
   });
 
   it('requires exactly one safe equipment image source', () => {
-    expect(gymEquipmentImageSchema.safeParse({ imageUrl: 'http://unsafe.test/image.jpg' }).success).toBe(
-      false,
-    );
+    expect(
+      gymEquipmentImageSchema.safeParse({ imageUrl: 'http://unsafe.test/image.jpg' }).success,
+    ).toBe(false);
     expect(
       gymEquipmentImageSchema.safeParse({ imageBase64: 'abcd', mimeType: 'image/gif' }).success,
     ).toBe(false);

--- a/lib/schemas/gym-equipment.test.ts
+++ b/lib/schemas/gym-equipment.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { gymEquipmentImageSchema, gymEquipmentUpsertSchema } from './gym-equipment';
 
 describe('gym equipment schemas', () => {
-  it('normalizes a complete equipment input', () => {
+  it('normalizes a complete equipment input without inventing omitted update fields', () => {
     const parsed = gymEquipmentUpsertSchema.parse({
       name: '  Cable station  ',
       equipmentType: 'CABLE',
@@ -16,8 +16,17 @@ describe('gym equipment schemas', () => {
       quantity: 2,
       weightOptions: [10, 20],
       exerciseIds: ['exercise-1'],
-      markExercisesAvailable: true,
     });
+    expect(parsed.markExercisesAvailable).toBeUndefined();
+
+    const minimal = gymEquipmentUpsertSchema.parse({
+      name: 'Cable station',
+      equipmentType: 'CABLE',
+    });
+    expect(minimal.quantity).toBeUndefined();
+    expect(minimal.weightOptions).toBeUndefined();
+    expect(minimal.exerciseIds).toBeUndefined();
+    expect(minimal.markExercisesAvailable).toBeUndefined();
   });
 
   it('requires exactly one safe equipment image source', () => {

--- a/lib/schemas/gym-equipment.test.ts
+++ b/lib/schemas/gym-equipment.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { gymEquipmentImageSchema, gymEquipmentUpsertSchema } from './gym-equipment';
+
+describe('gym equipment schemas', () => {
+  it('normalizes a complete equipment input', () => {
+    const parsed = gymEquipmentUpsertSchema.parse({
+      name: '  Cable station  ',
+      equipmentType: 'CABLE',
+      quantity: 2,
+      weightOptions: [20, 10, 20],
+      exerciseIds: ['exercise-1'],
+    });
+
+    expect(parsed).toMatchObject({
+      name: 'Cable station',
+      quantity: 2,
+      weightOptions: [10, 20],
+      exerciseIds: ['exercise-1'],
+      markExercisesAvailable: true,
+    });
+  });
+
+  it('requires exactly one safe equipment image source', () => {
+    expect(gymEquipmentImageSchema.safeParse({ imageUrl: 'http://unsafe.test/image.jpg' }).success).toBe(
+      false,
+    );
+    expect(
+      gymEquipmentImageSchema.safeParse({ imageBase64: 'abcd', mimeType: 'image/gif' }).success,
+    ).toBe(false);
+    expect(
+      gymEquipmentImageSchema.safeParse({
+        imageUrl: 'https://example.test/image.jpg',
+        imageBase64: 'abcd',
+        mimeType: 'image/jpeg',
+      }).success,
+    ).toBe(false);
+    expect(
+      gymEquipmentImageSchema.safeParse({ imageBase64: 'abcd', mimeType: 'image/jpeg' }).success,
+    ).toBe(true);
+  });
+});

--- a/lib/schemas/gym-equipment.ts
+++ b/lib/schemas/gym-equipment.ts
@@ -6,6 +6,7 @@ import { gymWeightListSchema } from '@/lib/schemas/gym';
 const databaseIdSchema = z.string().trim().min(1).max(191);
 
 export const gymEquipmentUpsertSchema = z.object({
+  equipmentId: databaseIdSchema.optional(),
   name: z.string().trim().min(1).max(120),
   equipmentType: z.nativeEnum(EquipmentType),
   description: z.string().trim().max(4000).nullable().optional(),

--- a/lib/schemas/gym-equipment.ts
+++ b/lib/schemas/gym-equipment.ts
@@ -11,10 +11,10 @@ export const gymEquipmentUpsertSchema = z.object({
   description: z.string().trim().max(4000).nullable().optional(),
   manufacturer: z.string().trim().max(120).nullable().optional(),
   modelName: z.string().trim().max(120).nullable().optional(),
-  quantity: z.number().int().min(1).max(100).default(1),
-  weightOptions: gymWeightListSchema.default([]),
-  exerciseIds: z.array(databaseIdSchema).max(100).default([]),
-  markExercisesAvailable: z.boolean().default(true),
+  quantity: z.number().int().min(1).max(100).optional(),
+  weightOptions: gymWeightListSchema.optional(),
+  exerciseIds: z.array(databaseIdSchema).max(100).optional(),
+  markExercisesAvailable: z.boolean().optional(),
 });
 
 const maximumBase64Length = 7_100_000;

--- a/lib/schemas/gym-equipment.ts
+++ b/lib/schemas/gym-equipment.ts
@@ -3,7 +3,7 @@ import { EquipmentType } from '@/lib/prisma-client';
 import { GYM_EQUIPMENT_IMAGE_MIME_TYPES } from '@/lib/gym-equipment';
 import { gymWeightListSchema } from '@/lib/schemas/gym';
 
-const databaseIdSchema = z.string().trim().min(1).max(191);
+export const databaseIdSchema = z.string().trim().min(1).max(191);
 
 export const gymEquipmentUpsertSchema = z.object({
   equipmentId: databaseIdSchema.optional(),

--- a/lib/schemas/gym-equipment.ts
+++ b/lib/schemas/gym-equipment.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+import { EquipmentType } from '@/lib/prisma-client';
+import { GYM_EQUIPMENT_IMAGE_MIME_TYPES } from '@/lib/gym-equipment';
+import { gymWeightListSchema } from '@/lib/schemas/gym';
+
+const databaseIdSchema = z.string().trim().min(1).max(191);
+
+export const gymEquipmentUpsertSchema = z.object({
+  name: z.string().trim().min(1).max(120),
+  equipmentType: z.nativeEnum(EquipmentType),
+  description: z.string().trim().max(4000).nullable().optional(),
+  manufacturer: z.string().trim().max(120).nullable().optional(),
+  modelName: z.string().trim().max(120).nullable().optional(),
+  quantity: z.number().int().min(1).max(100).default(1),
+  weightOptions: gymWeightListSchema.default([]),
+  exerciseIds: z.array(databaseIdSchema).max(100).default([]),
+  markExercisesAvailable: z.boolean().default(true),
+});
+
+const maximumBase64Length = 7_100_000;
+
+export const gymEquipmentImageSchema = z
+  .object({
+    imageUrl: z.string().trim().url().max(2048).startsWith('https://').optional(),
+    imageBase64: z.string().max(maximumBase64Length).optional(),
+    mimeType: z.enum(GYM_EQUIPMENT_IMAGE_MIME_TYPES).optional(),
+  })
+  .refine((value) => Number(value.imageUrl != null) + Number(value.imageBase64 != null) === 1, {
+    message: 'Choose exactly one image source.',
+  })
+  .refine((value) => value.imageBase64 == null || value.mimeType != null, {
+    message: 'Uploaded images require a MIME type.',
+  });
+
+export type GymEquipmentUpsertInput = z.infer<typeof gymEquipmentUpsertSchema>;
+export type GymEquipmentImageInput = z.infer<typeof gymEquipmentImageSchema>;

--- a/prisma/migrations/20260823063000_add_gym_equipment_inventory/migration.sql
+++ b/prisma/migrations/20260823063000_add_gym_equipment_inventory/migration.sql
@@ -1,7 +1,5 @@
--- Physical gym equipment is additive to the accepted saved-gym model.
--- IF NOT EXISTS keeps this migration compatible with forks that already
--- shipped the same tables under an earlier migration id.
-CREATE TABLE IF NOT EXISTS "GymEquipment" (
+-- CreateTable
+CREATE TABLE "GymEquipment" (
     "id" TEXT NOT NULL,
     "gymId" TEXT NOT NULL,
     "name" TEXT NOT NULL,
@@ -16,37 +14,32 @@ CREATE TABLE IF NOT EXISTS "GymEquipment" (
     "imageMimeType" TEXT,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
+
     CONSTRAINT "GymEquipment_pkey" PRIMARY KEY ("id")
 );
 
-CREATE TABLE IF NOT EXISTS "GymEquipmentExercise" (
+-- CreateTable
+CREATE TABLE "GymEquipmentExercise" (
     "equipmentId" TEXT NOT NULL,
     "exerciseId" TEXT NOT NULL,
+
     CONSTRAINT "GymEquipmentExercise_pkey" PRIMARY KEY ("equipmentId", "exerciseId")
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS "GymEquipment_gymId_name_key"
-    ON "GymEquipment"("gymId", "name");
-CREATE INDEX IF NOT EXISTS "GymEquipment_gymId_equipmentType_idx"
-    ON "GymEquipment"("gymId", "equipmentType");
-CREATE INDEX IF NOT EXISTS "GymEquipmentExercise_exerciseId_idx"
-    ON "GymEquipmentExercise"("exerciseId");
+-- CreateIndex
+CREATE UNIQUE INDEX "GymEquipment_gymId_name_key" ON "GymEquipment"("gymId", "name");
 
-DO $$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'GymEquipment_gymId_fkey') THEN
-    ALTER TABLE "GymEquipment"
-      ADD CONSTRAINT "GymEquipment_gymId_fkey"
-      FOREIGN KEY ("gymId") REFERENCES "Gym"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-  END IF;
-  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'GymEquipmentExercise_equipmentId_fkey') THEN
-    ALTER TABLE "GymEquipmentExercise"
-      ADD CONSTRAINT "GymEquipmentExercise_equipmentId_fkey"
-      FOREIGN KEY ("equipmentId") REFERENCES "GymEquipment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-  END IF;
-  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'GymEquipmentExercise_exerciseId_fkey') THEN
-    ALTER TABLE "GymEquipmentExercise"
-      ADD CONSTRAINT "GymEquipmentExercise_exerciseId_fkey"
-      FOREIGN KEY ("exerciseId") REFERENCES "Exercise"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-  END IF;
-END $$;
+-- CreateIndex
+CREATE INDEX "GymEquipment_gymId_equipmentType_idx" ON "GymEquipment"("gymId", "equipmentType");
+
+-- CreateIndex
+CREATE INDEX "GymEquipmentExercise_exerciseId_idx" ON "GymEquipmentExercise"("exerciseId");
+
+-- AddForeignKey
+ALTER TABLE "GymEquipment" ADD CONSTRAINT "GymEquipment_gymId_fkey" FOREIGN KEY ("gymId") REFERENCES "Gym"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GymEquipmentExercise" ADD CONSTRAINT "GymEquipmentExercise_equipmentId_fkey" FOREIGN KEY ("equipmentId") REFERENCES "GymEquipment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GymEquipmentExercise" ADD CONSTRAINT "GymEquipmentExercise_exerciseId_fkey" FOREIGN KEY ("exerciseId") REFERENCES "Exercise"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260823063000_add_gym_equipment_inventory/migration.sql
+++ b/prisma/migrations/20260823063000_add_gym_equipment_inventory/migration.sql
@@ -1,0 +1,52 @@
+-- Physical gym equipment is additive to the accepted saved-gym model.
+-- IF NOT EXISTS keeps this migration compatible with forks that already
+-- shipped the same tables under an earlier migration id.
+CREATE TABLE IF NOT EXISTS "GymEquipment" (
+    "id" TEXT NOT NULL,
+    "gymId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "equipmentType" "EquipmentType" NOT NULL,
+    "description" TEXT,
+    "manufacturer" TEXT,
+    "modelName" TEXT,
+    "quantity" INTEGER NOT NULL DEFAULT 1,
+    "weightOptions" DOUBLE PRECISION[] NOT NULL DEFAULT ARRAY[]::DOUBLE PRECISION[],
+    "imageUrl" TEXT,
+    "imageData" BYTEA,
+    "imageMimeType" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "GymEquipment_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE IF NOT EXISTS "GymEquipmentExercise" (
+    "equipmentId" TEXT NOT NULL,
+    "exerciseId" TEXT NOT NULL,
+    CONSTRAINT "GymEquipmentExercise_pkey" PRIMARY KEY ("equipmentId", "exerciseId")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "GymEquipment_gymId_name_key"
+    ON "GymEquipment"("gymId", "name");
+CREATE INDEX IF NOT EXISTS "GymEquipment_gymId_equipmentType_idx"
+    ON "GymEquipment"("gymId", "equipmentType");
+CREATE INDEX IF NOT EXISTS "GymEquipmentExercise_exerciseId_idx"
+    ON "GymEquipmentExercise"("exerciseId");
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'GymEquipment_gymId_fkey') THEN
+    ALTER TABLE "GymEquipment"
+      ADD CONSTRAINT "GymEquipment_gymId_fkey"
+      FOREIGN KEY ("gymId") REFERENCES "Gym"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'GymEquipmentExercise_equipmentId_fkey') THEN
+    ALTER TABLE "GymEquipmentExercise"
+      ADD CONSTRAINT "GymEquipmentExercise_equipmentId_fkey"
+      FOREIGN KEY ("equipmentId") REFERENCES "GymEquipment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'GymEquipmentExercise_exerciseId_fkey') THEN
+    ALTER TABLE "GymEquipmentExercise"
+      ADD CONSTRAINT "GymEquipmentExercise_exerciseId_fkey"
+      FOREIGN KEY ("exerciseId") REFERENCES "Exercise"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -122,26 +122,27 @@ model Message {
 }
 
 model Exercise {
-  id               String              @id @default(cuid())
-  userId           String
-  user             User                @relation(fields: [userId], references: [id])
-  name             String
-  muscleGroup      MuscleGroup
-  category         ExerciseCategory
-  defaultRestSec   Int                 @default(90)
-  notes            String?
+  id                String                 @id @default(cuid())
+  userId            String
+  user              User                   @relation(fields: [userId], references: [id])
+  name              String
+  muscleGroup       MuscleGroup
+  category          ExerciseCategory
+  defaultRestSec    Int                    @default(90)
+  notes             String?
   // For bodyweight exercises (pull-ups, dips, push-ups...): the effective
   // tonnage includes User.bodyweight. Set.weight remains the added load (0 by
   // default, always >= 0 - the input schemas clamp it; negative loads for
   // assistance machines are deliberately not supported, see issue #118).
-  usesBodyweight   Boolean             @default(false)
+  usesBodyweight    Boolean                @default(false)
   // Determines which saved-gym inventory constrains suggested loads.
-  equipmentType    EquipmentType       @default(OTHER)
-  createdAt        DateTime            @default(now())
-  programExercises ProgramExercise[]
-  sets             Set[]
-  goals            ExerciseGoal[]
-  gymConfigs       GymExerciseConfig[]
+  equipmentType     EquipmentType          @default(OTHER)
+  createdAt         DateTime               @default(now())
+  programExercises  ProgramExercise[]
+  sets              Set[]
+  goals             ExerciseGoal[]
+  gymConfigs        GymExerciseConfig[]
+  gymEquipmentLinks GymEquipmentExercise[]
 
   @@unique([userId, name])
 }
@@ -280,6 +281,7 @@ model Gym {
   activeForUsers  User[]              @relation("ActiveGym")
   sessions        Session[]
   exerciseConfigs GymExerciseConfig[]
+  equipment       GymEquipment[]
 
   @@unique([userId, name])
   @@index([userId, updatedAt])
@@ -297,6 +299,38 @@ model GymExerciseConfig {
   weightOptions Float[]  @default([])
 
   @@unique([gymId, exerciseId])
+  @@index([exerciseId])
+}
+
+model GymEquipment {
+  id            String                 @id @default(cuid())
+  gymId         String
+  gym           Gym                    @relation(fields: [gymId], references: [id], onDelete: Cascade)
+  name          String
+  equipmentType EquipmentType
+  description   String?
+  manufacturer  String?
+  modelName     String?
+  quantity      Int                    @default(1)
+  weightOptions Float[]                @default([])
+  imageUrl      String?
+  imageData     Bytes?
+  imageMimeType String?
+  createdAt     DateTime               @default(now())
+  updatedAt     DateTime               @updatedAt
+  exerciseLinks GymEquipmentExercise[]
+
+  @@unique([gymId, name])
+  @@index([gymId, equipmentType])
+}
+
+model GymEquipmentExercise {
+  equipmentId String
+  equipment   GymEquipment @relation(fields: [equipmentId], references: [id], onDelete: Cascade)
+  exerciseId  String
+  exercise    Exercise     @relation(fields: [exerciseId], references: [id], onDelete: Cascade)
+
+  @@id([equipmentId, exerciseId])
   @@index([exerciseId])
 }
 

--- a/tests/integration/backup-route.test.ts
+++ b/tests/integration/backup-route.test.ts
@@ -10,6 +10,8 @@ import { getCurrentUserId } from '@/lib/auth';
 // Auth is read through getCurrentUserId (via requireApiUserId in @/lib/api).
 vi.mock('@/lib/auth', () => ({ getCurrentUserId: vi.fn() }));
 const mockUserId = vi.mocked(getCurrentUserId);
+const EQUIPMENT_PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const EQUIPMENT_PNG_BASE64 = 'iVBORw0KGgo=';
 
 import { GET as getBackup, POST as postBackup } from '@/app/api/backup/route';
 
@@ -106,6 +108,21 @@ async function seedFullUser(email: string) {
     },
   });
   await db.user.update({ where: { id: user.id }, data: { activeGymId: gym.id } });
+  await db.gymEquipment.create({
+    data: {
+      gymId: gym.id,
+      name: 'Competition bench station',
+      equipmentType: 'BARBELL',
+      description: 'Flat bench with uprights and safety arms.',
+      manufacturer: 'GymCo',
+      modelName: 'Bench Pro',
+      quantity: 2,
+      weightOptions: [20, 40, 60, 80, 100],
+      imageData: EQUIPMENT_PNG,
+      imageMimeType: 'image/png',
+      exerciseLinks: { create: { exerciseId: bench.id } },
+    },
+  });
   const program = await db.program.create({
     data: {
       userId: user.id,
@@ -265,6 +282,10 @@ async function countsFor(userId: string) {
     messages: await db.message.count({ where: { conversation: { userId } } }),
     gyms: await db.gym.count({ where: { userId } }),
     gymConfigs: await db.gymExerciseConfig.count({ where: { gym: { userId } } }),
+    gymEquipment: await db.gymEquipment.count({ where: { gym: { userId } } }),
+    gymEquipmentLinks: await db.gymEquipmentExercise.count({
+      where: { equipment: { gym: { userId } } },
+    }),
   };
 }
 
@@ -273,7 +294,7 @@ beforeEach(() => {
 });
 
 describe('GET /api/backup - export completeness (issue #168)', () => {
-  it('exports version 3 with saved gyms and all earlier backup fields', async () => {
+  it('exports version 4 with physical gym equipment and all earlier backup fields', async () => {
     const user = await seedFullUser('a@test.dev');
     actAs(user.id);
 
@@ -281,7 +302,7 @@ describe('GET /api/backup - export completeness (issue #168)', () => {
     expect(res.status).toBe(200);
     const dump = await res.json();
 
-    expect(dump.version).toBe(3);
+    expect(dump.version).toBe(4);
     expect(dump.profile).toMatchObject({
       displayName: 'Julien',
       bodyweight: 82.5,
@@ -303,6 +324,21 @@ describe('GET /api/backup - export completeness (issue #168)', () => {
         dumbbellWeights: [10, 12, 14, 16, 19],
         plateWeights: [1.25, 2.5, 5, 10, 20],
         barWeights: [20],
+        equipment: [
+          {
+            name: 'Competition bench station',
+            equipmentType: 'BARBELL',
+            description: 'Flat bench with uprights and safety arms.',
+            manufacturer: 'GymCo',
+            modelName: 'Bench Pro',
+            quantity: 2,
+            weightOptions: [20, 40, 60, 80, 100],
+            imageUrl: null,
+            imageMimeType: 'image/png',
+            imageBase64: EQUIPMENT_PNG_BASE64,
+            exerciseNames: ['Bench Press'],
+          },
+        ],
         exerciseConfigs: [{ exerciseName: 'Running', isAvailable: false, weightOptions: [] }],
       },
     ]);

--- a/tests/integration/backup-route.test.ts
+++ b/tests/integration/backup-route.test.ts
@@ -395,10 +395,13 @@ describe('GET /api/backup - export completeness (issue #168)', () => {
       })),
     });
     actAs(user.id);
+    const materializeGyms = vi.spyOn(db.gym, 'findMany');
 
     const response = await getBackup();
 
     expect(response.status).toBe(413);
+    expect(materializeGyms).not.toHaveBeenCalled();
+    materializeGyms.mockRestore();
     expect(await response.json()).toEqual({
       error:
         'This backup is larger than the maximum restorable backup size. Reduce uploaded gym equipment images and try again.',

--- a/tests/integration/backup-route.test.ts
+++ b/tests/integration/backup-route.test.ts
@@ -375,6 +375,35 @@ describe('GET /api/backup - export completeness (issue #168)', () => {
     expect(dump.conversations).toHaveLength(1);
     expect(dump.conversations[0].messages).toHaveLength(2);
   });
+
+  it('rejects image-heavy exports before materializing an unrestorable backup', async () => {
+    const user = await db.user.create({
+      data: { email: 'export-budget@test.dev', passwordHash: 'x' },
+    });
+    const gym = await db.gym.create({
+      data: { userId: user.id, name: 'Image-heavy gym' },
+    });
+    const maxImage = new Uint8Array(5 * 1024 * 1024);
+    maxImage.set(EQUIPMENT_PNG);
+    await db.gymEquipment.createMany({
+      data: Array.from({ length: 8 }, (_, index) => ({
+        gymId: gym.id,
+        name: 'Image station ' + index,
+        equipmentType: 'MACHINE' as const,
+        imageData: maxImage,
+        imageMimeType: 'image/png',
+      })),
+    });
+    actAs(user.id);
+
+    const response = await getBackup();
+
+    expect(response.status).toBe(413);
+    expect(await response.json()).toEqual({
+      error:
+        'This backup is larger than the maximum restorable backup size. Reduce uploaded gym equipment images and try again.',
+    });
+  });
 });
 
 describe('POST /api/backup - restore round trip (issue #168)', () => {

--- a/tests/integration/gym-equipment-api.test.ts
+++ b/tests/integration/gym-equipment-api.test.ts
@@ -206,7 +206,8 @@ describe('gym equipment REST API', () => {
 
     const foreignSetImageResponse = await setImage(
       request(`http://test.local/api/gym-equipment/${privateEquipment.id}/image`, 'PUT', {
-        clear: true,
+        imageBase64: PNG.toString('base64'),
+        mimeType: 'image/png',
       }),
       params(privateEquipment.id),
     );

--- a/tests/integration/gym-equipment-api.test.ts
+++ b/tests/integration/gym-equipment-api.test.ts
@@ -1,0 +1,176 @@
+import { Buffer } from 'node:buffer';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { db } from '@/lib/db';
+import { getCurrentUserId } from '@/lib/auth';
+
+vi.mock('@/lib/auth', () => ({ getCurrentUserId: vi.fn() }));
+const mockUserId = vi.mocked(getCurrentUserId);
+
+import { GET as listEquipment, POST as createEquipment } from '@/app/api/gyms/[id]/equipment/route';
+import { DELETE as deleteEquipment, PUT as updateEquipment } from '@/app/api/gym-equipment/[id]/route';
+import {
+  DELETE as deleteImage,
+  GET as getImage,
+  PUT as setImage,
+} from '@/app/api/gym-equipment/[id]/image/route';
+
+const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+function request(url: string, method = 'GET', body?: unknown): Request {
+  return new Request(url, {
+    method,
+    headers: body === undefined ? undefined : { 'Content-Type': 'application/json' },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+function params(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+async function seedUser(label: string) {
+  const user = await db.user.create({
+    data: { email: `equipment-${label}-${Date.now()}@test.dev`, passwordHash: 'unused' },
+  });
+  const gym = await db.gym.create({ data: { userId: user.id, name: `${label} gym` } });
+  return { user, gym };
+}
+
+beforeEach(() => mockUserId.mockReset());
+
+describe('gym equipment REST API', () => {
+  it('manages a physical station, exercise links, compatibility config, and image', async () => {
+    const { user, gym } = await seedUser('owner');
+    const exercise = await db.exercise.create({
+      data: {
+        userId: user.id,
+        name: 'Cable row',
+        muscleGroup: 'BACK_THICKNESS',
+        category: 'COMPOUND',
+        equipmentType: 'CABLE',
+      },
+    });
+    mockUserId.mockResolvedValue(user.id);
+
+    const createdResponse = await createEquipment(
+      request(`http://test.local/api/gyms/${gym.id}/equipment`, 'POST', {
+        name: 'Dual cable station',
+        equipmentType: 'CABLE',
+        description: 'Two adjustable pulleys',
+        manufacturer: 'GymCo',
+        modelName: 'DC-2',
+        quantity: 2,
+        weightOptions: [20, 10, 20],
+        exerciseIds: [exercise.id],
+      }),
+      params(gym.id),
+    );
+    expect(createdResponse.status).toBe(201);
+    const created = await createdResponse.json();
+    const equipmentId = created.equipment.id as string;
+    expect(created.equipment).toMatchObject({
+      name: 'Dual cable station',
+      equipmentType: 'CABLE',
+      quantity: 2,
+      weightOptions: [10, 20],
+    });
+
+    const link = await db.gymEquipmentExercise.findUnique({
+      where: { equipmentId_exerciseId: { equipmentId, exerciseId: exercise.id } },
+    });
+    expect(link).not.toBeNull();
+    const compatibility = await db.gymExerciseConfig.findUnique({
+      where: { gymId_exerciseId: { gymId: gym.id, exerciseId: exercise.id } },
+    });
+    expect(compatibility).toMatchObject({ isAvailable: true, weightOptions: [10, 20] });
+
+    const listedResponse = await listEquipment(
+      request(`http://test.local/api/gyms/${gym.id}/equipment`),
+      params(gym.id),
+    );
+    expect(listedResponse.status).toBe(200);
+    const listed = await listedResponse.json();
+    expect(listed.equipment).toHaveLength(1);
+    expect(listed.equipment[0].exerciseLinks).toEqual([
+      expect.objectContaining({ id: exercise.id, name: 'Cable row' }),
+    ]);
+
+    const updatedResponse = await updateEquipment(
+      request(`http://test.local/api/gym-equipment/${equipmentId}`, 'PUT', {
+        name: 'Cable station A',
+        equipmentType: 'CABLE',
+        quantity: 1,
+        weightOptions: [5, 10, 15, 20],
+        exerciseIds: [exercise.id],
+      }),
+      params(equipmentId),
+    );
+    expect(updatedResponse.status).toBe(200);
+    expect((await updatedResponse.json()).equipment.name).toBe('Cable station A');
+
+    const imageResponse = await setImage(
+      request(`http://test.local/api/gym-equipment/${equipmentId}/image`, 'PUT', {
+        imageBase64: PNG.toString('base64'),
+        mimeType: 'image/png',
+      }),
+      params(equipmentId),
+    );
+    expect(imageResponse.status).toBe(200);
+    const fetchedImage = await getImage(
+      request(`http://test.local/api/gym-equipment/${equipmentId}/image`),
+      params(equipmentId),
+    );
+    expect(fetchedImage.status).toBe(200);
+    expect(fetchedImage.headers.get('content-type')).toBe('image/png');
+    expect(Buffer.from(await fetchedImage.arrayBuffer())).toEqual(PNG);
+
+    const clearResponse = await deleteImage(
+      request(`http://test.local/api/gym-equipment/${equipmentId}/image`, 'DELETE'),
+      params(equipmentId),
+    );
+    expect(clearResponse.status).toBe(200);
+    expect(
+      await db.gymEquipment.findUnique({ where: { id: equipmentId }, select: { imageData: true } }),
+    ).toEqual({ imageData: null });
+
+    const deletedResponse = await deleteEquipment(
+      request(`http://test.local/api/gym-equipment/${equipmentId}`, 'DELETE'),
+      params(equipmentId),
+    );
+    expect(deletedResponse.status).toBe(200);
+    expect(await db.gymEquipment.count({ where: { id: equipmentId } })).toBe(0);
+  });
+
+  it('does not expose another user gym or accept another user exercise link', async () => {
+    const owner = await seedUser('private-owner');
+    const other = await seedUser('other');
+    const otherExercise = await db.exercise.create({
+      data: {
+        userId: other.user.id,
+        name: 'Other machine exercise',
+        muscleGroup: 'QUADS',
+        category: 'COMPOUND',
+        equipmentType: 'MACHINE',
+      },
+    });
+
+    mockUserId.mockResolvedValue(owner.user.id);
+    const foreignLinkResponse = await createEquipment(
+      request(`http://test.local/api/gyms/${owner.gym.id}/equipment`, 'POST', {
+        name: 'Private station',
+        equipmentType: 'MACHINE',
+        exerciseIds: [otherExercise.id],
+      }),
+      params(owner.gym.id),
+    );
+    expect(foreignLinkResponse.status).toBe(400);
+    expect(await db.gymEquipment.count({ where: { gymId: owner.gym.id } })).toBe(0);
+
+    mockUserId.mockResolvedValue(other.user.id);
+    const foreignGymResponse = await listEquipment(
+      request(`http://test.local/api/gyms/${owner.gym.id}/equipment`),
+      params(owner.gym.id),
+    );
+    expect(foreignGymResponse.status).toBe(404);
+  });
+});

--- a/tests/integration/gym-equipment-api.test.ts
+++ b/tests/integration/gym-equipment-api.test.ts
@@ -166,11 +166,61 @@ describe('gym equipment REST API', () => {
     expect(foreignLinkResponse.status).toBe(400);
     expect(await db.gymEquipment.count({ where: { gymId: owner.gym.id } })).toBe(0);
 
+    const privateEquipment = await db.gymEquipment.create({
+      data: {
+        gymId: owner.gym.id,
+        name: 'Owner-only station',
+        equipmentType: 'MACHINE',
+        imageData: PNG,
+        imageMimeType: 'image/png',
+      },
+    });
+
     mockUserId.mockResolvedValue(other.user.id);
     const foreignGymResponse = await listEquipment(
       request(`http://test.local/api/gyms/${owner.gym.id}/equipment`),
       params(owner.gym.id),
     );
     expect(foreignGymResponse.status).toBe(404);
+
+    const foreignUpdateResponse = await updateEquipment(
+      request(`http://test.local/api/gym-equipment/${privateEquipment.id}`, 'PUT', {
+        name: 'Hacked station',
+        equipmentType: 'MACHINE',
+      }),
+      params(privateEquipment.id),
+    );
+    expect(foreignUpdateResponse.status).toBe(404);
+
+    const foreignDeleteResponse = await deleteEquipment(
+      request(`http://test.local/api/gym-equipment/${privateEquipment.id}`, 'DELETE'),
+      params(privateEquipment.id),
+    );
+    expect(foreignDeleteResponse.status).toBe(404);
+
+    const foreignGetImageResponse = await getImage(
+      request(`http://test.local/api/gym-equipment/${privateEquipment.id}/image`),
+      params(privateEquipment.id),
+    );
+    expect(foreignGetImageResponse.status).toBe(404);
+
+    const foreignSetImageResponse = await setImage(
+      request(`http://test.local/api/gym-equipment/${privateEquipment.id}/image`, 'PUT', {
+        clear: true,
+      }),
+      params(privateEquipment.id),
+    );
+    expect(foreignSetImageResponse.status).toBe(404);
+
+    const foreignDeleteImageResponse = await deleteImage(
+      request(`http://test.local/api/gym-equipment/${privateEquipment.id}/image`, 'DELETE'),
+      params(privateEquipment.id),
+    );
+    expect(foreignDeleteImageResponse.status).toBe(404);
+
+    const preserved = await db.gymEquipment.findUnique({ where: { id: privateEquipment.id } });
+    expect(preserved?.name).toBe('Owner-only station');
+    expect(preserved?.imageMimeType).toBe('image/png');
+    expect(preserved?.imageData?.byteLength).toBe(PNG.byteLength);
   });
 });

--- a/tests/integration/gym-equipment-api.test.ts
+++ b/tests/integration/gym-equipment-api.test.ts
@@ -181,6 +181,28 @@ describe('gym equipment REST API', () => {
     expect(await response.json()).toEqual({ error: 'Invalid gym id.' });
   });
 
+  it('rejects invalid equipment route ids before ownership operations', async () => {
+    const { user } = await seedUser('invalid-equipment-route-id');
+    mockUserId.mockResolvedValue(user.id);
+
+    const updateResponse = await updateEquipment(
+      request('http://test.local/api/gym-equipment/%20', 'PUT', {
+        name: 'Ignored station',
+        equipmentType: 'MACHINE',
+      }),
+      params('   '),
+    );
+    expect(updateResponse.status).toBe(400);
+    expect(await updateResponse.json()).toEqual({ error: 'Invalid equipment id.' });
+
+    const deleteResponse = await deleteEquipment(
+      request('http://test.local/api/gym-equipment/%20', 'DELETE'),
+      params('   '),
+    );
+    expect(deleteResponse.status).toBe(400);
+    expect(await deleteResponse.json()).toEqual({ error: 'Invalid equipment id.' });
+  });
+
   it('enforces the per-gym equipment cap atomically across concurrent creates', async () => {
     const { user, gym } = await seedUser('capacity-race');
     mockUserId.mockResolvedValue(user.id);

--- a/tests/integration/gym-equipment-api.test.ts
+++ b/tests/integration/gym-equipment-api.test.ts
@@ -7,7 +7,10 @@ vi.mock('@/lib/auth', () => ({ getCurrentUserId: vi.fn() }));
 const mockUserId = vi.mocked(getCurrentUserId);
 
 import { GET as listEquipment, POST as createEquipment } from '@/app/api/gyms/[id]/equipment/route';
-import { DELETE as deleteEquipment, PUT as updateEquipment } from '@/app/api/gym-equipment/[id]/route';
+import {
+  DELETE as deleteEquipment,
+  PUT as updateEquipment,
+} from '@/app/api/gym-equipment/[id]/route';
 import {
   DELETE as deleteImage,
   GET as getImage,
@@ -108,6 +111,22 @@ describe('gym equipment REST API', () => {
     expect(updatedResponse.status).toBe(200);
     expect((await updatedResponse.json()).equipment.name).toBe('Cable station A');
 
+    const renamedViaCollection = await createEquipment(
+      request('http://test.local/api/gyms/' + gym.id + '/equipment', 'POST', {
+        equipmentId,
+        name: 'Cable station renamed',
+        equipmentType: 'CABLE',
+        quantity: 1,
+        weightOptions: [5, 10, 15, 20],
+        exerciseIds: [exercise.id],
+      }),
+      params(gym.id),
+    );
+    expect(renamedViaCollection.status).toBe(200);
+    const renamed = await renamedViaCollection.json();
+    expect(renamed.equipment).toMatchObject({ id: equipmentId, name: 'Cable station renamed' });
+    expect(await db.gymEquipment.count({ where: { gymId: gym.id } })).toBe(1);
+
     const imageResponse = await setImage(
       request(`http://test.local/api/gym-equipment/${equipmentId}/image`, 'PUT', {
         imageBase64: PNG.toString('base64'),
@@ -123,6 +142,14 @@ describe('gym equipment REST API', () => {
     expect(fetchedImage.status).toBe(200);
     expect(fetchedImage.headers.get('content-type')).toBe('image/png');
     expect(Buffer.from(await fetchedImage.arrayBuffer())).toEqual(PNG);
+
+    const listedWithImage = await listEquipment(
+      request('http://attacker.invalid/api/gyms/' + gym.id + '/equipment'),
+      params(gym.id),
+    );
+    const listedImage = (await listedWithImage.json()).equipment[0].image;
+    expect(listedImage.url.startsWith(`/api/gym-equipment/${equipmentId}/image?v=`)).toBe(true);
+    expect(listedImage.url).not.toContain('attacker.invalid');
 
     const clearResponse = await deleteImage(
       request(`http://test.local/api/gym-equipment/${equipmentId}/image`, 'DELETE'),

--- a/tests/integration/gym-equipment-api.test.ts
+++ b/tests/integration/gym-equipment-api.test.ts
@@ -168,6 +168,45 @@ describe('gym equipment REST API', () => {
     expect(await db.gymEquipment.count({ where: { id: equipmentId } })).toBe(0);
   });
 
+  it('rejects an invalid gym route id before the domain query', async () => {
+    const { user } = await seedUser('invalid-route-id');
+    mockUserId.mockResolvedValue(user.id);
+
+    const response = await listEquipment(
+      request('http://test.local/api/gyms/%20/equipment'),
+      params('   '),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'Invalid gym id.' });
+  });
+
+  it('enforces the per-gym equipment cap atomically across concurrent creates', async () => {
+    const { user, gym } = await seedUser('capacity-race');
+    mockUserId.mockResolvedValue(user.id);
+
+    await db.gymEquipment.createMany({
+      data: Array.from({ length: 999 }, (_, index) => ({
+        gymId: gym.id,
+        name: `Existing station ${index}`,
+        equipmentType: 'MACHINE' as const,
+      })),
+    });
+
+    const create = (name: string) =>
+      createEquipment(
+        request(`http://test.local/api/gyms/${gym.id}/equipment`, 'POST', {
+          name,
+          equipmentType: 'MACHINE',
+        }),
+        params(gym.id),
+      );
+
+    const responses = await Promise.all([create('Race station A'), create('Race station B')]);
+    expect(responses.map((response) => response.status).sort()).toEqual([201, 400]);
+    expect(await db.gymEquipment.count({ where: { gymId: gym.id } })).toBe(1000);
+  });
+
   it('does not expose another user gym or accept another user exercise link', async () => {
     const owner = await seedUser('private-owner');
     const other = await seedUser('other');

--- a/tests/integration/gym-equipment-review-regressions.test.ts
+++ b/tests/integration/gym-equipment-review-regressions.test.ts
@@ -1,0 +1,169 @@
+import { Buffer } from 'node:buffer';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { db } from '@/lib/db';
+import { getCurrentUserId } from '@/lib/auth';
+import { MAX_GYM_EQUIPMENT_PER_GYM } from '@/lib/gym-equipment';
+
+vi.mock('@/lib/auth', () => ({ getCurrentUserId: vi.fn() }));
+const mockUserId = vi.mocked(getCurrentUserId);
+
+import { POST as restoreBackup } from '@/app/api/backup/route';
+import { POST as upsertEquipment } from '@/app/api/gyms/[id]/equipment/route';
+
+let seed = 0;
+
+function request(url: string, method: string, body: unknown): Request {
+  return new Request(url, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function params(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+async function seedUser(label: string) {
+  seed += 1;
+  const user = await db.user.create({
+    data: {
+      email: `equipment-review-${label}-${Date.now()}-${seed}@test.dev`,
+      passwordHash: 'unused',
+    },
+  });
+  const gym = await db.gym.create({ data: { userId: user.id, name: `${label} gym ${seed}` } });
+  return { user, gym };
+}
+
+beforeEach(() => mockUserId.mockReset());
+
+describe('gym equipment maintainer-review regressions', () => {
+  it('returns 200 for a name-matched update and preserves omitted mutable fields', async () => {
+    const { user, gym } = await seedUser('preserve');
+    const exercise = await db.exercise.create({
+      data: {
+        userId: user.id,
+        name: `Cable row ${seed}`,
+        muscleGroup: 'BACK_THICKNESS',
+        category: 'COMPOUND',
+        equipmentType: 'CABLE',
+      },
+    });
+    const existing = await db.gymEquipment.create({
+      data: {
+        gymId: gym.id,
+        name: 'Cable station',
+        equipmentType: 'CABLE',
+        quantity: 3,
+        weightOptions: [10, 20],
+        exerciseLinks: { create: { exerciseId: exercise.id } },
+      },
+    });
+    mockUserId.mockResolvedValue(user.id);
+
+    const response = await upsertEquipment(
+      request(`http://test.local/api/gyms/${gym.id}/equipment`, 'POST', {
+        name: 'CABLE STATION',
+        equipmentType: 'CABLE',
+      }),
+      params(gym.id),
+    );
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).created).toBe(false);
+    const saved = await db.gymEquipment.findUnique({
+      where: { id: existing.id },
+      include: { exerciseLinks: true },
+    });
+    expect(saved).toMatchObject({ quantity: 3, weightOptions: [10, 20] });
+    expect(saved?.exerciseLinks.map((link) => link.exerciseId)).toEqual([exercise.id]);
+  });
+
+  it('enforces the per-gym REST creation cap without blocking updates', async () => {
+    const { user, gym } = await seedUser('cap');
+    await db.gymEquipment.createMany({
+      data: Array.from({ length: MAX_GYM_EQUIPMENT_PER_GYM }, (_, index) => ({
+        gymId: gym.id,
+        name: `Station ${index}`,
+        equipmentType: 'MACHINE' as const,
+      })),
+    });
+    mockUserId.mockResolvedValue(user.id);
+
+    const updateResponse = await upsertEquipment(
+      request(`http://test.local/api/gyms/${gym.id}/equipment`, 'POST', {
+        name: 'Station 0',
+        equipmentType: 'MACHINE',
+        description: 'Still editable at the cap',
+      }),
+      params(gym.id),
+    );
+    expect(updateResponse.status).toBe(200);
+
+    const createResponse = await upsertEquipment(
+      request(`http://test.local/api/gyms/${gym.id}/equipment`, 'POST', {
+        name: 'One station too many',
+        equipmentType: 'MACHINE',
+      }),
+      params(gym.id),
+    );
+    expect(createResponse.status).toBe(400);
+    expect(await db.gymEquipment.count({ where: { gymId: gym.id } })).toBe(
+      MAX_GYM_EQUIPMENT_PER_GYM,
+    );
+  });
+
+  it('rejects malformed backup equipment images before replacing existing data', async () => {
+    const { user } = await seedUser('preflight');
+    const existingExercise = await db.exercise.create({
+      data: {
+        userId: user.id,
+        name: `Keep me ${seed}`,
+        muscleGroup: 'CHEST',
+        category: 'COMPOUND',
+      },
+    });
+    mockUserId.mockResolvedValue(user.id);
+
+    const response = await restoreBackup(
+      request('http://test.local/api/backup', 'POST', {
+        confirmReplace: true,
+        payload: {
+          version: 4,
+          exercises: [],
+          programs: [],
+          sessions: [],
+          gyms: [
+            {
+              name: 'Imported gym',
+              dumbbellWeights: [],
+              plateWeights: [],
+              barWeights: [],
+              exerciseConfigs: [],
+              equipment: [
+                {
+                  name: 'Tampered station',
+                  equipmentType: 'MACHINE',
+                  description: null,
+                  manufacturer: null,
+                  modelName: null,
+                  quantity: 1,
+                  weightOptions: [],
+                  imageUrl: null,
+                  imageMimeType: 'image/png',
+                  imageBase64: Buffer.from('not a png').toString('base64'),
+                  exerciseNames: [],
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await db.exercise.findUnique({ where: { id: existingExercise.id } })).not.toBeNull();
+    expect(await db.exercise.count({ where: { userId: user.id } })).toBe(1);
+  });
+});

--- a/tests/integration/route-ownership-coverage.test.ts
+++ b/tests/integration/route-ownership-coverage.test.ts
@@ -17,6 +17,9 @@ const COVERED_ELSEWHERE: Record<string, string> = {
   'app/api/bodyweight/[id]/route.ts': 'tests/integration/bodyweight-route.test.ts',
   'app/api/goals/[id]/route.ts': 'tests/integration/goals-route.test.ts',
   'app/api/measurements/[id]/route.ts': 'tests/integration/measurements-route.test.ts',
+  'app/api/gym-equipment/[id]/route.ts': 'tests/integration/gym-equipment-api.test.ts',
+  'app/api/gym-equipment/[id]/image/route.ts': 'tests/integration/gym-equipment-api.test.ts',
+  'app/api/gyms/[id]/equipment/route.ts': 'tests/integration/gym-equipment-api.test.ts',
   'app/api/progress-photos/[id]/route.ts': 'tests/integration/progress-photos-route.test.ts',
   'app/api/progress-photos/[id]/image/route.ts': 'tests/integration/progress-photos-route.test.ts',
 };


### PR DESCRIPTION
## What this adds

This extends the accepted saved-gym model with concrete physical equipment while keeping the existing Gym/GymExerciseConfig behavior intact.

- `GymEquipment` as a concrete physical station/item in one gym
- many-to-many equipment-to-exercise links
- name, type, description, manufacturer, model, quantity and item-specific weight options
- uploaded JPEG/PNG/WebP images or external HTTPS image URLs
- owner-scoped REST CRUD and image endpoints
- compatibility projection into the existing `GymExerciseConfig` model so linked exercises immediately remain available to current upstream flows
- backup/restore v4 support for equipment, images and exercise links

## Migration safety

The migration is intentionally additive and uses `IF NOT EXISTS` plus constraint guards. A fresh upstream database creates the new tables normally. A fork that already shipped equivalent physical-equipment tables under an earlier migration id can apply this migration safely as a no-op and record the new migration without rebuilding user data.

Verified both cases:

1. completely fresh PostgreSQL -> all 23 migrations apply successfully in order
2. equipment tables already present, new migration record absent -> `prisma migrate deploy` applies the migration successfully without recreating the tables

## Ownership and validation

- a user cannot read another user's gym inventory
- equipment cannot be linked to an exercise owned by another user
- uploaded image bytes are signature-checked and limited to JPEG/PNG/WebP, max 5 MiB
- external image sources must use HTTPS

## Verification

- targeted REST + backup integration: 13/13 green
- full E2E regression suite: 17/17 green
- lint: green (existing GPX unused-helper warning only)
- typecheck: green
- production build: green
- full Windows unit: 955/958; the only three failures are the existing upstream progress-photo POSIX/path assertions
- full Windows integration: 225/228; the only three failures are the same existing progress-photo Windows path assertions

This PR intentionally does not include workout equipment selection/history, free-weight compatibility profiles, Android, or MCP. Those are separate follow-up layers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added gym equipment inventory management with details, quantities, weight options, and exercise associations.
  * Added secure viewing, uploading, updating, and removal of equipment images.
  * Added ownership protections and per-gym equipment limits.
* **Backup & Restore**
  * Backups now include equipment, images, and exercise links.
  * Imports validate equipment data and safely restore linked information.
* **Bug Fixes**
  * Improved image validation, duplicate handling, and data preservation during imports and updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->