### PR TITLE
feat/equipment workout history

### DIFF
--- a/app/(app)/session/[id]/page.tsx
+++ b/app/(app)/session/[id]/page.tsx
@@ -6,6 +6,7 @@ import { READINESS_RECENCY_HOURS, type ReadinessSignal } from '@/lib/progression
 import { isDeloadActive } from '@/lib/deload';
 import { getReturnToTrainingRecommendations } from '@/lib/return-to-training-history';
 import { SessionRunner, type SerializedLastPerformance } from '@/components/session/session-runner';
+import { liveSessionGymInclude } from '@/lib/session-gym-selection';
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -28,7 +29,7 @@ export default async function SessionRunPage(props: Props) {
         },
       },
       sets: { orderBy: [{ exerciseId: 'asc' }, { setNumber: 'asc' }] },
-      gym: { include: { exerciseConfigs: true, equipment: { include: { exerciseLinks: true } } } },
+      gym: { include: liveSessionGymInclude },
     },
   });
 

--- a/app/(app)/session/[id]/page.tsx
+++ b/app/(app)/session/[id]/page.tsx
@@ -28,7 +28,7 @@ export default async function SessionRunPage(props: Props) {
         },
       },
       sets: { orderBy: [{ exerciseId: 'asc' }, { setNumber: 'asc' }] },
-      gym: { include: { exerciseConfigs: true } },
+      gym: { include: { exerciseConfigs: true, equipment: { include: { exerciseLinks: true } } } },
     },
   });
 

--- a/app/api/backup/route.ts
+++ b/app/api/backup/route.ts
@@ -251,9 +251,6 @@ export async function GET() {
           exerciseName: exercises.find((e) => e.id === set.exerciseId)?.name ?? null,
           gymEquipmentName: set.gymEquipment?.name ?? null,
           equipmentNameSnapshot: set.equipmentNameSnapshot,
-          selectedLoadKg: set.selectedLoadKg,
-          selectedLoadMultiplierSnapshot: set.selectedLoadMultiplierSnapshot,
-          nominalResistanceKg: set.nominalResistanceKg,
           equipmentLoadSnapshot: set.equipmentLoadSnapshot,
           setNumber: set.setNumber,
           weight: set.weight,
@@ -437,9 +434,6 @@ const importSchema = z.object({
               exerciseName: z.string().max(120).nullable(),
               gymEquipmentName: z.string().max(120).nullable().optional(),
               equipmentNameSnapshot: z.string().max(120).nullable().optional(),
-              selectedLoadKg: z.number().min(0).max(5000).nullable().optional(),
-              selectedLoadMultiplierSnapshot: z.number().positive().max(100).nullable().optional(),
-              nominalResistanceKg: z.number().min(0).max(50_000).nullable().optional(),
               equipmentLoadSnapshot: z.record(z.string(), z.unknown()).nullable().optional(),
               setNumber: z.number().int().min(1).max(1000),
               weight: z.number().min(0).max(5000),
@@ -611,7 +605,7 @@ export async function POST(req: Request) {
     const preparedEquipmentByGymName = new Map<
       string,
       Array<{
-        item: NonNullable<NonNullable<(typeof payload.gyms)>[number]['equipment']>[number];
+        item: NonNullable<NonNullable<typeof payload.gyms>[number]['equipment']>[number];
         decoded: ReturnType<typeof decodeGymEquipmentImage> | null;
       }>
     >();
@@ -856,12 +850,9 @@ export async function POST(req: Request) {
                       ) ?? null)
                     : null,
                 equipmentNameSnapshot: set.equipmentNameSnapshot ?? null,
-                selectedLoadKg: set.selectedLoadKg ?? null,
-                selectedLoadMultiplierSnapshot: set.selectedLoadMultiplierSnapshot ?? null,
-                nominalResistanceKg: set.nominalResistanceKg ?? null,
                 equipmentLoadSnapshot:
                   set.equipmentLoadSnapshot == null
-                    ? Prisma.DbNull
+                    ? Prisma.JsonNull
                     : (set.equipmentLoadSnapshot as Prisma.InputJsonValue),
                 setNumber: set.setNumber,
                 weight: set.weight,

--- a/app/api/backup/route.ts
+++ b/app/api/backup/route.ts
@@ -23,7 +23,11 @@ import {
 import { MAX_SUPERSET_GROUP, MIN_SUPERSET_GROUP } from '@/lib/supersets';
 import { sorenessSchema } from '@/lib/schemas/readiness';
 import { gymWeightListSchema } from '@/lib/schemas/gym';
-import { GYM_EQUIPMENT_IMAGE_MIME_TYPES, decodeGymEquipmentImage } from '@/lib/gym-equipment';
+import {
+  GYM_EQUIPMENT_IMAGE_MIME_TYPES,
+  MAX_GYM_EQUIPMENT_PER_GYM,
+  decodeGymEquipmentImage,
+} from '@/lib/gym-equipment';
 
 // ============================================================
 // Backup / Import JSON (LOT 11, completed by issue #168)
@@ -295,7 +299,14 @@ export async function GET() {
     };
 
     const filename = `gymcoach-backup-${new Date().toISOString().slice(0, 10)}.json`;
-    return new NextResponse(JSON.stringify(dump, null, 2), {
+    const serialized = JSON.stringify(dump, null, 2);
+    if (Buffer.byteLength(serialized, 'utf8') > MAX_BACKUP_BYTES) {
+      throw new ApiError(
+        413,
+        'This backup is larger than the maximum restorable backup size. Reduce uploaded gym equipment images and try again.',
+      );
+    }
+    return new NextResponse(serialized, {
       headers: {
         'Content-Type': 'application/json; charset=utf-8',
         'Content-Disposition': `attachment; filename="${filename}"`,
@@ -493,7 +504,7 @@ const importSchema = z.object({
               exerciseNames: z.array(z.string().max(120)).max(100),
             }),
           )
-          .max(1000)
+          .max(MAX_GYM_EQUIPMENT_PER_GYM)
           .optional(),
         exerciseConfigs: z
           .array(
@@ -578,6 +589,35 @@ export async function POST(req: Request) {
     const { payload } = await parseJsonBody(req, importBodySchema, {
       maxBytes: MAX_BACKUP_BYTES,
     });
+
+    // Validate and decode equipment images before taking purge locks so a
+    // malformed or hand-edited backup fails before any replacement work starts.
+    const preparedEquipmentByGymName = new Map<
+      string,
+      Array<{
+        item: NonNullable<NonNullable<(typeof payload.gyms)>[number]['equipment']>[number];
+        decoded: ReturnType<typeof decodeGymEquipmentImage> | null;
+      }>
+    >();
+    const seenGymNames = new Set<string>();
+    for (const gym of payload.gyms ?? []) {
+      if (seenGymNames.has(gym.name)) continue;
+      seenGymNames.add(gym.name);
+      const seenEquipmentNames = new Set<string>();
+      const prepared = [] as NonNullable<ReturnType<typeof preparedEquipmentByGymName.get>>;
+      for (const item of gym.equipment ?? []) {
+        const equipmentNameKey = item.name.toLocaleLowerCase('en-US');
+        if (seenEquipmentNames.has(equipmentNameKey)) {
+          throw new ApiError(400, `Duplicate gym equipment name in backup: ${item.name}`);
+        }
+        seenEquipmentNames.add(equipmentNameKey);
+        const decoded = item.imageBase64
+          ? decodeGymEquipmentImage(item.imageBase64, item.imageMimeType ?? undefined)
+          : null;
+        prepared.push({ item, decoded });
+      }
+      preparedEquipmentByGymName.set(gym.name, prepared);
+    }
 
     await db.$transaction(
       async (tx) => {
@@ -666,38 +706,41 @@ export async function POST(req: Request) {
               exerciseConfigs: { createMany: { data: configs } },
             },
           });
-          for (const item of gym.equipment ?? []) {
-            const decoded = item.imageBase64
-              ? decodeGymEquipmentImage(item.imageBase64, item.imageMimeType ?? undefined)
-              : null;
-            const equipment = await tx.gymEquipment.create({
-              data: {
-                gymId: created.id,
-                name: item.name,
-                equipmentType: item.equipmentType,
-                description: item.description ?? null,
-                manufacturer: item.manufacturer ?? null,
-                modelName: item.modelName ?? null,
-                quantity: item.quantity,
-                weightOptions: item.weightOptions,
-                imageUrl: decoded ? null : (item.imageUrl ?? null),
-                imageData: decoded?.bytes,
-                imageMimeType: decoded?.mimeType ?? null,
-              },
-            });
-            const exerciseIds = [
+          const preparedEquipment = preparedEquipmentByGymName.get(gym.name) ?? [];
+          const createdEquipment =
+            preparedEquipment.length > 0
+              ? await tx.gymEquipment.createManyAndReturn({
+                  data: preparedEquipment.map(({ item, decoded }) => ({
+                    gymId: created.id,
+                    name: item.name,
+                    equipmentType: item.equipmentType,
+                    description: item.description ?? null,
+                    manufacturer: item.manufacturer ?? null,
+                    modelName: item.modelName ?? null,
+                    quantity: item.quantity,
+                    weightOptions: item.weightOptions,
+                    imageUrl: decoded ? null : (item.imageUrl ?? null),
+                    imageData: decoded?.bytes,
+                    imageMimeType: decoded?.mimeType ?? null,
+                  })),
+                  select: { id: true, name: true },
+                })
+              : [];
+          const equipmentIdByName = new Map(createdEquipment.map((item) => [item.name, item.id]));
+          const equipmentExerciseLinks = preparedEquipment.flatMap(({ item }) => {
+            const equipmentId = equipmentIdByName.get(item.name);
+            if (!equipmentId) return [];
+            return [
               ...new Set(
                 item.exerciseNames.flatMap((name) => {
                   const exerciseId = exerciseIdByName.get(name);
                   return exerciseId ? [exerciseId] : [];
                 }),
               ),
-            ];
-            if (exerciseIds.length > 0) {
-              await tx.gymEquipmentExercise.createMany({
-                data: exerciseIds.map((exerciseId) => ({ equipmentId: equipment.id, exerciseId })),
-              });
-            }
+            ].map((exerciseId) => ({ equipmentId, exerciseId }));
+          });
+          if (equipmentExerciseLinks.length > 0) {
+            await tx.gymEquipmentExercise.createMany({ data: equipmentExerciseLinks });
           }
           gymIdByName.set(gym.name, created.id);
         }

--- a/app/api/backup/route.ts
+++ b/app/api/backup/route.ts
@@ -1,6 +1,7 @@
 import { Buffer } from 'node:buffer';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
+import { Prisma } from '@/prisma/generated/client';
 import {
   ExerciseCategory,
   EquipmentType,
@@ -61,7 +62,7 @@ import {
 // - Program.createdAt / Program.updatedAt and Exercise.createdAt (server-side
 //   bookkeeping with no user-facing meaning; reset to the import time).
 
-const VERSION = 4;
+const VERSION = 5;
 
 // Hard cap on the import body size, enforced while reading the stream (the
 // Content-Length header is attacker-controlled). Generous: a decade of daily
@@ -121,7 +122,10 @@ export async function GET() {
         where: { userId },
         orderBy: { startedAt: 'asc' },
         include: {
-          sets: { orderBy: [{ exerciseId: 'asc' }, { setNumber: 'asc' }] },
+          sets: {
+            orderBy: [{ exerciseId: 'asc' }, { setNumber: 'asc' }],
+            include: { gymEquipment: { select: { name: true } } },
+          },
         },
       }),
       db.coachSession.findMany({ where: { userId }, orderBy: { createdAt: 'asc' } }),
@@ -245,6 +249,12 @@ export async function GET() {
         gymName: gyms.find((gym) => gym.id === s.gymId)?.name ?? null,
         sets: s.sets.map((set) => ({
           exerciseName: exercises.find((e) => e.id === set.exerciseId)?.name ?? null,
+          gymEquipmentName: set.gymEquipment?.name ?? null,
+          equipmentNameSnapshot: set.equipmentNameSnapshot,
+          selectedLoadKg: set.selectedLoadKg,
+          selectedLoadMultiplierSnapshot: set.selectedLoadMultiplierSnapshot,
+          nominalResistanceKg: set.nominalResistanceKg,
+          equipmentLoadSnapshot: set.equipmentLoadSnapshot,
           setNumber: set.setNumber,
           weight: set.weight,
           reps: set.reps,
@@ -425,6 +435,12 @@ const importSchema = z.object({
           .array(
             z.object({
               exerciseName: z.string().max(120).nullable(),
+              gymEquipmentName: z.string().max(120).nullable().optional(),
+              equipmentNameSnapshot: z.string().max(120).nullable().optional(),
+              selectedLoadKg: z.number().min(0).max(5000).nullable().optional(),
+              selectedLoadMultiplierSnapshot: z.number().positive().max(100).nullable().optional(),
+              nominalResistanceKg: z.number().min(0).max(50_000).nullable().optional(),
+              equipmentLoadSnapshot: z.record(z.string(), z.unknown()).nullable().optional(),
               setNumber: z.number().int().min(1).max(1000),
               weight: z.number().min(0).max(5000),
               reps: z.number().int().min(0).max(1000),
@@ -682,6 +698,7 @@ export async function POST(req: Request) {
         // abort the whole restore: keep the first occurrence and skip the
         // rest instead of failing.
         const gymIdByName = new Map<string, string>();
+        const gymEquipmentIdByGymAndName = new Map<string, string>();
         for (const gym of payload.gyms ?? []) {
           if (gymIdByName.has(gym.name)) continue;
           const configs = gym.exerciseConfigs.flatMap((config) => {
@@ -727,6 +744,9 @@ export async function POST(req: Request) {
                 })
               : [];
           const equipmentIdByName = new Map(createdEquipment.map((item) => [item.name, item.id]));
+          for (const item of createdEquipment) {
+            gymEquipmentIdByGymAndName.set(JSON.stringify([gym.name, item.name]), item.id);
+          }
           const equipmentExerciseLinks = preparedEquipment.flatMap(({ item }) => {
             const equipmentId = equipmentIdByName.get(item.name);
             if (!equipmentId) return [];
@@ -829,6 +849,20 @@ export async function POST(req: Request) {
               {
                 sessionId: session.id,
                 exerciseId: exId,
+                gymEquipmentId:
+                  s.gymName && set.gymEquipmentName
+                    ? (gymEquipmentIdByGymAndName.get(
+                        JSON.stringify([s.gymName, set.gymEquipmentName]),
+                      ) ?? null)
+                    : null,
+                equipmentNameSnapshot: set.equipmentNameSnapshot ?? null,
+                selectedLoadKg: set.selectedLoadKg ?? null,
+                selectedLoadMultiplierSnapshot: set.selectedLoadMultiplierSnapshot ?? null,
+                nominalResistanceKg: set.nominalResistanceKg ?? null,
+                equipmentLoadSnapshot:
+                  set.equipmentLoadSnapshot == null
+                    ? Prisma.DbNull
+                    : (set.equipmentLoadSnapshot as Prisma.InputJsonValue),
                 setNumber: set.setNumber,
                 weight: set.weight,
                 reps: set.reps,

--- a/app/api/backup/route.ts
+++ b/app/api/backup/route.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'node:buffer';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import {
@@ -22,6 +23,7 @@ import {
 import { MAX_SUPERSET_GROUP, MIN_SUPERSET_GROUP } from '@/lib/supersets';
 import { sorenessSchema } from '@/lib/schemas/readiness';
 import { gymWeightListSchema } from '@/lib/schemas/gym';
+import { GYM_EQUIPMENT_IMAGE_MIME_TYPES, decodeGymEquipmentImage } from '@/lib/gym-equipment';
 
 // ============================================================
 // Backup / Import JSON (LOT 11, completed by issue #168)
@@ -43,6 +45,8 @@ import { gymWeightListSchema } from '@/lib/schemas/gym';
 //   usesBodyweight.
 // - Program / Workout / ProgramExercise: all user content incl supersetGroup.
 // - Session / Set: all user content incl durationSec, distanceM, avgHr.
+// - Saved Gym profiles plus physical GymEquipment, equipment-to-exercise links,
+//   and uploaded/external equipment images.
 // - CoachSession, ExerciseGoal, BodyweightEntry, ReadinessCheckin,
 //   Conversation / Message: all user content.
 //
@@ -53,7 +57,7 @@ import { gymWeightListSchema } from '@/lib/schemas/gym';
 // - Program.createdAt / Program.updatedAt and Exercise.createdAt (server-side
 //   bookkeeping with no user-facing meaning; reset to the import time).
 
-const VERSION = 3;
+const VERSION = 4;
 
 // Hard cap on the import body size, enforced while reading the stream (the
 // Content-Length header is attacker-controlled). Generous: a decade of daily
@@ -139,6 +143,10 @@ export async function GET() {
         where: { userId },
         orderBy: { createdAt: 'asc' },
         include: {
+          equipment: {
+            orderBy: { name: 'asc' },
+            include: { exerciseLinks: { include: { exercise: { select: { name: true } } } } },
+          },
           exerciseConfigs: { include: { exercise: { select: { name: true } } } },
         },
       }),
@@ -176,6 +184,19 @@ export async function GET() {
         dumbbellWeights: gym.dumbbellWeights,
         plateWeights: gym.plateWeights,
         barWeights: gym.barWeights,
+        equipment: gym.equipment.map((item) => ({
+          name: item.name,
+          equipmentType: item.equipmentType,
+          description: item.description,
+          manufacturer: item.manufacturer,
+          modelName: item.modelName,
+          quantity: item.quantity,
+          weightOptions: item.weightOptions,
+          imageUrl: item.imageUrl,
+          imageMimeType: item.imageMimeType,
+          imageBase64: item.imageData ? Buffer.from(item.imageData).toString('base64') : null,
+          exerciseNames: item.exerciseLinks.map((link) => link.exercise.name),
+        })),
         exerciseConfigs: gym.exerciseConfigs.map((config) => ({
           exerciseName: config.exercise.name,
           isAvailable: config.isAvailable,
@@ -448,6 +469,32 @@ const importSchema = z.object({
         dumbbellWeights: gymWeightListSchema,
         plateWeights: gymWeightListSchema,
         barWeights: gymWeightListSchema,
+        equipment: z
+          .array(
+            z.object({
+              name: z.string().trim().min(1).max(120),
+              equipmentType: z.nativeEnum(EquipmentType),
+              description: z.string().max(4000).nullable().optional(),
+              manufacturer: z.string().max(120).nullable().optional(),
+              modelName: z.string().max(120).nullable().optional(),
+              quantity: z.number().int().min(1).max(100),
+              weightOptions: gymWeightListSchema,
+              imageUrl: z
+                .string()
+                .url()
+                .max(2048)
+                .nullable()
+                .optional()
+                .refine((value) => value == null || value.startsWith('https://'), {
+                  message: 'Equipment image URL must use HTTPS.',
+                }),
+              imageMimeType: z.enum(GYM_EQUIPMENT_IMAGE_MIME_TYPES).nullable().optional(),
+              imageBase64: z.string().max(7_100_000).nullable().optional(),
+              exerciseNames: z.array(z.string().max(120)).max(100),
+            }),
+          )
+          .max(1000)
+          .optional(),
         exerciseConfigs: z
           .array(
             z.object({
@@ -619,6 +666,39 @@ export async function POST(req: Request) {
               exerciseConfigs: { createMany: { data: configs } },
             },
           });
+          for (const item of gym.equipment ?? []) {
+            const decoded = item.imageBase64
+              ? decodeGymEquipmentImage(item.imageBase64, item.imageMimeType ?? undefined)
+              : null;
+            const equipment = await tx.gymEquipment.create({
+              data: {
+                gymId: created.id,
+                name: item.name,
+                equipmentType: item.equipmentType,
+                description: item.description ?? null,
+                manufacturer: item.manufacturer ?? null,
+                modelName: item.modelName ?? null,
+                quantity: item.quantity,
+                weightOptions: item.weightOptions,
+                imageUrl: decoded ? null : (item.imageUrl ?? null),
+                imageData: decoded?.bytes,
+                imageMimeType: decoded?.mimeType ?? null,
+              },
+            });
+            const exerciseIds = [
+              ...new Set(
+                item.exerciseNames.flatMap((name) => {
+                  const exerciseId = exerciseIdByName.get(name);
+                  return exerciseId ? [exerciseId] : [];
+                }),
+              ),
+            ];
+            if (exerciseIds.length > 0) {
+              await tx.gymEquipmentExercise.createMany({
+                data: exerciseIds.map((exerciseId) => ({ equipmentId: equipment.id, exerciseId })),
+              });
+            }
+          }
           gymIdByName.set(gym.name, created.id);
         }
         const activeGymId = payload.profile?.activeGymName

--- a/app/api/gym-equipment/[id]/image/route.ts
+++ b/app/api/gym-equipment/[id]/image/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+import { handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
+import { getOwnedGymEquipmentImage, setOwnedGymEquipmentImage } from '@/lib/gym-equipment';
+import { gymEquipmentImageSchema } from '@/lib/schemas/gym-equipment';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+interface Params {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(_req: Request, props: Params) {
+  try {
+    const userId = await requireApiUserId();
+    const { id } = await props.params;
+    const image = await getOwnedGymEquipmentImage(userId, id);
+    if (image.kind === 'external') return NextResponse.redirect(image.url);
+    return new Response(image.bytes, {
+      headers: {
+        'Content-Type': image.mimeType,
+        'Content-Length': String(image.bytes.byteLength),
+        'Cache-Control': 'private, max-age=3600',
+        'Last-Modified': image.updatedAt.toUTCString(),
+        'X-Content-Type-Options': 'nosniff',
+      },
+    });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}
+
+export async function PUT(req: Request, props: Params) {
+  try {
+    const userId = await requireApiUserId();
+    const { id } = await props.params;
+    const input = await parseJsonBody(req, gymEquipmentImageSchema, { maxBytes: 7_110_000 });
+    const equipment = await setOwnedGymEquipmentImage(userId, id, input);
+    return NextResponse.json({ equipment });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}
+
+export async function DELETE(_req: Request, props: Params) {
+  try {
+    const userId = await requireApiUserId();
+    const { id } = await props.params;
+    const equipment = await setOwnedGymEquipmentImage(userId, id, { clear: true });
+    return NextResponse.json({ equipment });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/app/api/gym-equipment/[id]/route.ts
+++ b/app/api/gym-equipment/[id]/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
+import { db } from '@/lib/db';
+import { deleteOwnedGymEquipment, upsertOwnedGymEquipment } from '@/lib/gym-equipment';
+import { gymEquipmentUpsertSchema } from '@/lib/schemas/gym-equipment';
+
+interface Params {
+  params: Promise<{ id: string }>;
+}
+
+export async function PUT(req: Request, props: Params) {
+  try {
+    const userId = await requireApiUserId();
+    const { id } = await props.params;
+    const existing = await db.gymEquipment.findFirst({
+      where: { id, gym: { userId } },
+      select: { id: true, gymId: true },
+    });
+    if (!existing) return NextResponse.json({ error: 'Gym equipment not found.' }, { status: 404 });
+    const input = await parseJsonBody(req, gymEquipmentUpsertSchema);
+    const saved = await upsertOwnedGymEquipment(userId, existing.gymId, {
+      equipmentId: existing.id,
+      ...input,
+    });
+    return NextResponse.json(saved);
+  } catch (err) {
+    return handleApiError(err);
+  }
+}
+
+export async function DELETE(_req: Request, props: Params) {
+  try {
+    const userId = await requireApiUserId();
+    const { id } = await props.params;
+    await deleteOwnedGymEquipment(userId, id);
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/app/api/gym-equipment/[id]/route.ts
+++ b/app/api/gym-equipment/[id]/route.ts
@@ -1,19 +1,26 @@
 import { NextResponse } from 'next/server';
-import { handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
+import { ApiError, handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
 import { db } from '@/lib/db';
 import { deleteOwnedGymEquipment, upsertOwnedGymEquipment } from '@/lib/gym-equipment';
-import { gymEquipmentUpsertSchema } from '@/lib/schemas/gym-equipment';
+import { databaseIdSchema, gymEquipmentUpsertSchema } from '@/lib/schemas/gym-equipment';
 
 interface Params {
   params: Promise<{ id: string }>;
+}
+
+function parseEquipmentId(id: string): string {
+  const parsed = databaseIdSchema.safeParse(id);
+  if (!parsed.success) throw new ApiError(400, 'Invalid equipment id.');
+  return parsed.data;
 }
 
 export async function PUT(req: Request, props: Params) {
   try {
     const userId = await requireApiUserId();
     const { id } = await props.params;
+    const equipmentId = parseEquipmentId(id);
     const existing = await db.gymEquipment.findFirst({
-      where: { id, gym: { userId } },
+      where: { id: equipmentId, gym: { userId } },
       select: { id: true, gymId: true },
     });
     if (!existing) return NextResponse.json({ error: 'Gym equipment not found.' }, { status: 404 });
@@ -32,7 +39,8 @@ export async function DELETE(_req: Request, props: Params) {
   try {
     const userId = await requireApiUserId();
     const { id } = await props.params;
-    await deleteOwnedGymEquipment(userId, id);
+    const equipmentId = parseEquipmentId(id);
+    await deleteOwnedGymEquipment(userId, equipmentId);
     return NextResponse.json({ ok: true });
   } catch (err) {
     return handleApiError(err);

--- a/app/api/gym-equipment/[id]/route.ts
+++ b/app/api/gym-equipment/[id]/route.ts
@@ -19,8 +19,8 @@ export async function PUT(req: Request, props: Params) {
     if (!existing) return NextResponse.json({ error: 'Gym equipment not found.' }, { status: 404 });
     const input = await parseJsonBody(req, gymEquipmentUpsertSchema);
     const saved = await upsertOwnedGymEquipment(userId, existing.gymId, {
-      equipmentId: existing.id,
       ...input,
+      equipmentId: existing.id,
     });
     return NextResponse.json(saved);
   } catch (err) {

--- a/app/api/gyms/[id]/equipment/route.ts
+++ b/app/api/gyms/[id]/equipment/route.ts
@@ -7,11 +7,11 @@ interface Params {
   params: Promise<{ id: string }>;
 }
 
-export async function GET(req: Request, props: Params) {
+export async function GET(_req: Request, props: Params) {
   try {
     const userId = await requireApiUserId();
     const { id } = await props.params;
-    return NextResponse.json({ equipment: await listOwnedGymEquipment(userId, id, req.url) });
+    return NextResponse.json({ equipment: await listOwnedGymEquipment(userId, id) });
   } catch (err) {
     return handleApiError(err);
   }

--- a/app/api/gyms/[id]/equipment/route.ts
+++ b/app/api/gyms/[id]/equipment/route.ts
@@ -1,17 +1,24 @@
 import { NextResponse } from 'next/server';
-import { handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
+import { ApiError, handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
 import { listOwnedGymEquipment, upsertOwnedGymEquipment } from '@/lib/gym-equipment';
-import { gymEquipmentUpsertSchema } from '@/lib/schemas/gym-equipment';
+import { databaseIdSchema, gymEquipmentUpsertSchema } from '@/lib/schemas/gym-equipment';
 
 interface Params {
   params: Promise<{ id: string }>;
+}
+
+function parseGymId(id: string): string {
+  const parsed = databaseIdSchema.safeParse(id);
+  if (!parsed.success) throw new ApiError(400, 'Invalid gym id.');
+  return parsed.data;
 }
 
 export async function GET(_req: Request, props: Params) {
   try {
     const userId = await requireApiUserId();
     const { id } = await props.params;
-    return NextResponse.json({ equipment: await listOwnedGymEquipment(userId, id) });
+    const gymId = parseGymId(id);
+    return NextResponse.json({ equipment: await listOwnedGymEquipment(userId, gymId) });
   } catch (err) {
     return handleApiError(err);
   }
@@ -21,8 +28,9 @@ export async function POST(req: Request, props: Params) {
   try {
     const userId = await requireApiUserId();
     const { id } = await props.params;
+    const gymId = parseGymId(id);
     const input = await parseJsonBody(req, gymEquipmentUpsertSchema);
-    const saved = await upsertOwnedGymEquipment(userId, id, input);
+    const saved = await upsertOwnedGymEquipment(userId, gymId, input);
     return NextResponse.json(saved, { status: saved.created ? 201 : 200 });
   } catch (err) {
     return handleApiError(err);

--- a/app/api/gyms/[id]/equipment/route.ts
+++ b/app/api/gyms/[id]/equipment/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
+import { listOwnedGymEquipment, upsertOwnedGymEquipment } from '@/lib/gym-equipment';
+import { gymEquipmentUpsertSchema } from '@/lib/schemas/gym-equipment';
+
+interface Params {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(req: Request, props: Params) {
+  try {
+    const userId = await requireApiUserId();
+    const { id } = await props.params;
+    return NextResponse.json({ equipment: await listOwnedGymEquipment(userId, id, req.url) });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}
+
+export async function POST(req: Request, props: Params) {
+  try {
+    const userId = await requireApiUserId();
+    const { id } = await props.params;
+    const input = await parseJsonBody(req, gymEquipmentUpsertSchema);
+    const saved = await upsertOwnedGymEquipment(userId, id, input);
+    return NextResponse.json(saved, { status: 201 });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/app/api/gyms/[id]/equipment/route.ts
+++ b/app/api/gyms/[id]/equipment/route.ts
@@ -23,7 +23,7 @@ export async function POST(req: Request, props: Params) {
     const { id } = await props.params;
     const input = await parseJsonBody(req, gymEquipmentUpsertSchema);
     const saved = await upsertOwnedGymEquipment(userId, id, input);
-    return NextResponse.json(saved, { status: 201 });
+    return NextResponse.json(saved, { status: saved.created ? 201 : 200 });
   } catch (err) {
     return handleApiError(err);
   }

--- a/app/api/sessions/[id]/sets/route.ts
+++ b/app/api/sessions/[id]/sets/route.ts
@@ -52,7 +52,6 @@ export async function POST(req: Request, props: Params) {
         sessionGymId: session.gymId,
         exerciseId: data.exerciseId,
         gymEquipmentId: data.gymEquipmentId,
-        selectedLoadKg: canonicalWeight,
       });
       return tx.set.create({
         data: {
@@ -96,11 +95,7 @@ export async function POST(req: Request, props: Params) {
 // (deterministic - the same instant the goal-creation path would derive).
 // Comparison runs on the effective load (bodyweight + added load for
 // bodyweight exercises), consistent with lib/stats.
-async function stampGoalIfAchieved(
-  userId: string,
-  exercise: Exercise,
-  set: Set,
-): Promise<void> {
+async function stampGoalIfAchieved(userId: string, exercise: Exercise, set: Set): Promise<void> {
   if (set.isWarmup) return;
   const goal = await db.exerciseGoal.findUnique({
     where: { userId_exerciseId: { userId, exerciseId: exercise.id } },

--- a/app/api/sessions/[id]/sets/route.ts
+++ b/app/api/sessions/[id]/sets/route.ts
@@ -5,6 +5,7 @@ import { setInputSchema, validateSetForCategory } from '@/lib/schemas/set';
 import { ApiError, handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
 import { setAchievesGoal } from '@/lib/goals';
 import { effectiveWeight } from '@/lib/stats';
+import { resolveSetEquipmentSnapshot } from '@/lib/set-equipment';
 
 interface Params {
   params: Promise<{ id: string }>;
@@ -44,24 +45,35 @@ export async function POST(req: Request, props: Params) {
     }
     const isCardio = exercise.category === 'CARDIO';
 
-    const created = await db.set.create({
-      data: {
-        sessionId: params.id,
+    const created = await db.$transaction(async (tx) => {
+      const canonicalWeight = isCardio ? 0 : data.weight;
+      const equipmentSnapshot = await resolveSetEquipmentSnapshot(tx, {
+        userId,
+        sessionGymId: session.gymId,
         exerciseId: data.exerciseId,
-        setNumber: data.setNumber,
-        // Cardio sets store weight = 0 / reps = 1 by convention (the columns
-        // are NOT NULL); the UI never shows them for CARDIO exercises.
-        weight: isCardio ? 0 : data.weight,
-        reps: isCardio ? 1 : data.reps,
-        rir: isCardio ? null : (data.rir ?? null),
-        durationSec: isCardio ? data.durationSec : null,
-        distanceM: isCardio ? (data.distanceM ?? null) : null,
-        avgHr: isCardio ? (data.avgHr ?? null) : null,
-        maxHr: isCardio ? (data.maxHr ?? null) : null,
-        notes: data.notes ?? null,
-        isWarmup: data.isWarmup ?? false,
-        isDropSet: data.isDropSet ?? false,
-      },
+        gymEquipmentId: data.gymEquipmentId,
+        selectedLoadKg: canonicalWeight,
+      });
+      return tx.set.create({
+        data: {
+          sessionId: params.id,
+          exerciseId: data.exerciseId,
+          ...equipmentSnapshot,
+          setNumber: data.setNumber,
+          // Cardio sets store weight = 0 / reps = 1 by convention (the columns
+          // are NOT NULL); the UI never shows them for CARDIO exercises.
+          weight: canonicalWeight,
+          reps: isCardio ? 1 : data.reps,
+          rir: isCardio ? null : (data.rir ?? null),
+          durationSec: isCardio ? data.durationSec : null,
+          distanceM: isCardio ? (data.distanceM ?? null) : null,
+          avgHr: isCardio ? (data.avgHr ?? null) : null,
+          maxHr: isCardio ? (data.maxHr ?? null) : null,
+          notes: data.notes ?? null,
+          isWarmup: data.isWarmup ?? false,
+          isDropSet: data.isDropSet ?? false,
+        },
+      });
     });
     // Best-effort: the set is already committed, so a failure here must never
     // fail the request (a 500 would make the offline sync retry the POST and

--- a/components/session/session-runner.tsx
+++ b/components/session/session-runner.tsx
@@ -65,6 +65,11 @@ export interface SerializedLastPerformance {
 }
 
 type ProgramExerciseWithExercise = ProgramExercise & { exercise: Exercise };
+type SessionGymEquipment = {
+  id: string;
+  name: string;
+  exerciseLinks: { exerciseId: string }[];
+};
 
 type SessionRunnerProps = {
   session: Session & {
@@ -75,7 +80,7 @@ type SessionRunnerProps = {
         })
       | null;
     sets: PrismaSet[];
-    gym: (Gym & { exerciseConfigs: GymExerciseConfig[] }) | null;
+    gym: (Gym & { exerciseConfigs: GymExerciseConfig[]; equipment: SessionGymEquipment[] }) | null;
   };
   lastPerformances: Record<string, SerializedLastPerformance>;
   returnRecommendations: Record<string, ReturnRecommendation>;
@@ -286,6 +291,7 @@ export function SessionRunner({
     isWarmup: boolean;
     isDropSet: boolean;
     notes: string | null;
+    gymEquipmentId?: string | null;
   }) {
     if (!currentPE || !currentTarget) return;
     const existing = setsByExercise.get(currentPE.exerciseId) ?? [];
@@ -297,6 +303,7 @@ export function SessionRunner({
       localId: generateLocalId(),
       sessionId: session.id,
       exerciseId: currentPE.exerciseId,
+      gymEquipmentId: values.gymEquipmentId ?? null,
       setNumber,
       weight: values.weight,
       reps: values.reps,
@@ -527,6 +534,9 @@ export function SessionRunner({
             recommendation={currentRecommendation}
             returnRecommendation={currentReturnRecommendation}
             loadConstraints={loadConstraintsFor(currentTarget)}
+            equipmentOptions={(session.gym?.equipment ?? []).filter((item) =>
+              item.exerciseLinks.some((link) => link.exerciseId === currentPE.exerciseId),
+            )}
             onSubmit={handleValidate}
           />
         ) : (

--- a/components/session/set-input.test.tsx
+++ b/components/session/set-input.test.tsx
@@ -399,6 +399,65 @@ describe('SetInput AI parse', () => {
     expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ weight: 0, reps: 8, rir: 2 }));
   });
 
+  it('submits the selected physical gym equipment', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(
+      <SetInput
+        programExercise={pe}
+        existingSets={[]}
+        lastPerformance={undefined}
+        readiness={null}
+        deloadActive={false}
+        unit="KG"
+        equipmentOptions={[{ id: 'machine-1', name: 'Hammer Strength Squat' }]}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    await user.selectOptions(screen.getByRole('combobox'), 'machine-1');
+    await user.click(screen.getByRole('button', { name: /log the set/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ gymEquipmentId: 'machine-1' }));
+  });
+
+  it('keeps the most recently used physical equipment selected for the next set', () => {
+    const previousSet = {
+      localId: 'l-equipment',
+      sessionId: 's1',
+      exerciseId: 'e1',
+      gymEquipmentId: 'machine-1',
+      setNumber: 1,
+      weight: 100,
+      reps: 8,
+      rir: 2,
+      notes: null,
+      isWarmup: false,
+      isDropSet: false,
+      createdAt: Date.now(),
+      status: 'synced' as const,
+      serverId: 'set-equipment',
+      syncedAt: Date.now(),
+      attempts: 0,
+      lastError: null,
+    };
+
+    render(
+      <SetInput
+        programExercise={pe}
+        existingSets={[previousSet]}
+        lastPerformance={undefined}
+        readiness={null}
+        deloadActive={false}
+        unit="KG"
+        equipmentOptions={[{ id: 'machine-1', name: 'Hammer Strength Squat' }]}
+        onSubmit={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    expect(screen.getByRole('combobox')).toHaveValue('machine-1');
+  });
+
   it('ignores a cardio parse on a strength exercise (wrong shape)', async () => {
     const user = userEvent.setup();
     stubFetch({ kind: 'cardio', durationSec: 1500 });

--- a/components/session/set-input.tsx
+++ b/components/session/set-input.tsx
@@ -44,6 +44,7 @@ interface Props {
   recommendation?: IntraSetRecommendation | null;
   returnRecommendation?: ReturnRecommendation | null;
   loadConstraints?: GymLoadConstraints | null;
+  equipmentOptions?: { id: string; name: string }[];
   onSubmit: (values: {
     weight: number;
     reps: number;
@@ -53,6 +54,7 @@ interface Props {
     isWarmup: boolean;
     isDropSet: boolean;
     notes: string | null;
+    gymEquipmentId?: string | null;
   }) => Promise<void>;
 }
 
@@ -85,6 +87,7 @@ export function SetInput({
   recommendation = null,
   returnRecommendation = null,
   loadConstraints = null,
+  equipmentOptions = [],
   onSubmit,
 }: Props) {
   const t = useTranslations('session.input');
@@ -111,6 +114,7 @@ export function SetInput({
   const [aiText, setAiText] = useState('');
   const [aiParsing, setAiParsing] = useState(false);
   const [aiHint, setAiHint] = useState<string | null>(null);
+  const [gymEquipmentId, setGymEquipmentId] = useState('');
 
   // Re-init when the exercise changes or a set changes.
   useEffect(() => {
@@ -129,6 +133,12 @@ export function SetInput({
     setQuickEntry('');
     setAiText('');
     setAiHint(null);
+    const recentEquipmentId = existingSets.at(-1)?.gymEquipmentId ?? '';
+    setGymEquipmentId(
+      equipmentOptions.some((equipment) => equipment.id === recentEquipmentId)
+        ? recentEquipmentId
+        : '',
+    );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [programExercise.id, existingSets.length]);
 
@@ -254,29 +264,31 @@ export function SetInput({
     if (cardioInvalid) return;
     setSubmitting(true);
     try {
+      const values = isCardio
+        ? {
+            weight: 0,
+            reps: 1,
+            rir: null,
+            durationSec: durationSec!,
+            distanceM: hasDistance && distanceKm > 0 ? Math.round(distanceKm * 1000) : null,
+            isWarmup: false,
+            isDropSet: false,
+            notes: form.notes.trim() || null,
+          }
+        : {
+            weight: form.weight,
+            reps: form.reps,
+            rir: form.rir,
+            durationSec: null,
+            distanceM: null,
+            isWarmup: form.isWarmup,
+            isDropSet: form.isDropSet,
+            notes: form.notes.trim() || null,
+          };
       await onSubmit(
-        isCardio
-          ? {
-              weight: 0,
-              reps: 1,
-              rir: null,
-              durationSec: durationSec!,
-              // Stored in meters; the input is km with decimals.
-              distanceM: hasDistance && distanceKm > 0 ? Math.round(distanceKm * 1000) : null,
-              isWarmup: false,
-              isDropSet: false,
-              notes: form.notes.trim() || null,
-            }
-          : {
-              weight: form.weight,
-              reps: form.reps,
-              rir: form.rir,
-              durationSec: null,
-              distanceM: null,
-              isWarmup: form.isWarmup,
-              isDropSet: form.isDropSet,
-              notes: form.notes.trim() || null,
-            },
+        equipmentOptions.length > 0
+          ? { ...values, gymEquipmentId: gymEquipmentId || null }
+          : values,
       );
       // The transition animation to the rest timer is handled by the parent.
     } finally {
@@ -341,6 +353,30 @@ export function SetInput({
             <p className="text-xs text-muted-foreground">{t('parseHelp')}</p>
           )}
         </div>
+
+        {equipmentOptions.length > 0 && (
+          <div className="space-y-1">
+            <Label
+              htmlFor="gym-equipment"
+              className="text-xs uppercase tracking-wide text-muted-foreground"
+            >
+              {t('equipment')}
+            </Label>
+            <select
+              id="gym-equipment"
+              value={gymEquipmentId}
+              onChange={(event) => setGymEquipmentId(event.target.value)}
+              className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+            >
+              <option value="">{t('equipmentNone')}</option>
+              {equipmentOptions.map((equipment) => (
+                <option key={equipment.id} value={equipment.id}>
+                  {equipment.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
 
         {isCardio ? (
           <>

--- a/lib/gym-equipment.test.ts
+++ b/lib/gym-equipment.test.ts
@@ -1,0 +1,36 @@
+import { Buffer } from 'node:buffer';
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_GYM_EQUIPMENT_IMAGE_BYTES,
+  decodeGymEquipmentImage,
+} from './gym-equipment';
+
+const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+describe('decodeGymEquipmentImage', () => {
+  it('rejects bytes whose magic signature does not match the declared MIME type', () => {
+    expect(() =>
+      decodeGymEquipmentImage(Buffer.from('not a png').toString('base64'), 'image/png'),
+    ).toThrow('Uploaded bytes do not match the declared image type.');
+  });
+
+  it('rejects an over-cap payload before decoding it', () => {
+    const tooLarge = 'A'.repeat(Math.ceil((MAX_GYM_EQUIPMENT_IMAGE_BYTES * 4) / 3) + 17);
+    expect(() => decodeGymEquipmentImage(tooLarge, 'image/png')).toThrow(
+      'Uploaded equipment image is larger than 5 MB.',
+    );
+  });
+
+  it('rejects a declared MIME type that disagrees with the data URL', () => {
+    const dataUrl = `data:image/png;base64,${PNG.toString('base64')}`;
+    expect(() => decodeGymEquipmentImage(dataUrl, 'image/jpeg')).toThrow(
+      'The declared image MIME type does not match the data URL.',
+    );
+  });
+
+  it('rejects invalid base64', () => {
+    expect(() => decodeGymEquipmentImage('%%%not-base64%%%', 'image/png')).toThrow(
+      'Invalid base64 image data.',
+    );
+  });
+});

--- a/lib/gym-equipment.ts
+++ b/lib/gym-equipment.ts
@@ -58,7 +58,7 @@ const equipmentSelection = {
   },
 } as const;
 
-export async function listOwnedGymEquipment(userId: string, gymId: string, baseUrl: string) {
+export async function listOwnedGymEquipment(userId: string, gymId: string) {
   await requireOwnedGym(userId, gymId);
   const equipment = await db.gymEquipment.findMany({
     where: { gymId },
@@ -70,10 +70,7 @@ export async function listOwnedGymEquipment(userId: string, gymId: string, baseU
     image: item.imageMimeType
       ? {
           kind: 'uploaded' as const,
-          url: new URL(
-            `/api/gym-equipment/${item.id}/image?v=${item.updatedAt.getTime()}`,
-            baseUrl,
-          ).toString(),
+          url: `/api/gym-equipment/${item.id}/image?v=${item.updatedAt.getTime()}`,
           mimeType: item.imageMimeType,
         }
       : item.imageUrl
@@ -203,7 +200,10 @@ export async function upsertOwnedGymEquipment(
     return saved;
   });
 
-  const saved = await db.gymEquipment.findUnique({ where: { id: item.id }, select: equipmentSelection });
+  const saved = await db.gymEquipment.findUnique({
+    where: { id: item.id },
+    select: equipmentSelection,
+  });
   if (!saved) throw new ApiError(500, 'Gym equipment could not be read after saving.');
 
   const mismatchedExercises = exercises
@@ -241,7 +241,9 @@ export async function getOwnedGymEquipmentImage(userId: string, equipmentId: str
   if (!equipment) throw new ApiError(404, 'Gym equipment not found.');
 
   if (equipment.imageData && equipment.imageMimeType) {
-    if (!GYM_EQUIPMENT_IMAGE_MIME_TYPES.includes(equipment.imageMimeType as GymEquipmentImageMimeType)) {
+    if (
+      !GYM_EQUIPMENT_IMAGE_MIME_TYPES.includes(equipment.imageMimeType as GymEquipmentImageMimeType)
+    ) {
       throw new ApiError(500, 'Gym equipment image has an unsupported MIME type.');
     }
     return {
@@ -263,8 +265,9 @@ export async function setOwnedGymEquipmentImage(
   input: SetGymEquipmentImageInput,
 ) {
   const equipment = await requireOwnedEquipment(userId, equipmentId);
-  const modes = [input.clear === true, input.imageUrl != null, input.imageBase64 != null].filter(Boolean)
-    .length;
+  const modes = [input.clear === true, input.imageUrl != null, input.imageBase64 != null].filter(
+    Boolean,
+  ).length;
   if (modes !== 1) {
     throw new ApiError(400, 'Choose exactly one image action: clear, imageUrl, or imageBase64.');
   }
@@ -282,7 +285,14 @@ export async function setOwnedGymEquipmentImage(
   return db.gymEquipment.update({
     where: { id: equipment.id },
     data,
-    select: { id: true, gymId: true, name: true, imageUrl: true, imageMimeType: true, updatedAt: true },
+    select: {
+      id: true,
+      gymId: true,
+      name: true,
+      imageUrl: true,
+      imageMimeType: true,
+      updatedAt: true,
+    },
   });
 }
 

--- a/lib/gym-equipment.ts
+++ b/lib/gym-equipment.ts
@@ -1,0 +1,338 @@
+import { Buffer } from 'node:buffer';
+import { ApiError } from '@/lib/api';
+import { db } from '@/lib/db';
+import type { EquipmentType } from '@/lib/prisma-client';
+
+export const GYM_EQUIPMENT_IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'] as const;
+export type GymEquipmentImageMimeType = (typeof GYM_EQUIPMENT_IMAGE_MIME_TYPES)[number];
+export const MAX_GYM_EQUIPMENT_IMAGE_BYTES = 5 * 1024 * 1024;
+
+export interface UpsertGymEquipmentInput {
+  equipmentId?: string;
+  name: string;
+  equipmentType: EquipmentType;
+  description?: string | null;
+  manufacturer?: string | null;
+  modelName?: string | null;
+  quantity?: number;
+  weightOptions?: number[];
+  exerciseIds?: string[];
+  markExercisesAvailable?: boolean;
+}
+
+export interface SetGymEquipmentImageInput {
+  clear?: boolean;
+  imageUrl?: string;
+  imageBase64?: string;
+  mimeType?: GymEquipmentImageMimeType;
+}
+
+const equipmentSelection = {
+  id: true,
+  gymId: true,
+  name: true,
+  equipmentType: true,
+  description: true,
+  manufacturer: true,
+  modelName: true,
+  quantity: true,
+  weightOptions: true,
+  imageUrl: true,
+  imageMimeType: true,
+  createdAt: true,
+  updatedAt: true,
+  exerciseLinks: {
+    orderBy: { exercise: { name: 'asc' as const } },
+    include: {
+      exercise: {
+        select: {
+          id: true,
+          name: true,
+          muscleGroup: true,
+          category: true,
+          equipmentType: true,
+        },
+      },
+    },
+  },
+} as const;
+
+export async function listOwnedGymEquipment(userId: string, gymId: string, baseUrl: string) {
+  await requireOwnedGym(userId, gymId);
+  const equipment = await db.gymEquipment.findMany({
+    where: { gymId },
+    orderBy: { name: 'asc' },
+    select: equipmentSelection,
+  });
+  return equipment.map((item) => ({
+    ...item,
+    image: item.imageMimeType
+      ? {
+          kind: 'uploaded' as const,
+          url: new URL(
+            `/api/gym-equipment/${item.id}/image?v=${item.updatedAt.getTime()}`,
+            baseUrl,
+          ).toString(),
+          mimeType: item.imageMimeType,
+        }
+      : item.imageUrl
+        ? { kind: 'external' as const, url: item.imageUrl, mimeType: null }
+        : null,
+    exerciseLinks: item.exerciseLinks.map((link) => link.exercise),
+  }));
+}
+
+export async function upsertOwnedGymEquipment(
+  userId: string,
+  gymId: string,
+  input: UpsertGymEquipmentInput,
+) {
+  await requireOwnedGym(userId, gymId);
+  const requestedExerciseIds = input.exerciseIds ? [...new Set(input.exerciseIds)] : undefined;
+  const current = input.equipmentId
+    ? await db.gymEquipment.findFirst({
+        where: { id: input.equipmentId, gymId },
+        select: {
+          id: true,
+          equipmentType: true,
+          weightOptions: true,
+          exerciseLinks: { select: { exerciseId: true } },
+        },
+      })
+    : await db.gymEquipment.findFirst({
+        where: { gymId, name: { equals: input.name, mode: 'insensitive' } },
+        select: {
+          id: true,
+          equipmentType: true,
+          weightOptions: true,
+          exerciseLinks: { select: { exerciseId: true } },
+        },
+      });
+  if (input.equipmentId && !current) throw new ApiError(404, 'Gym equipment not found.');
+
+  const exerciseIds =
+    requestedExerciseIds ?? current?.exerciseLinks.map((link) => link.exerciseId) ?? [];
+  const exercises = exerciseIds.length
+    ? await db.exercise.findMany({
+        where: { userId, id: { in: exerciseIds } },
+        select: { id: true, name: true, equipmentType: true },
+      })
+    : [];
+  if (exercises.length !== exerciseIds.length) {
+    throw new ApiError(400, 'One or more exercise IDs do not belong to the trainee.');
+  }
+
+  const equipmentTypeChanged = current != null && current.equipmentType !== input.equipmentType;
+  const shouldSyncExerciseConfigs =
+    requestedExerciseIds !== undefined || input.weightOptions !== undefined || equipmentTypeChanged;
+  const effectiveWeightOptions = input.weightOptions ?? current?.weightOptions ?? [];
+
+  const item = await db.$transaction(async (tx) => {
+    const saved = current
+      ? await tx.gymEquipment.update({
+          where: { id: current.id },
+          data: {
+            name: input.name,
+            equipmentType: input.equipmentType,
+            description: input.description,
+            manufacturer: input.manufacturer,
+            modelName: input.modelName,
+            quantity: input.quantity,
+            weightOptions: input.weightOptions,
+          },
+        })
+      : await tx.gymEquipment.create({
+          data: {
+            gymId,
+            name: input.name,
+            equipmentType: input.equipmentType,
+            description: input.description,
+            manufacturer: input.manufacturer,
+            modelName: input.modelName,
+            quantity: input.quantity ?? 1,
+            weightOptions: input.weightOptions ?? [],
+          },
+        });
+
+    if (requestedExerciseIds !== undefined) {
+      await tx.gymEquipmentExercise.deleteMany({ where: { equipmentId: saved.id } });
+      if (requestedExerciseIds.length > 0) {
+        await tx.gymEquipmentExercise.createMany({
+          data: requestedExerciseIds.map((exerciseId) => ({ equipmentId: saved.id, exerciseId })),
+        });
+      }
+    }
+
+    // Keep the already-accepted GymExerciseConfig model in sync as a compatibility
+    // projection. Later equipment-first workout code can use the physical item
+    // directly, while current upstream screens immediately see linked exercises
+    // as available and retain their machine/cable load options.
+    if (input.markExercisesAvailable !== false && shouldSyncExerciseConfigs) {
+      const useItemWeights = ['MACHINE', 'CABLE', 'OTHER'].includes(input.equipmentType);
+      for (const exercise of exercises) {
+        await tx.gymExerciseConfig.upsert({
+          where: { gymId_exerciseId: { gymId, exerciseId: exercise.id } },
+          update: {
+            isAvailable: true,
+            ...(useItemWeights
+              ? { weightOptions: effectiveWeightOptions }
+              : equipmentTypeChanged
+                ? { weightOptions: [] }
+                : {}),
+          },
+          create: {
+            gymId,
+            exerciseId: exercise.id,
+            isAvailable: true,
+            weightOptions: useItemWeights ? effectiveWeightOptions : [],
+          },
+        });
+      }
+    }
+    return saved;
+  });
+
+  const saved = await db.gymEquipment.findUnique({ where: { id: item.id }, select: equipmentSelection });
+  if (!saved) throw new ApiError(500, 'Gym equipment could not be read after saving.');
+
+  const mismatchedExercises = exercises
+    .filter(
+      (exercise) =>
+        exercise.equipmentType !== 'OTHER' &&
+        input.equipmentType !== 'OTHER' &&
+        exercise.equipmentType !== input.equipmentType,
+    )
+    .map((exercise) => ({
+      id: exercise.id,
+      name: exercise.name,
+      exerciseEquipmentType: exercise.equipmentType,
+    }));
+
+  return { equipment: saved, mismatchedExercises };
+}
+
+export async function deleteOwnedGymEquipment(userId: string, equipmentId: string) {
+  const equipment = await requireOwnedEquipment(userId, equipmentId);
+  await db.gymEquipment.delete({ where: { id: equipment.id } });
+}
+
+export async function getOwnedGymEquipmentImage(userId: string, equipmentId: string) {
+  const equipment = await db.gymEquipment.findFirst({
+    where: { id: equipmentId, gym: { userId } },
+    select: {
+      id: true,
+      imageUrl: true,
+      imageData: true,
+      imageMimeType: true,
+      updatedAt: true,
+    },
+  });
+  if (!equipment) throw new ApiError(404, 'Gym equipment not found.');
+
+  if (equipment.imageData && equipment.imageMimeType) {
+    if (!GYM_EQUIPMENT_IMAGE_MIME_TYPES.includes(equipment.imageMimeType as GymEquipmentImageMimeType)) {
+      throw new ApiError(500, 'Gym equipment image has an unsupported MIME type.');
+    }
+    return {
+      kind: 'uploaded' as const,
+      bytes: Buffer.from(equipment.imageData),
+      mimeType: equipment.imageMimeType as GymEquipmentImageMimeType,
+      updatedAt: equipment.updatedAt,
+    };
+  }
+  if (equipment.imageUrl) {
+    return { kind: 'external' as const, url: equipment.imageUrl, updatedAt: equipment.updatedAt };
+  }
+  throw new ApiError(404, 'Gym equipment image not found.');
+}
+
+export async function setOwnedGymEquipmentImage(
+  userId: string,
+  equipmentId: string,
+  input: SetGymEquipmentImageInput,
+) {
+  const equipment = await requireOwnedEquipment(userId, equipmentId);
+  const modes = [input.clear === true, input.imageUrl != null, input.imageBase64 != null].filter(Boolean)
+    .length;
+  if (modes !== 1) {
+    throw new ApiError(400, 'Choose exactly one image action: clear, imageUrl, or imageBase64.');
+  }
+
+  const data = input.clear
+    ? { imageUrl: null, imageData: null, imageMimeType: null }
+    : input.imageUrl
+      ? { imageUrl: input.imageUrl, imageData: null, imageMimeType: null }
+      : (() => {
+          const decoded = decodeGymEquipmentImage(input.imageBase64!, input.mimeType);
+          return { imageUrl: null, imageData: decoded.bytes, imageMimeType: decoded.mimeType };
+        })();
+
+  return db.gymEquipment.update({
+    where: { id: equipment.id },
+    data,
+    select: { id: true, gymId: true, name: true, imageUrl: true, imageMimeType: true, updatedAt: true },
+  });
+}
+
+export function decodeGymEquipmentImage(
+  raw: string,
+  declaredMimeType?: GymEquipmentImageMimeType,
+): { bytes: Uint8Array<ArrayBuffer>; mimeType: GymEquipmentImageMimeType } {
+  const dataUrl = /^data:(image\/(?:jpeg|png|webp));base64,(.+)$/s.exec(raw.trim());
+  const mimeType = (dataUrl?.[1] ?? declaredMimeType) as GymEquipmentImageMimeType | undefined;
+  if (!mimeType || !GYM_EQUIPMENT_IMAGE_MIME_TYPES.includes(mimeType)) {
+    throw new ApiError(400, 'Uploaded equipment image must be JPEG, PNG, or WebP.');
+  }
+  if (dataUrl && declaredMimeType && dataUrl[1] !== declaredMimeType) {
+    throw new ApiError(400, 'The declared image MIME type does not match the data URL.');
+  }
+
+  const base64 = (dataUrl?.[2] ?? raw).replace(/\s/g, '');
+  if (base64.length > Math.ceil((MAX_GYM_EQUIPMENT_IMAGE_BYTES * 4) / 3) + 16) {
+    throw new ApiError(400, 'Uploaded equipment image is larger than 5 MB.');
+  }
+  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(base64)) throw new ApiError(400, 'Invalid base64 image data.');
+  const buffer = Buffer.from(base64, 'base64');
+  if (buffer.length === 0) throw new ApiError(400, 'Uploaded equipment image is empty.');
+  if (buffer.length > MAX_GYM_EQUIPMENT_IMAGE_BYTES) {
+    throw new ApiError(400, 'Uploaded equipment image is larger than 5 MB.');
+  }
+  if (!matchesImageSignature(buffer, mimeType)) {
+    throw new ApiError(400, 'Uploaded bytes do not match the declared image type.');
+  }
+  const bytes = new Uint8Array(new ArrayBuffer(buffer.length));
+  bytes.set(buffer);
+  return { bytes, mimeType };
+}
+
+async function requireOwnedGym(userId: string, gymId: string) {
+  const gym = await db.gym.findFirst({ where: { id: gymId, userId }, select: { id: true } });
+  if (!gym) throw new ApiError(404, 'Gym not found.');
+  return gym;
+}
+
+async function requireOwnedEquipment(userId: string, equipmentId: string) {
+  const equipment = await db.gymEquipment.findFirst({
+    where: { id: equipmentId, gym: { userId } },
+    select: { id: true, gymId: true },
+  });
+  if (!equipment) throw new ApiError(404, 'Gym equipment not found.');
+  return equipment;
+}
+
+function matchesImageSignature(buffer: Buffer, mimeType: GymEquipmentImageMimeType): boolean {
+  if (mimeType === 'image/jpeg') {
+    return buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff;
+  }
+  if (mimeType === 'image/png') {
+    return (
+      buffer.length >= 8 &&
+      buffer.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))
+    );
+  }
+  return (
+    buffer.length >= 12 &&
+    buffer.subarray(0, 4).toString('ascii') === 'RIFF' &&
+    buffer.subarray(8, 12).toString('ascii') === 'WEBP'
+  );
+}

--- a/lib/gym-equipment.ts
+++ b/lib/gym-equipment.ts
@@ -108,15 +108,6 @@ export async function upsertOwnedGymEquipment(
       });
   if (input.equipmentId && !current) throw new ApiError(404, 'Gym equipment not found.');
   const created = current == null;
-  if (created) {
-    const equipmentCount = await db.gymEquipment.count({ where: { gymId } });
-    if (equipmentCount >= MAX_GYM_EQUIPMENT_PER_GYM) {
-      throw new ApiError(
-        400,
-        'A gym can contain at most ' + MAX_GYM_EQUIPMENT_PER_GYM + ' physical equipment items.',
-      );
-    }
-  }
 
   const exerciseIds =
     requestedExerciseIds ?? current?.exerciseLinks.map((link) => link.exerciseId) ?? [];
@@ -136,6 +127,19 @@ export async function upsertOwnedGymEquipment(
   const effectiveWeightOptions = input.weightOptions ?? current?.weightOptions ?? [];
 
   const item = await db.$transaction(async (tx) => {
+    if (created) {
+      // Serialize creations per gym so concurrent requests cannot both observe
+      // the same pre-limit count and exceed MAX_GYM_EQUIPMENT_PER_GYM.
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${gymId}))`;
+      const equipmentCount = await tx.gymEquipment.count({ where: { gymId } });
+      if (equipmentCount >= MAX_GYM_EQUIPMENT_PER_GYM) {
+        throw new ApiError(
+          400,
+          'A gym can contain at most ' + MAX_GYM_EQUIPMENT_PER_GYM + ' physical equipment items.',
+        );
+      }
+    }
+
     const saved = current
       ? await tx.gymEquipment.update({
           where: { id: current.id },

--- a/lib/gym-equipment.ts
+++ b/lib/gym-equipment.ts
@@ -6,6 +6,7 @@ import type { EquipmentType } from '@/lib/prisma-client';
 export const GYM_EQUIPMENT_IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'] as const;
 export type GymEquipmentImageMimeType = (typeof GYM_EQUIPMENT_IMAGE_MIME_TYPES)[number];
 export const MAX_GYM_EQUIPMENT_IMAGE_BYTES = 5 * 1024 * 1024;
+export const MAX_GYM_EQUIPMENT_PER_GYM = 1000;
 
 export interface UpsertGymEquipmentInput {
   equipmentId?: string;
@@ -109,6 +110,16 @@ export async function upsertOwnedGymEquipment(
         },
       });
   if (input.equipmentId && !current) throw new ApiError(404, 'Gym equipment not found.');
+  const created = current == null;
+  if (created) {
+    const equipmentCount = await db.gymEquipment.count({ where: { gymId } });
+    if (equipmentCount >= MAX_GYM_EQUIPMENT_PER_GYM) {
+      throw new ApiError(
+        400,
+        'A gym can contain at most ' + MAX_GYM_EQUIPMENT_PER_GYM + ' physical equipment items.',
+      );
+    }
+  }
 
   const exerciseIds =
     requestedExerciseIds ?? current?.exerciseLinks.map((link) => link.exerciseId) ?? [];
@@ -208,7 +219,7 @@ export async function upsertOwnedGymEquipment(
       exerciseEquipmentType: exercise.equipmentType,
     }));
 
-  return { equipment: saved, mismatchedExercises };
+  return { equipment: saved, mismatchedExercises, created };
 }
 
 export async function deleteOwnedGymEquipment(userId: string, equipmentId: string) {
@@ -258,14 +269,15 @@ export async function setOwnedGymEquipmentImage(
     throw new ApiError(400, 'Choose exactly one image action: clear, imageUrl, or imageBase64.');
   }
 
+  const decoded = input.imageBase64
+    ? decodeGymEquipmentImage(input.imageBase64, input.mimeType)
+    : null;
+
   const data = input.clear
     ? { imageUrl: null, imageData: null, imageMimeType: null }
     : input.imageUrl
       ? { imageUrl: input.imageUrl, imageData: null, imageMimeType: null }
-      : (() => {
-          const decoded = decodeGymEquipmentImage(input.imageBase64!, input.mimeType);
-          return { imageUrl: null, imageData: decoded.bytes, imageMimeType: decoded.mimeType };
-        })();
+      : { imageUrl: null, imageData: decoded!.bytes, imageMimeType: decoded!.mimeType };
 
   return db.gymEquipment.update({
     where: { id: equipment.id },

--- a/lib/indexeddb.ts
+++ b/lib/indexeddb.ts
@@ -24,6 +24,9 @@ export interface PendingSet {
   sessionId: string;
 
   exerciseId: string;
+  // Concrete physical machine/equipment selected for this set. Optional keeps
+  // IndexedDB rows written before equipment selection backward-compatible.
+  gymEquipmentId?: string | null;
   setNumber: number;
   weight: number;
   reps: number;
@@ -37,7 +40,7 @@ export interface PendingSet {
   isWarmup: boolean;
   isDropSet: boolean;
 
-  createdAt: number;        // epoch ms
+  createdAt: number; // epoch ms
   status: PendingSetStatus;
   // If synced: server id returned by the API. Allows reconciliation
   // with the UI state and avoids double-POST on retry.

--- a/lib/schemas/gym-equipment.test.ts
+++ b/lib/schemas/gym-equipment.test.ts
@@ -4,6 +4,7 @@ import { gymEquipmentImageSchema, gymEquipmentUpsertSchema } from './gym-equipme
 describe('gym equipment schemas', () => {
   it('normalizes a complete equipment input without inventing omitted update fields', () => {
     const parsed = gymEquipmentUpsertSchema.parse({
+      equipmentId: ' equipment-1 ',
       name: '  Cable station  ',
       equipmentType: 'CABLE',
       quantity: 2,
@@ -12,6 +13,7 @@ describe('gym equipment schemas', () => {
     });
 
     expect(parsed).toMatchObject({
+      equipmentId: 'equipment-1',
       name: 'Cable station',
       quantity: 2,
       weightOptions: [10, 20],
@@ -30,9 +32,9 @@ describe('gym equipment schemas', () => {
   });
 
   it('requires exactly one safe equipment image source', () => {
-    expect(gymEquipmentImageSchema.safeParse({ imageUrl: 'http://unsafe.test/image.jpg' }).success).toBe(
-      false,
-    );
+    expect(
+      gymEquipmentImageSchema.safeParse({ imageUrl: 'http://unsafe.test/image.jpg' }).success,
+    ).toBe(false);
     expect(
       gymEquipmentImageSchema.safeParse({ imageBase64: 'abcd', mimeType: 'image/gif' }).success,
     ).toBe(false);

--- a/lib/schemas/gym-equipment.test.ts
+++ b/lib/schemas/gym-equipment.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { gymEquipmentImageSchema, gymEquipmentUpsertSchema } from './gym-equipment';
 
 describe('gym equipment schemas', () => {
-  it('normalizes a complete equipment input', () => {
+  it('normalizes a complete equipment input without inventing omitted update fields', () => {
     const parsed = gymEquipmentUpsertSchema.parse({
       name: '  Cable station  ',
       equipmentType: 'CABLE',
@@ -16,8 +16,17 @@ describe('gym equipment schemas', () => {
       quantity: 2,
       weightOptions: [10, 20],
       exerciseIds: ['exercise-1'],
-      markExercisesAvailable: true,
     });
+    expect(parsed.markExercisesAvailable).toBeUndefined();
+
+    const minimal = gymEquipmentUpsertSchema.parse({
+      name: 'Cable station',
+      equipmentType: 'CABLE',
+    });
+    expect(minimal.quantity).toBeUndefined();
+    expect(minimal.weightOptions).toBeUndefined();
+    expect(minimal.exerciseIds).toBeUndefined();
+    expect(minimal.markExercisesAvailable).toBeUndefined();
   });
 
   it('requires exactly one safe equipment image source', () => {

--- a/lib/schemas/gym-equipment.test.ts
+++ b/lib/schemas/gym-equipment.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { gymEquipmentImageSchema, gymEquipmentUpsertSchema } from './gym-equipment';
+
+describe('gym equipment schemas', () => {
+  it('normalizes a complete equipment input', () => {
+    const parsed = gymEquipmentUpsertSchema.parse({
+      name: '  Cable station  ',
+      equipmentType: 'CABLE',
+      quantity: 2,
+      weightOptions: [20, 10, 20],
+      exerciseIds: ['exercise-1'],
+    });
+
+    expect(parsed).toMatchObject({
+      name: 'Cable station',
+      quantity: 2,
+      weightOptions: [10, 20],
+      exerciseIds: ['exercise-1'],
+      markExercisesAvailable: true,
+    });
+  });
+
+  it('requires exactly one safe equipment image source', () => {
+    expect(gymEquipmentImageSchema.safeParse({ imageUrl: 'http://unsafe.test/image.jpg' }).success).toBe(
+      false,
+    );
+    expect(
+      gymEquipmentImageSchema.safeParse({ imageBase64: 'abcd', mimeType: 'image/gif' }).success,
+    ).toBe(false);
+    expect(
+      gymEquipmentImageSchema.safeParse({
+        imageUrl: 'https://example.test/image.jpg',
+        imageBase64: 'abcd',
+        mimeType: 'image/jpeg',
+      }).success,
+    ).toBe(false);
+    expect(
+      gymEquipmentImageSchema.safeParse({ imageBase64: 'abcd', mimeType: 'image/jpeg' }).success,
+    ).toBe(true);
+  });
+});

--- a/lib/schemas/gym-equipment.ts
+++ b/lib/schemas/gym-equipment.ts
@@ -6,6 +6,7 @@ import { gymWeightListSchema } from '@/lib/schemas/gym';
 const databaseIdSchema = z.string().trim().min(1).max(191);
 
 export const gymEquipmentUpsertSchema = z.object({
+  equipmentId: databaseIdSchema.optional(),
   name: z.string().trim().min(1).max(120),
   equipmentType: z.nativeEnum(EquipmentType),
   description: z.string().trim().max(4000).nullable().optional(),

--- a/lib/schemas/gym-equipment.ts
+++ b/lib/schemas/gym-equipment.ts
@@ -11,10 +11,10 @@ export const gymEquipmentUpsertSchema = z.object({
   description: z.string().trim().max(4000).nullable().optional(),
   manufacturer: z.string().trim().max(120).nullable().optional(),
   modelName: z.string().trim().max(120).nullable().optional(),
-  quantity: z.number().int().min(1).max(100).default(1),
-  weightOptions: gymWeightListSchema.default([]),
-  exerciseIds: z.array(databaseIdSchema).max(100).default([]),
-  markExercisesAvailable: z.boolean().default(true),
+  quantity: z.number().int().min(1).max(100).optional(),
+  weightOptions: gymWeightListSchema.optional(),
+  exerciseIds: z.array(databaseIdSchema).max(100).optional(),
+  markExercisesAvailable: z.boolean().optional(),
 });
 
 const maximumBase64Length = 7_100_000;

--- a/lib/schemas/gym-equipment.ts
+++ b/lib/schemas/gym-equipment.ts
@@ -3,7 +3,7 @@ import { EquipmentType } from '@/lib/prisma-client';
 import { GYM_EQUIPMENT_IMAGE_MIME_TYPES } from '@/lib/gym-equipment';
 import { gymWeightListSchema } from '@/lib/schemas/gym';
 
-const databaseIdSchema = z.string().trim().min(1).max(191);
+export const databaseIdSchema = z.string().trim().min(1).max(191);
 
 export const gymEquipmentUpsertSchema = z.object({
   equipmentId: databaseIdSchema.optional(),

--- a/lib/schemas/gym-equipment.ts
+++ b/lib/schemas/gym-equipment.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+import { EquipmentType } from '@/lib/prisma-client';
+import { GYM_EQUIPMENT_IMAGE_MIME_TYPES } from '@/lib/gym-equipment';
+import { gymWeightListSchema } from '@/lib/schemas/gym';
+
+const databaseIdSchema = z.string().trim().min(1).max(191);
+
+export const gymEquipmentUpsertSchema = z.object({
+  name: z.string().trim().min(1).max(120),
+  equipmentType: z.nativeEnum(EquipmentType),
+  description: z.string().trim().max(4000).nullable().optional(),
+  manufacturer: z.string().trim().max(120).nullable().optional(),
+  modelName: z.string().trim().max(120).nullable().optional(),
+  quantity: z.number().int().min(1).max(100).default(1),
+  weightOptions: gymWeightListSchema.default([]),
+  exerciseIds: z.array(databaseIdSchema).max(100).default([]),
+  markExercisesAvailable: z.boolean().default(true),
+});
+
+const maximumBase64Length = 7_100_000;
+
+export const gymEquipmentImageSchema = z
+  .object({
+    imageUrl: z.string().trim().url().max(2048).startsWith('https://').optional(),
+    imageBase64: z.string().max(maximumBase64Length).optional(),
+    mimeType: z.enum(GYM_EQUIPMENT_IMAGE_MIME_TYPES).optional(),
+  })
+  .refine((value) => Number(value.imageUrl != null) + Number(value.imageBase64 != null) === 1, {
+    message: 'Choose exactly one image source.',
+  })
+  .refine((value) => value.imageBase64 == null || value.mimeType != null, {
+    message: 'Uploaded images require a MIME type.',
+  });
+
+export type GymEquipmentUpsertInput = z.infer<typeof gymEquipmentUpsertSchema>;
+export type GymEquipmentImageInput = z.infer<typeof gymEquipmentImageSchema>;

--- a/lib/schemas/set.ts
+++ b/lib/schemas/set.ts
@@ -11,6 +11,7 @@ import {
 
 export const setInputSchema = z.object({
   exerciseId: z.string().min(1),
+  gymEquipmentId: z.string().min(1).nullable().optional(),
   setNumber: z.coerce.number().int().min(1).max(50),
   weight: z.coerce.number().min(0).max(500),
   reps: z.coerce.number().int().min(0).max(100),

--- a/lib/session-gym-selection.test.ts
+++ b/lib/session-gym-selection.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { liveSessionGymInclude } from '@/lib/session-gym-selection';
+
+describe('live session gym selection', () => {
+  it('selects only lightweight equipment fields and never the image blob', () => {
+    const equipment = liveSessionGymInclude.equipment.select;
+
+    expect(equipment).toEqual({
+      id: true,
+      name: true,
+      exerciseLinks: { select: { exerciseId: true } },
+    });
+    expect('imageData' in equipment).toBe(false);
+    expect('imageMimeType' in equipment).toBe(false);
+  });
+});

--- a/lib/session-gym-selection.ts
+++ b/lib/session-gym-selection.ts
@@ -1,0 +1,13 @@
+// Keep the live-session RSC payload deliberately small. In particular, do not
+// select GymEquipment.imageData here: equipment photos can be several MiB each
+// and the runner only needs identity/name plus exercise compatibility.
+export const liveSessionGymInclude = {
+  exerciseConfigs: true,
+  equipment: {
+    select: {
+      id: true,
+      name: true,
+      exerciseLinks: { select: { exerciseId: true } },
+    },
+  },
+} as const;

--- a/lib/set-equipment.ts
+++ b/lib/set-equipment.ts
@@ -1,0 +1,82 @@
+import { ApiError } from '@/lib/api';
+import { Prisma } from '@/prisma/generated/client';
+
+type EquipmentReader = Pick<Prisma.TransactionClient, 'gymEquipment'>;
+
+export interface SetEquipmentSnapshot {
+  gymEquipmentId: string | null;
+  equipmentNameSnapshot: string | null;
+  selectedLoadKg: number | null;
+  selectedLoadMultiplierSnapshot: number | null;
+  nominalResistanceKg: number | null;
+  equipmentLoadSnapshot: Prisma.InputJsonValue | typeof Prisma.JsonNull;
+}
+
+export async function resolveSetEquipmentSnapshot(
+  client: EquipmentReader,
+  input: {
+    userId: string;
+    sessionGymId: string | null;
+    exerciseId: string;
+    gymEquipmentId?: string | null;
+    selectedLoadKg: number;
+  },
+): Promise<SetEquipmentSnapshot> {
+  if (!input.gymEquipmentId) return emptySetEquipmentSnapshot();
+
+  const equipment = await client.gymEquipment.findFirst({
+    where: {
+      id: input.gymEquipmentId,
+      gym: { userId: input.userId },
+      exerciseLinks: { some: { exerciseId: input.exerciseId } },
+    },
+    select: {
+      id: true,
+      gymId: true,
+      name: true,
+      equipmentType: true,
+      manufacturer: true,
+      modelName: true,
+      weightOptions: true,
+    },
+  });
+  if (!equipment) {
+    throw new ApiError(400, 'Equipment is not available for this exercise.');
+  }
+  if (!input.sessionGymId || equipment.gymId !== input.sessionGymId) {
+    throw new ApiError(400, 'Equipment must belong to the gym frozen on this session.');
+  }
+
+  const selectedLoadKg = round(input.selectedLoadKg);
+  const snapshot = {
+    version: 1,
+    equipmentType: equipment.equipmentType,
+    manufacturer: equipment.manufacturer,
+    modelName: equipment.modelName,
+    weightOptions: equipment.weightOptions,
+  } satisfies Prisma.InputJsonObject;
+
+  return {
+    gymEquipmentId: equipment.id,
+    equipmentNameSnapshot: equipment.name,
+    selectedLoadKg,
+    selectedLoadMultiplierSnapshot: null,
+    nominalResistanceKg: null,
+    equipmentLoadSnapshot: snapshot,
+  };
+}
+
+export function emptySetEquipmentSnapshot(): SetEquipmentSnapshot {
+  return {
+    gymEquipmentId: null,
+    equipmentNameSnapshot: null,
+    selectedLoadKg: null,
+    selectedLoadMultiplierSnapshot: null,
+    nominalResistanceKg: null,
+    equipmentLoadSnapshot: Prisma.JsonNull,
+  };
+}
+
+function round(value: number): number {
+  return Math.round(value * 100) / 100;
+}

--- a/lib/set-equipment.ts
+++ b/lib/set-equipment.ts
@@ -1,4 +1,3 @@
-import { ApiError } from '@/lib/api';
 import { Prisma } from '@/prisma/generated/client';
 
 type EquipmentReader = Pick<Prisma.TransactionClient, 'gymEquipment'>;
@@ -6,9 +5,6 @@ type EquipmentReader = Pick<Prisma.TransactionClient, 'gymEquipment'>;
 export interface SetEquipmentSnapshot {
   gymEquipmentId: string | null;
   equipmentNameSnapshot: string | null;
-  selectedLoadKg: number | null;
-  selectedLoadMultiplierSnapshot: number | null;
-  nominalResistanceKg: number | null;
   equipmentLoadSnapshot: Prisma.InputJsonValue | typeof Prisma.JsonNull;
 }
 
@@ -19,7 +15,6 @@ export async function resolveSetEquipmentSnapshot(
     sessionGymId: string | null;
     exerciseId: string;
     gymEquipmentId?: string | null;
-    selectedLoadKg: number;
   },
 ): Promise<SetEquipmentSnapshot> {
   if (!input.gymEquipmentId) return emptySetEquipmentSnapshot();
@@ -40,14 +35,13 @@ export async function resolveSetEquipmentSnapshot(
       weightOptions: true,
     },
   });
-  if (!equipment) {
-    throw new ApiError(400, 'Equipment is not available for this exercise.');
-  }
-  if (!input.sessionGymId || equipment.gymId !== input.sessionGymId) {
-    throw new ApiError(400, 'Equipment must belong to the gym frozen on this session.');
+  // Equipment is optional decoration on a training set. A stale/deleted,
+  // unlinked, foreign, or wrong-gym reference must never make the actual
+  // weight/reps/RIR fail to record. Drop the reference and preserve the set.
+  if (!equipment || !input.sessionGymId || equipment.gymId !== input.sessionGymId) {
+    return emptySetEquipmentSnapshot();
   }
 
-  const selectedLoadKg = round(input.selectedLoadKg);
   const snapshot = {
     version: 1,
     equipmentType: equipment.equipmentType,
@@ -59,9 +53,6 @@ export async function resolveSetEquipmentSnapshot(
   return {
     gymEquipmentId: equipment.id,
     equipmentNameSnapshot: equipment.name,
-    selectedLoadKg,
-    selectedLoadMultiplierSnapshot: null,
-    nominalResistanceKg: null,
     equipmentLoadSnapshot: snapshot,
   };
 }
@@ -70,13 +61,6 @@ export function emptySetEquipmentSnapshot(): SetEquipmentSnapshot {
   return {
     gymEquipmentId: null,
     equipmentNameSnapshot: null,
-    selectedLoadKg: null,
-    selectedLoadMultiplierSnapshot: null,
-    nominalResistanceKg: null,
     equipmentLoadSnapshot: Prisma.JsonNull,
   };
-}
-
-function round(value: number): number {
-  return Math.round(value * 100) / 100;
 }

--- a/lib/sync-hydration.ts
+++ b/lib/sync-hydration.ts
@@ -18,6 +18,7 @@ export async function hydrateFromServerSets(
     localId: `srv_${s.id}`,
     sessionId,
     exerciseId: s.exerciseId,
+    gymEquipmentId: s.gymEquipmentId,
     setNumber: s.setNumber,
     weight: s.weight,
     reps: s.reps,

--- a/lib/sync.test.ts
+++ b/lib/sync.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PendingSet } from '@/lib/indexeddb';
+
+const { mockGetDB } = vi.hoisted(() => ({ mockGetDB: vi.fn() }));
+
+vi.mock('@/lib/indexeddb', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/indexeddb')>();
+  return { ...actual, getDB: mockGetDB };
+});
+
+import { flushPendingSets } from '@/lib/sync';
+
+function pendingSet(): PendingSet {
+  return {
+    localId: 'local-1',
+    sessionId: 'session-1',
+    exerciseId: 'exercise-1',
+    gymEquipmentId: 'stale-equipment',
+    setNumber: 1,
+    weight: 82.5,
+    reps: 7,
+    rir: 2,
+    notes: 'offline set',
+    isWarmup: false,
+    isDropSet: false,
+    createdAt: 1,
+    status: 'pending',
+    serverId: null,
+    syncedAt: null,
+    attempts: 0,
+    lastError: null,
+  };
+}
+
+describe('offline set sync', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(navigator, 'onLine', { configurable: true, value: true });
+  });
+
+  it('retries a 400 once without stale optional equipment and preserves the training set', async () => {
+    const item = pendingSet();
+    const updates: Array<Partial<PendingSet>> = [];
+    const table = {
+      where: vi.fn(() => ({
+        anyOf: vi.fn(() => ({
+          sortBy: vi.fn(async () => [item]),
+          count: vi.fn(async () => (item.status === 'synced' ? 0 : 1)),
+        })),
+      })),
+      update: vi.fn(async (_id: string, patch: Partial<PendingSet>) => {
+        Object.assign(item, patch);
+        updates.push(patch);
+        return 1;
+      }),
+    };
+    mockGetDB.mockReturnValue({ pendingSets: table });
+
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'Equipment is not available for this exercise.' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 'server-set-1' }), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+
+    const result = await flushPendingSets();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const firstBody = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    const retryBody = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body));
+    expect(firstBody).toMatchObject({
+      gymEquipmentId: 'stale-equipment',
+      weight: 82.5,
+      reps: 7,
+      rir: 2,
+    });
+    expect(retryBody).toMatchObject({
+      gymEquipmentId: null,
+      weight: 82.5,
+      reps: 7,
+      rir: 2,
+    });
+    expect(item.status).toBe('synced');
+    expect(item.serverId).toBe('server-set-1');
+    expect(updates.at(-1)).toMatchObject({ status: 'synced', serverId: 'server-set-1' });
+    expect(result).toEqual({ flushed: 1, failed: 0, pending: 0 });
+  });
+});

--- a/lib/sync.ts
+++ b/lib/sync.ts
@@ -50,23 +50,33 @@ async function doFlush(): Promise<FlushResult> {
     await db.pendingSets.update(item.localId, { status: 'syncing' });
 
     try {
-      const res = await fetch(`/api/sessions/${item.sessionId}/sets`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          exerciseId: item.exerciseId,
-          gymEquipmentId: item.gymEquipmentId ?? null,
-          setNumber: item.setNumber,
-          weight: item.weight,
-          reps: item.reps,
-          rir: item.rir,
-          durationSec: item.durationSec ?? null,
-          distanceM: item.distanceM ?? null,
-          notes: item.notes,
-          isWarmup: item.isWarmup,
-          isDropSet: item.isDropSet,
-        }),
-      });
+      const payload = {
+        exerciseId: item.exerciseId,
+        gymEquipmentId: item.gymEquipmentId ?? null,
+        setNumber: item.setNumber,
+        weight: item.weight,
+        reps: item.reps,
+        rir: item.rir,
+        durationSec: item.durationSec ?? null,
+        distanceM: item.distanceM ?? null,
+        notes: item.notes,
+        isWarmup: item.isWarmup,
+        isDropSet: item.isDropSet,
+      };
+      const post = (gymEquipmentId: string | null) =>
+        fetch(`/api/sessions/${item.sessionId}/sets`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ ...payload, gymEquipmentId }),
+        });
+
+      let res = await post(payload.gymEquipmentId);
+      // Equipment is optional metadata. If a server version rejects a stale
+      // reference with 400, retry once without it so the actual queued set is
+      // never stranded by an inventory decoration.
+      if (res.status === 400 && payload.gymEquipmentId) {
+        res = await post(null);
+      }
 
       if (!res.ok) {
         const data = (await res.json().catch(() => null)) as { error?: string } | null;

--- a/lib/sync.ts
+++ b/lib/sync.ts
@@ -55,6 +55,7 @@ async function doFlush(): Promise<FlushResult> {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           exerciseId: item.exerciseId,
+          gymEquipmentId: item.gymEquipmentId ?? null,
           setNumber: item.setNumber,
           weight: item.weight,
           reps: item.reps,
@@ -107,7 +108,10 @@ async function doFlush(): Promise<FlushResult> {
 
 // Helper: adds a set to the queue (status pending) and triggers a flush.
 export async function queueSet(
-  set: Omit<PendingSet, 'createdAt' | 'status' | 'serverId' | 'syncedAt' | 'attempts' | 'lastError'>,
+  set: Omit<
+    PendingSet,
+    'createdAt' | 'status' | 'serverId' | 'syncedAt' | 'attempts' | 'lastError'
+  >,
 ): Promise<PendingSet> {
   const db = getDB();
   const record: PendingSet = {

--- a/messages/en/session.ts
+++ b/messages/en/session.ts
@@ -98,6 +98,8 @@ export const session = {
     quickEntry: 'Quick entry',
     quickEntryExample: 'e.g. 100x8@9 ({unit} x reps @ RPE)',
     quickEntryError: 'Expected format: weight x reps, optionally @ RPE - e.g. 100x8 or 62.5x8@8.5',
+    equipment: 'Machine / equipment',
+    equipmentNone: 'No specific machine',
     load: 'Load ({unit})',
     reps: 'Reps',
     repsInReserve: 'RIR (reps in reserve)',

--- a/messages/ru/session.ts
+++ b/messages/ru/session.ts
@@ -102,6 +102,8 @@ export const session = {
     quickEntryExample: 'например: 100x8@9 ({unit} x повторы @ RPE)',
     quickEntryError:
       'Формат: вес x повторы, при необходимости @ RPE, например 100x8 или 62.5x8@8.5',
+    equipment: 'Тренажёр / оборудование',
+    equipmentNone: 'Без конкретного тренажёра',
     load: 'Вес ({unit})',
     reps: 'Повторы',
     repsInReserve: 'RIR (повторов в запасе)',

--- a/prisma/migrations/20260823063000_add_gym_equipment_inventory/migration.sql
+++ b/prisma/migrations/20260823063000_add_gym_equipment_inventory/migration.sql
@@ -1,7 +1,5 @@
--- Physical gym equipment is additive to the accepted saved-gym model.
--- IF NOT EXISTS keeps this migration compatible with forks that already
--- shipped the same tables under an earlier migration id.
-CREATE TABLE IF NOT EXISTS "GymEquipment" (
+-- CreateTable
+CREATE TABLE "GymEquipment" (
     "id" TEXT NOT NULL,
     "gymId" TEXT NOT NULL,
     "name" TEXT NOT NULL,
@@ -16,37 +14,32 @@ CREATE TABLE IF NOT EXISTS "GymEquipment" (
     "imageMimeType" TEXT,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
+
     CONSTRAINT "GymEquipment_pkey" PRIMARY KEY ("id")
 );
 
-CREATE TABLE IF NOT EXISTS "GymEquipmentExercise" (
+-- CreateTable
+CREATE TABLE "GymEquipmentExercise" (
     "equipmentId" TEXT NOT NULL,
     "exerciseId" TEXT NOT NULL,
+
     CONSTRAINT "GymEquipmentExercise_pkey" PRIMARY KEY ("equipmentId", "exerciseId")
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS "GymEquipment_gymId_name_key"
-    ON "GymEquipment"("gymId", "name");
-CREATE INDEX IF NOT EXISTS "GymEquipment_gymId_equipmentType_idx"
-    ON "GymEquipment"("gymId", "equipmentType");
-CREATE INDEX IF NOT EXISTS "GymEquipmentExercise_exerciseId_idx"
-    ON "GymEquipmentExercise"("exerciseId");
+-- CreateIndex
+CREATE UNIQUE INDEX "GymEquipment_gymId_name_key" ON "GymEquipment"("gymId", "name");
 
-DO $$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'GymEquipment_gymId_fkey') THEN
-    ALTER TABLE "GymEquipment"
-      ADD CONSTRAINT "GymEquipment_gymId_fkey"
-      FOREIGN KEY ("gymId") REFERENCES "Gym"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-  END IF;
-  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'GymEquipmentExercise_equipmentId_fkey') THEN
-    ALTER TABLE "GymEquipmentExercise"
-      ADD CONSTRAINT "GymEquipmentExercise_equipmentId_fkey"
-      FOREIGN KEY ("equipmentId") REFERENCES "GymEquipment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-  END IF;
-  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'GymEquipmentExercise_exerciseId_fkey') THEN
-    ALTER TABLE "GymEquipmentExercise"
-      ADD CONSTRAINT "GymEquipmentExercise_exerciseId_fkey"
-      FOREIGN KEY ("exerciseId") REFERENCES "Exercise"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-  END IF;
-END $$;
+-- CreateIndex
+CREATE INDEX "GymEquipment_gymId_equipmentType_idx" ON "GymEquipment"("gymId", "equipmentType");
+
+-- CreateIndex
+CREATE INDEX "GymEquipmentExercise_exerciseId_idx" ON "GymEquipmentExercise"("exerciseId");
+
+-- AddForeignKey
+ALTER TABLE "GymEquipment" ADD CONSTRAINT "GymEquipment_gymId_fkey" FOREIGN KEY ("gymId") REFERENCES "Gym"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GymEquipmentExercise" ADD CONSTRAINT "GymEquipmentExercise_equipmentId_fkey" FOREIGN KEY ("equipmentId") REFERENCES "GymEquipment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GymEquipmentExercise" ADD CONSTRAINT "GymEquipmentExercise_exerciseId_fkey" FOREIGN KEY ("exerciseId") REFERENCES "Exercise"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260823063000_add_gym_equipment_inventory/migration.sql
+++ b/prisma/migrations/20260823063000_add_gym_equipment_inventory/migration.sql
@@ -1,0 +1,52 @@
+-- Physical gym equipment is additive to the accepted saved-gym model.
+-- IF NOT EXISTS keeps this migration compatible with forks that already
+-- shipped the same tables under an earlier migration id.
+CREATE TABLE IF NOT EXISTS "GymEquipment" (
+    "id" TEXT NOT NULL,
+    "gymId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "equipmentType" "EquipmentType" NOT NULL,
+    "description" TEXT,
+    "manufacturer" TEXT,
+    "modelName" TEXT,
+    "quantity" INTEGER NOT NULL DEFAULT 1,
+    "weightOptions" DOUBLE PRECISION[] NOT NULL DEFAULT ARRAY[]::DOUBLE PRECISION[],
+    "imageUrl" TEXT,
+    "imageData" BYTEA,
+    "imageMimeType" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "GymEquipment_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE IF NOT EXISTS "GymEquipmentExercise" (
+    "equipmentId" TEXT NOT NULL,
+    "exerciseId" TEXT NOT NULL,
+    CONSTRAINT "GymEquipmentExercise_pkey" PRIMARY KEY ("equipmentId", "exerciseId")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "GymEquipment_gymId_name_key"
+    ON "GymEquipment"("gymId", "name");
+CREATE INDEX IF NOT EXISTS "GymEquipment_gymId_equipmentType_idx"
+    ON "GymEquipment"("gymId", "equipmentType");
+CREATE INDEX IF NOT EXISTS "GymEquipmentExercise_exerciseId_idx"
+    ON "GymEquipmentExercise"("exerciseId");
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'GymEquipment_gymId_fkey') THEN
+    ALTER TABLE "GymEquipment"
+      ADD CONSTRAINT "GymEquipment_gymId_fkey"
+      FOREIGN KEY ("gymId") REFERENCES "Gym"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'GymEquipmentExercise_equipmentId_fkey') THEN
+    ALTER TABLE "GymEquipmentExercise"
+      ADD CONSTRAINT "GymEquipmentExercise_equipmentId_fkey"
+      FOREIGN KEY ("equipmentId") REFERENCES "GymEquipment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'GymEquipmentExercise_exerciseId_fkey') THEN
+    ALTER TABLE "GymEquipmentExercise"
+      ADD CONSTRAINT "GymEquipmentExercise_exerciseId_fkey"
+      FOREIGN KEY ("exerciseId") REFERENCES "Exercise"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;

--- a/prisma/migrations/20260823073000_add_set_equipment_history/migration.sql
+++ b/prisma/migrations/20260823073000_add_set_equipment_history/migration.sql
@@ -1,23 +1,11 @@
--- Preserve the concrete equipment used for each set. The columns are additive
--- and guarded so forks that already shipped the same history fields can adopt
--- this migration id without rebuilding user data.
+-- Preserve the concrete equipment used for each set. Equipment is optional:
+-- historical training data remains valid if inventory rows are later deleted.
 ALTER TABLE "Set"
-  ADD COLUMN IF NOT EXISTS "gymEquipmentId" TEXT,
-  ADD COLUMN IF NOT EXISTS "equipmentNameSnapshot" TEXT,
-  ADD COLUMN IF NOT EXISTS "selectedLoadKg" DOUBLE PRECISION,
-  ADD COLUMN IF NOT EXISTS "selectedLoadMultiplierSnapshot" DOUBLE PRECISION,
-  ADD COLUMN IF NOT EXISTS "nominalResistanceKg" DOUBLE PRECISION,
-  ADD COLUMN IF NOT EXISTS "equipmentLoadSnapshot" JSONB;
+  ADD COLUMN "gymEquipmentId" TEXT,
+  ADD COLUMN "equipmentNameSnapshot" TEXT,
+  ADD COLUMN "equipmentLoadSnapshot" JSONB;
 
-CREATE INDEX IF NOT EXISTS "Set_gymEquipmentId_completedAt_idx"
-  ON "Set"("gymEquipmentId", "completedAt");
-
-DO $$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'Set_gymEquipmentId_fkey') THEN
-    ALTER TABLE "Set"
-      ADD CONSTRAINT "Set_gymEquipmentId_fkey"
-      FOREIGN KEY ("gymEquipmentId") REFERENCES "GymEquipment"("id")
-      ON DELETE SET NULL ON UPDATE CASCADE;
-  END IF;
-END $$;
+ALTER TABLE "Set"
+  ADD CONSTRAINT "Set_gymEquipmentId_fkey"
+  FOREIGN KEY ("gymEquipmentId") REFERENCES "GymEquipment"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260823073000_add_set_equipment_history/migration.sql
+++ b/prisma/migrations/20260823073000_add_set_equipment_history/migration.sql
@@ -1,0 +1,23 @@
+-- Preserve the concrete equipment used for each set. The columns are additive
+-- and guarded so forks that already shipped the same history fields can adopt
+-- this migration id without rebuilding user data.
+ALTER TABLE "Set"
+  ADD COLUMN IF NOT EXISTS "gymEquipmentId" TEXT,
+  ADD COLUMN IF NOT EXISTS "equipmentNameSnapshot" TEXT,
+  ADD COLUMN IF NOT EXISTS "selectedLoadKg" DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS "selectedLoadMultiplierSnapshot" DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS "nominalResistanceKg" DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS "equipmentLoadSnapshot" JSONB;
+
+CREATE INDEX IF NOT EXISTS "Set_gymEquipmentId_completedAt_idx"
+  ON "Set"("gymEquipmentId", "completedAt");
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'Set_gymEquipmentId_fkey') THEN
+    ALTER TABLE "Set"
+      ADD CONSTRAINT "Set_gymEquipmentId_fkey"
+      FOREIGN KEY ("gymEquipmentId") REFERENCES "GymEquipment"("id")
+      ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -122,26 +122,27 @@ model Message {
 }
 
 model Exercise {
-  id               String              @id @default(cuid())
-  userId           String
-  user             User                @relation(fields: [userId], references: [id])
-  name             String
-  muscleGroup      MuscleGroup
-  category         ExerciseCategory
-  defaultRestSec   Int                 @default(90)
-  notes            String?
+  id                String                 @id @default(cuid())
+  userId            String
+  user              User                   @relation(fields: [userId], references: [id])
+  name              String
+  muscleGroup       MuscleGroup
+  category          ExerciseCategory
+  defaultRestSec    Int                    @default(90)
+  notes             String?
   // For bodyweight exercises (pull-ups, dips, push-ups...): the effective
   // tonnage includes User.bodyweight. Set.weight remains the added load (0 by
   // default, always >= 0 - the input schemas clamp it; negative loads for
   // assistance machines are deliberately not supported, see issue #118).
-  usesBodyweight   Boolean             @default(false)
+  usesBodyweight    Boolean                @default(false)
   // Determines which saved-gym inventory constrains suggested loads.
-  equipmentType    EquipmentType       @default(OTHER)
-  createdAt        DateTime            @default(now())
-  programExercises ProgramExercise[]
-  sets             Set[]
-  goals            ExerciseGoal[]
-  gymConfigs       GymExerciseConfig[]
+  equipmentType     EquipmentType          @default(OTHER)
+  createdAt         DateTime               @default(now())
+  programExercises  ProgramExercise[]
+  sets              Set[]
+  goals             ExerciseGoal[]
+  gymConfigs        GymExerciseConfig[]
+  gymEquipmentLinks GymEquipmentExercise[]
 
   @@unique([userId, name])
 }
@@ -280,6 +281,7 @@ model Gym {
   activeForUsers  User[]              @relation("ActiveGym")
   sessions        Session[]
   exerciseConfigs GymExerciseConfig[]
+  equipment       GymEquipment[]
 
   @@unique([userId, name])
   @@index([userId, updatedAt])
@@ -297,6 +299,38 @@ model GymExerciseConfig {
   weightOptions Float[]  @default([])
 
   @@unique([gymId, exerciseId])
+  @@index([exerciseId])
+}
+
+model GymEquipment {
+  id            String                 @id @default(cuid())
+  gymId         String
+  gym           Gym                    @relation(fields: [gymId], references: [id], onDelete: Cascade)
+  name          String
+  equipmentType EquipmentType
+  description   String?
+  manufacturer  String?
+  modelName     String?
+  quantity      Int                    @default(1)
+  weightOptions Float[]                @default([])
+  imageUrl      String?
+  imageData     Bytes?
+  imageMimeType String?
+  createdAt     DateTime               @default(now())
+  updatedAt     DateTime               @updatedAt
+  exerciseLinks GymEquipmentExercise[]
+
+  @@unique([gymId, name])
+  @@index([gymId, equipmentType])
+}
+
+model GymEquipmentExercise {
+  equipmentId String
+  equipment   GymEquipment @relation(fields: [equipmentId], references: [id], onDelete: Cascade)
+  exerciseId  String
+  exercise    Exercise     @relation(fields: [exerciseId], references: [id], onDelete: Cascade)
+
+  @@id([equipmentId, exerciseId])
   @@index([exerciseId])
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -344,9 +344,6 @@ model Set {
   gymEquipmentId                 String?
   gymEquipment                   GymEquipment? @relation(fields: [gymEquipmentId], references: [id], onDelete: SetNull)
   equipmentNameSnapshot          String?
-  selectedLoadKg                 Float?
-  selectedLoadMultiplierSnapshot Float?
-  nominalResistanceKg            Float?
   equipmentLoadSnapshot          Json?
   setNumber                      Int
   weight                         Float
@@ -377,7 +374,6 @@ model Set {
   completedAt                    DateTime      @default(now())
 
   @@index([exerciseId, completedAt])
-  @@index([gymEquipmentId, completedAt])
 }
 
 // Per-exercise target goal (issue #90): a concrete "weight x reps" the user

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -319,6 +319,7 @@ model GymEquipment {
   createdAt     DateTime               @default(now())
   updatedAt     DateTime               @updatedAt
   exerciseLinks GymEquipmentExercise[]
+  performedSets Set[]
 
   @@unique([gymId, name])
   @@index([gymId, equipmentType])
@@ -335,40 +336,48 @@ model GymEquipmentExercise {
 }
 
 model Set {
-  id          String   @id @default(cuid())
-  sessionId   String
-  session     Session  @relation(fields: [sessionId], references: [id], onDelete: Cascade)
-  exerciseId  String
-  exercise    Exercise @relation(fields: [exerciseId], references: [id])
-  setNumber   Int
-  weight      Float
-  reps        Int
-  rir         Int?
+  id                             String        @id @default(cuid())
+  sessionId                      String
+  session                        Session       @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+  exerciseId                     String
+  exercise                       Exercise      @relation(fields: [exerciseId], references: [id])
+  gymEquipmentId                 String?
+  gymEquipment                   GymEquipment? @relation(fields: [gymEquipmentId], references: [id], onDelete: SetNull)
+  equipmentNameSnapshot          String?
+  selectedLoadKg                 Float?
+  selectedLoadMultiplierSnapshot Float?
+  nominalResistanceKg            Float?
+  equipmentLoadSnapshot          Json?
+  setNumber                      Int
+  weight                         Float
+  reps                           Int
+  rir                            Int?
   // Cardio sets (issue #133, additive): duration in seconds (>= 1 when set)
   // and optional distance in meters. NULL on strength sets - existing rows
   // are untouched and lifting flows never write these.
-  durationSec Int?
-  distanceM   Float?
+  durationSec                    Int?
+  distanceM                      Float?
   // Average heart rate in bpm (issue #152, additive): the extra signal a TCX
   // file import carries over manual logging. 40..250 when present (enforced
   // by every writer), NULL on strength sets and on cardio logged without it.
-  avgHr       Int?
+  avgHr                          Int?
   // Maximum (peak) heart rate in bpm (issue #203, additive): the companion HR
   // metric watches record, carried in the same TCX exports. 40..250 when
   // present (enforced by every writer), NULL on strength sets and on cardio
   // logged without it.
-  maxHr       Int?
+  maxHr                          Int?
   // Downsampled pace/HR track of an imported cardio activity (issue #254,
   // additive): a JSON array of up to a few hundred points
   // [{ t, d?, hr? }] where t = seconds from the start, d = cumulative meters,
   // hr = bpm. NULL on strength sets and on cardio logged without a track.
-  track       Json?
-  notes       String?
-  isWarmup    Boolean  @default(false)
-  isDropSet   Boolean  @default(false)
-  completedAt DateTime @default(now())
+  track                          Json?
+  notes                          String?
+  isWarmup                       Boolean       @default(false)
+  isDropSet                      Boolean       @default(false)
+  completedAt                    DateTime      @default(now())
 
   @@index([exerciseId, completedAt])
+  @@index([gymEquipmentId, completedAt])
 }
 
 // Per-exercise target goal (issue #90): a concrete "weight x reps" the user

--- a/tests/integration/backup-route.test.ts
+++ b/tests/integration/backup-route.test.ts
@@ -181,9 +181,6 @@ async function seedFullUser(email: string) {
             exerciseId: bench.id,
             gymEquipmentId: equipment.id,
             equipmentNameSnapshot: 'Competition bench station',
-            selectedLoadKg: 100,
-            selectedLoadMultiplierSnapshot: null,
-            nominalResistanceKg: null,
             equipmentLoadSnapshot: {
               version: 1,
               equipmentType: 'BARBELL',
@@ -361,9 +358,6 @@ describe('GET /api/backup - export completeness (issue #168)', () => {
     expect(benchSet).toMatchObject({
       gymEquipmentName: 'Competition bench station',
       equipmentNameSnapshot: 'Competition bench station',
-      selectedLoadKg: 100,
-      selectedLoadMultiplierSnapshot: null,
-      nominalResistanceKg: null,
       equipmentLoadSnapshot: {
         version: 1,
         equipmentType: 'BARBELL',
@@ -426,6 +420,22 @@ describe('POST /api/backup - restore round trip (issue #168)', () => {
     // Ownership-scoped: user A's data is untouched, user B owns a full copy.
     expect(await countsFor(userA.id)).toEqual(countsA);
     expect(await countsFor(userB.id)).toEqual(countsA);
+
+    // JSON null convention is preserved by restore: a set with no equipment
+    // snapshot stores JSON null, not SQL NULL, matching the normal set writer.
+    const [restoredNullState] = await db.$queryRaw<
+      Array<{ isDbNull: boolean; isJsonNull: boolean }>
+    >`
+      SELECT
+        s."equipmentLoadSnapshot" IS NULL AS "isDbNull",
+        s."equipmentLoadSnapshot" = 'null'::jsonb AS "isJsonNull"
+      FROM "Set" s
+      JOIN "Session" sess ON sess."id" = s."sessionId"
+      JOIN "Exercise" e ON e."id" = s."exerciseId"
+      WHERE sess."userId" = ${userB.id} AND e."name" = 'Running'
+      LIMIT 1
+    `;
+    expect(restoredNullState).toEqual({ isDbNull: false, isJsonNull: true });
 
     // The goal was re-linked to user B's own copy of the exercise.
     const goalB = await db.exerciseGoal.findFirst({

--- a/tests/integration/backup-route.test.ts
+++ b/tests/integration/backup-route.test.ts
@@ -10,6 +10,8 @@ import { getCurrentUserId } from '@/lib/auth';
 // Auth is read through getCurrentUserId (via requireApiUserId in @/lib/api).
 vi.mock('@/lib/auth', () => ({ getCurrentUserId: vi.fn() }));
 const mockUserId = vi.mocked(getCurrentUserId);
+const EQUIPMENT_PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const EQUIPMENT_PNG_BASE64 = 'iVBORw0KGgo=';
 
 import { GET as getBackup, POST as postBackup } from '@/app/api/backup/route';
 
@@ -106,6 +108,21 @@ async function seedFullUser(email: string) {
     },
   });
   await db.user.update({ where: { id: user.id }, data: { activeGymId: gym.id } });
+  await db.gymEquipment.create({
+    data: {
+      gymId: gym.id,
+      name: 'Competition bench station',
+      equipmentType: 'BARBELL',
+      description: 'Flat bench with uprights and safety arms.',
+      manufacturer: 'GymCo',
+      modelName: 'Bench Pro',
+      quantity: 2,
+      weightOptions: [20, 40, 60, 80, 100],
+      imageData: EQUIPMENT_PNG,
+      imageMimeType: 'image/png',
+      exerciseLinks: { create: { exerciseId: bench.id } },
+    },
+  });
   const program = await db.program.create({
     data: {
       userId: user.id,
@@ -265,6 +282,10 @@ async function countsFor(userId: string) {
     messages: await db.message.count({ where: { conversation: { userId } } }),
     gyms: await db.gym.count({ where: { userId } }),
     gymConfigs: await db.gymExerciseConfig.count({ where: { gym: { userId } } }),
+    gymEquipment: await db.gymEquipment.count({ where: { gym: { userId } } }),
+    gymEquipmentLinks: await db.gymEquipmentExercise.count({
+      where: { equipment: { gym: { userId } } },
+    }),
   };
 }
 
@@ -273,7 +294,7 @@ beforeEach(() => {
 });
 
 describe('GET /api/backup - export completeness (issue #168)', () => {
-  it('exports version 3 with saved gyms and all earlier backup fields', async () => {
+  it('exports version 4 with physical gym equipment and all earlier backup fields', async () => {
     const user = await seedFullUser('a@test.dev');
     actAs(user.id);
 
@@ -281,7 +302,7 @@ describe('GET /api/backup - export completeness (issue #168)', () => {
     expect(res.status).toBe(200);
     const dump = await res.json();
 
-    expect(dump.version).toBe(3);
+    expect(dump.version).toBe(4);
     expect(dump.profile).toMatchObject({
       displayName: 'Julien',
       bodyweight: 82.5,
@@ -303,6 +324,21 @@ describe('GET /api/backup - export completeness (issue #168)', () => {
         dumbbellWeights: [10, 12, 14, 16, 19],
         plateWeights: [1.25, 2.5, 5, 10, 20],
         barWeights: [20],
+        equipment: [
+          {
+            name: 'Competition bench station',
+            equipmentType: 'BARBELL',
+            description: 'Flat bench with uprights and safety arms.',
+            manufacturer: 'GymCo',
+            modelName: 'Bench Pro',
+            quantity: 2,
+            weightOptions: [20, 40, 60, 80, 100],
+            imageUrl: null,
+            imageMimeType: 'image/png',
+            imageBase64: EQUIPMENT_PNG_BASE64,
+            exerciseNames: ['Bench Press'],
+          },
+        ],
         exerciseConfigs: [{ exerciseName: 'Running', isAvailable: false, weightOptions: [] }],
       },
     ]);

--- a/tests/integration/backup-route.test.ts
+++ b/tests/integration/backup-route.test.ts
@@ -108,7 +108,7 @@ async function seedFullUser(email: string) {
     },
   });
   await db.user.update({ where: { id: user.id }, data: { activeGymId: gym.id } });
-  await db.gymEquipment.create({
+  const equipment = await db.gymEquipment.create({
     data: {
       gymId: gym.id,
       name: 'Competition bench station',
@@ -179,6 +179,18 @@ async function seedFullUser(email: string) {
         create: [
           {
             exerciseId: bench.id,
+            gymEquipmentId: equipment.id,
+            equipmentNameSnapshot: 'Competition bench station',
+            selectedLoadKg: 100,
+            selectedLoadMultiplierSnapshot: null,
+            nominalResistanceKg: null,
+            equipmentLoadSnapshot: {
+              version: 1,
+              equipmentType: 'BARBELL',
+              manufacturer: 'GymCo',
+              modelName: 'Bench Pro',
+              weightOptions: [20, 40, 60, 80, 100],
+            },
             setNumber: 1,
             weight: 100,
             reps: 5,
@@ -294,7 +306,7 @@ beforeEach(() => {
 });
 
 describe('GET /api/backup - export completeness (issue #168)', () => {
-  it('exports version 4 with physical gym equipment and all earlier backup fields', async () => {
+  it('exports version 5 with set equipment history and all earlier backup fields', async () => {
     const user = await seedFullUser('a@test.dev');
     actAs(user.id);
 
@@ -302,7 +314,7 @@ describe('GET /api/backup - export completeness (issue #168)', () => {
     expect(res.status).toBe(200);
     const dump = await res.json();
 
-    expect(dump.version).toBe(4);
+    expect(dump.version).toBe(5);
     expect(dump.profile).toMatchObject({
       displayName: 'Julien',
       bodyweight: 82.5,
@@ -345,6 +357,21 @@ describe('GET /api/backup - export completeness (issue #168)', () => {
     expect(dump.sessions[0].gymName).toBe('Basement');
 
     const sets = dump.sessions[0].sets as Array<Record<string, unknown>>;
+    const benchSet = sets.find((s) => s.exerciseName === 'Bench Press');
+    expect(benchSet).toMatchObject({
+      gymEquipmentName: 'Competition bench station',
+      equipmentNameSnapshot: 'Competition bench station',
+      selectedLoadKg: 100,
+      selectedLoadMultiplierSnapshot: null,
+      nominalResistanceKg: null,
+      equipmentLoadSnapshot: {
+        version: 1,
+        equipmentType: 'BARBELL',
+        manufacturer: 'GymCo',
+        modelName: 'Bench Pro',
+        weightOptions: [20, 40, 60, 80, 100],
+      },
+    });
     const cardio = sets.find((s) => s.exerciseName === 'Running');
     expect(cardio).toMatchObject({ durationSec: 1800, distanceM: 5000, avgHr: 152, maxHr: 181 });
 

--- a/tests/integration/gym-equipment-api.test.ts
+++ b/tests/integration/gym-equipment-api.test.ts
@@ -206,7 +206,8 @@ describe('gym equipment REST API', () => {
 
     const foreignSetImageResponse = await setImage(
       request(`http://test.local/api/gym-equipment/${privateEquipment.id}/image`, 'PUT', {
-        clear: true,
+        imageBase64: PNG.toString('base64'),
+        mimeType: 'image/png',
       }),
       params(privateEquipment.id),
     );

--- a/tests/integration/gym-equipment-api.test.ts
+++ b/tests/integration/gym-equipment-api.test.ts
@@ -1,0 +1,176 @@
+import { Buffer } from 'node:buffer';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { db } from '@/lib/db';
+import { getCurrentUserId } from '@/lib/auth';
+
+vi.mock('@/lib/auth', () => ({ getCurrentUserId: vi.fn() }));
+const mockUserId = vi.mocked(getCurrentUserId);
+
+import { GET as listEquipment, POST as createEquipment } from '@/app/api/gyms/[id]/equipment/route';
+import { DELETE as deleteEquipment, PUT as updateEquipment } from '@/app/api/gym-equipment/[id]/route';
+import {
+  DELETE as deleteImage,
+  GET as getImage,
+  PUT as setImage,
+} from '@/app/api/gym-equipment/[id]/image/route';
+
+const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+function request(url: string, method = 'GET', body?: unknown): Request {
+  return new Request(url, {
+    method,
+    headers: body === undefined ? undefined : { 'Content-Type': 'application/json' },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+function params(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+async function seedUser(label: string) {
+  const user = await db.user.create({
+    data: { email: `equipment-${label}-${Date.now()}@test.dev`, passwordHash: 'unused' },
+  });
+  const gym = await db.gym.create({ data: { userId: user.id, name: `${label} gym` } });
+  return { user, gym };
+}
+
+beforeEach(() => mockUserId.mockReset());
+
+describe('gym equipment REST API', () => {
+  it('manages a physical station, exercise links, compatibility config, and image', async () => {
+    const { user, gym } = await seedUser('owner');
+    const exercise = await db.exercise.create({
+      data: {
+        userId: user.id,
+        name: 'Cable row',
+        muscleGroup: 'BACK_THICKNESS',
+        category: 'COMPOUND',
+        equipmentType: 'CABLE',
+      },
+    });
+    mockUserId.mockResolvedValue(user.id);
+
+    const createdResponse = await createEquipment(
+      request(`http://test.local/api/gyms/${gym.id}/equipment`, 'POST', {
+        name: 'Dual cable station',
+        equipmentType: 'CABLE',
+        description: 'Two adjustable pulleys',
+        manufacturer: 'GymCo',
+        modelName: 'DC-2',
+        quantity: 2,
+        weightOptions: [20, 10, 20],
+        exerciseIds: [exercise.id],
+      }),
+      params(gym.id),
+    );
+    expect(createdResponse.status).toBe(201);
+    const created = await createdResponse.json();
+    const equipmentId = created.equipment.id as string;
+    expect(created.equipment).toMatchObject({
+      name: 'Dual cable station',
+      equipmentType: 'CABLE',
+      quantity: 2,
+      weightOptions: [10, 20],
+    });
+
+    const link = await db.gymEquipmentExercise.findUnique({
+      where: { equipmentId_exerciseId: { equipmentId, exerciseId: exercise.id } },
+    });
+    expect(link).not.toBeNull();
+    const compatibility = await db.gymExerciseConfig.findUnique({
+      where: { gymId_exerciseId: { gymId: gym.id, exerciseId: exercise.id } },
+    });
+    expect(compatibility).toMatchObject({ isAvailable: true, weightOptions: [10, 20] });
+
+    const listedResponse = await listEquipment(
+      request(`http://test.local/api/gyms/${gym.id}/equipment`),
+      params(gym.id),
+    );
+    expect(listedResponse.status).toBe(200);
+    const listed = await listedResponse.json();
+    expect(listed.equipment).toHaveLength(1);
+    expect(listed.equipment[0].exerciseLinks).toEqual([
+      expect.objectContaining({ id: exercise.id, name: 'Cable row' }),
+    ]);
+
+    const updatedResponse = await updateEquipment(
+      request(`http://test.local/api/gym-equipment/${equipmentId}`, 'PUT', {
+        name: 'Cable station A',
+        equipmentType: 'CABLE',
+        quantity: 1,
+        weightOptions: [5, 10, 15, 20],
+        exerciseIds: [exercise.id],
+      }),
+      params(equipmentId),
+    );
+    expect(updatedResponse.status).toBe(200);
+    expect((await updatedResponse.json()).equipment.name).toBe('Cable station A');
+
+    const imageResponse = await setImage(
+      request(`http://test.local/api/gym-equipment/${equipmentId}/image`, 'PUT', {
+        imageBase64: PNG.toString('base64'),
+        mimeType: 'image/png',
+      }),
+      params(equipmentId),
+    );
+    expect(imageResponse.status).toBe(200);
+    const fetchedImage = await getImage(
+      request(`http://test.local/api/gym-equipment/${equipmentId}/image`),
+      params(equipmentId),
+    );
+    expect(fetchedImage.status).toBe(200);
+    expect(fetchedImage.headers.get('content-type')).toBe('image/png');
+    expect(Buffer.from(await fetchedImage.arrayBuffer())).toEqual(PNG);
+
+    const clearResponse = await deleteImage(
+      request(`http://test.local/api/gym-equipment/${equipmentId}/image`, 'DELETE'),
+      params(equipmentId),
+    );
+    expect(clearResponse.status).toBe(200);
+    expect(
+      await db.gymEquipment.findUnique({ where: { id: equipmentId }, select: { imageData: true } }),
+    ).toEqual({ imageData: null });
+
+    const deletedResponse = await deleteEquipment(
+      request(`http://test.local/api/gym-equipment/${equipmentId}`, 'DELETE'),
+      params(equipmentId),
+    );
+    expect(deletedResponse.status).toBe(200);
+    expect(await db.gymEquipment.count({ where: { id: equipmentId } })).toBe(0);
+  });
+
+  it('does not expose another user gym or accept another user exercise link', async () => {
+    const owner = await seedUser('private-owner');
+    const other = await seedUser('other');
+    const otherExercise = await db.exercise.create({
+      data: {
+        userId: other.user.id,
+        name: 'Other machine exercise',
+        muscleGroup: 'QUADS',
+        category: 'COMPOUND',
+        equipmentType: 'MACHINE',
+      },
+    });
+
+    mockUserId.mockResolvedValue(owner.user.id);
+    const foreignLinkResponse = await createEquipment(
+      request(`http://test.local/api/gyms/${owner.gym.id}/equipment`, 'POST', {
+        name: 'Private station',
+        equipmentType: 'MACHINE',
+        exerciseIds: [otherExercise.id],
+      }),
+      params(owner.gym.id),
+    );
+    expect(foreignLinkResponse.status).toBe(400);
+    expect(await db.gymEquipment.count({ where: { gymId: owner.gym.id } })).toBe(0);
+
+    mockUserId.mockResolvedValue(other.user.id);
+    const foreignGymResponse = await listEquipment(
+      request(`http://test.local/api/gyms/${owner.gym.id}/equipment`),
+      params(owner.gym.id),
+    );
+    expect(foreignGymResponse.status).toBe(404);
+  });
+});

--- a/tests/integration/gym-equipment-api.test.ts
+++ b/tests/integration/gym-equipment-api.test.ts
@@ -166,11 +166,61 @@ describe('gym equipment REST API', () => {
     expect(foreignLinkResponse.status).toBe(400);
     expect(await db.gymEquipment.count({ where: { gymId: owner.gym.id } })).toBe(0);
 
+    const privateEquipment = await db.gymEquipment.create({
+      data: {
+        gymId: owner.gym.id,
+        name: 'Owner-only station',
+        equipmentType: 'MACHINE',
+        imageData: PNG,
+        imageMimeType: 'image/png',
+      },
+    });
+
     mockUserId.mockResolvedValue(other.user.id);
     const foreignGymResponse = await listEquipment(
       request(`http://test.local/api/gyms/${owner.gym.id}/equipment`),
       params(owner.gym.id),
     );
     expect(foreignGymResponse.status).toBe(404);
+
+    const foreignUpdateResponse = await updateEquipment(
+      request(`http://test.local/api/gym-equipment/${privateEquipment.id}`, 'PUT', {
+        name: 'Hacked station',
+        equipmentType: 'MACHINE',
+      }),
+      params(privateEquipment.id),
+    );
+    expect(foreignUpdateResponse.status).toBe(404);
+
+    const foreignDeleteResponse = await deleteEquipment(
+      request(`http://test.local/api/gym-equipment/${privateEquipment.id}`, 'DELETE'),
+      params(privateEquipment.id),
+    );
+    expect(foreignDeleteResponse.status).toBe(404);
+
+    const foreignGetImageResponse = await getImage(
+      request(`http://test.local/api/gym-equipment/${privateEquipment.id}/image`),
+      params(privateEquipment.id),
+    );
+    expect(foreignGetImageResponse.status).toBe(404);
+
+    const foreignSetImageResponse = await setImage(
+      request(`http://test.local/api/gym-equipment/${privateEquipment.id}/image`, 'PUT', {
+        clear: true,
+      }),
+      params(privateEquipment.id),
+    );
+    expect(foreignSetImageResponse.status).toBe(404);
+
+    const foreignDeleteImageResponse = await deleteImage(
+      request(`http://test.local/api/gym-equipment/${privateEquipment.id}/image`, 'DELETE'),
+      params(privateEquipment.id),
+    );
+    expect(foreignDeleteImageResponse.status).toBe(404);
+
+    const preserved = await db.gymEquipment.findUnique({ where: { id: privateEquipment.id } });
+    expect(preserved?.name).toBe('Owner-only station');
+    expect(preserved?.imageMimeType).toBe('image/png');
+    expect(preserved?.imageData?.byteLength).toBe(PNG.byteLength);
   });
 });

--- a/tests/integration/gym-equipment-api.test.ts
+++ b/tests/integration/gym-equipment-api.test.ts
@@ -181,6 +181,28 @@ describe('gym equipment REST API', () => {
     expect(await response.json()).toEqual({ error: 'Invalid gym id.' });
   });
 
+  it('rejects invalid equipment route ids before ownership operations', async () => {
+    const { user } = await seedUser('invalid-equipment-route-id');
+    mockUserId.mockResolvedValue(user.id);
+
+    const updateResponse = await updateEquipment(
+      request('http://test.local/api/gym-equipment/%20', 'PUT', {
+        name: 'Ignored station',
+        equipmentType: 'MACHINE',
+      }),
+      params('   '),
+    );
+    expect(updateResponse.status).toBe(400);
+    expect(await updateResponse.json()).toEqual({ error: 'Invalid equipment id.' });
+
+    const deleteResponse = await deleteEquipment(
+      request('http://test.local/api/gym-equipment/%20', 'DELETE'),
+      params('   '),
+    );
+    expect(deleteResponse.status).toBe(400);
+    expect(await deleteResponse.json()).toEqual({ error: 'Invalid equipment id.' });
+  });
+
   it('enforces the per-gym equipment cap atomically across concurrent creates', async () => {
     const { user, gym } = await seedUser('capacity-race');
     mockUserId.mockResolvedValue(user.id);

--- a/tests/integration/gym-equipment-api.test.ts
+++ b/tests/integration/gym-equipment-api.test.ts
@@ -7,7 +7,10 @@ vi.mock('@/lib/auth', () => ({ getCurrentUserId: vi.fn() }));
 const mockUserId = vi.mocked(getCurrentUserId);
 
 import { GET as listEquipment, POST as createEquipment } from '@/app/api/gyms/[id]/equipment/route';
-import { DELETE as deleteEquipment, PUT as updateEquipment } from '@/app/api/gym-equipment/[id]/route';
+import {
+  DELETE as deleteEquipment,
+  PUT as updateEquipment,
+} from '@/app/api/gym-equipment/[id]/route';
 import {
   DELETE as deleteImage,
   GET as getImage,
@@ -108,6 +111,22 @@ describe('gym equipment REST API', () => {
     expect(updatedResponse.status).toBe(200);
     expect((await updatedResponse.json()).equipment.name).toBe('Cable station A');
 
+    const renamedViaCollection = await createEquipment(
+      request('http://test.local/api/gyms/' + gym.id + '/equipment', 'POST', {
+        equipmentId,
+        name: 'Cable station renamed',
+        equipmentType: 'CABLE',
+        quantity: 1,
+        weightOptions: [5, 10, 15, 20],
+        exerciseIds: [exercise.id],
+      }),
+      params(gym.id),
+    );
+    expect(renamedViaCollection.status).toBe(200);
+    const renamed = await renamedViaCollection.json();
+    expect(renamed.equipment).toMatchObject({ id: equipmentId, name: 'Cable station renamed' });
+    expect(await db.gymEquipment.count({ where: { gymId: gym.id } })).toBe(1);
+
     const imageResponse = await setImage(
       request(`http://test.local/api/gym-equipment/${equipmentId}/image`, 'PUT', {
         imageBase64: PNG.toString('base64'),
@@ -123,6 +142,14 @@ describe('gym equipment REST API', () => {
     expect(fetchedImage.status).toBe(200);
     expect(fetchedImage.headers.get('content-type')).toBe('image/png');
     expect(Buffer.from(await fetchedImage.arrayBuffer())).toEqual(PNG);
+
+    const listedWithImage = await listEquipment(
+      request('http://attacker.invalid/api/gyms/' + gym.id + '/equipment'),
+      params(gym.id),
+    );
+    const listedImage = (await listedWithImage.json()).equipment[0].image;
+    expect(listedImage.url.startsWith(`/api/gym-equipment/${equipmentId}/image?v=`)).toBe(true);
+    expect(listedImage.url).not.toContain('attacker.invalid');
 
     const clearResponse = await deleteImage(
       request(`http://test.local/api/gym-equipment/${equipmentId}/image`, 'DELETE'),

--- a/tests/integration/gym-equipment-api.test.ts
+++ b/tests/integration/gym-equipment-api.test.ts
@@ -168,6 +168,45 @@ describe('gym equipment REST API', () => {
     expect(await db.gymEquipment.count({ where: { id: equipmentId } })).toBe(0);
   });
 
+  it('rejects an invalid gym route id before the domain query', async () => {
+    const { user } = await seedUser('invalid-route-id');
+    mockUserId.mockResolvedValue(user.id);
+
+    const response = await listEquipment(
+      request('http://test.local/api/gyms/%20/equipment'),
+      params('   '),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'Invalid gym id.' });
+  });
+
+  it('enforces the per-gym equipment cap atomically across concurrent creates', async () => {
+    const { user, gym } = await seedUser('capacity-race');
+    mockUserId.mockResolvedValue(user.id);
+
+    await db.gymEquipment.createMany({
+      data: Array.from({ length: 999 }, (_, index) => ({
+        gymId: gym.id,
+        name: `Existing station ${index}`,
+        equipmentType: 'MACHINE' as const,
+      })),
+    });
+
+    const create = (name: string) =>
+      createEquipment(
+        request(`http://test.local/api/gyms/${gym.id}/equipment`, 'POST', {
+          name,
+          equipmentType: 'MACHINE',
+        }),
+        params(gym.id),
+      );
+
+    const responses = await Promise.all([create('Race station A'), create('Race station B')]);
+    expect(responses.map((response) => response.status).sort()).toEqual([201, 400]);
+    expect(await db.gymEquipment.count({ where: { gymId: gym.id } })).toBe(1000);
+  });
+
   it('does not expose another user gym or accept another user exercise link', async () => {
     const owner = await seedUser('private-owner');
     const other = await seedUser('other');

--- a/tests/integration/gym-equipment-review-regressions.test.ts
+++ b/tests/integration/gym-equipment-review-regressions.test.ts
@@ -1,0 +1,169 @@
+import { Buffer } from 'node:buffer';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { db } from '@/lib/db';
+import { getCurrentUserId } from '@/lib/auth';
+import { MAX_GYM_EQUIPMENT_PER_GYM } from '@/lib/gym-equipment';
+
+vi.mock('@/lib/auth', () => ({ getCurrentUserId: vi.fn() }));
+const mockUserId = vi.mocked(getCurrentUserId);
+
+import { POST as restoreBackup } from '@/app/api/backup/route';
+import { POST as upsertEquipment } from '@/app/api/gyms/[id]/equipment/route';
+
+let seed = 0;
+
+function request(url: string, method: string, body: unknown): Request {
+  return new Request(url, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function params(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+async function seedUser(label: string) {
+  seed += 1;
+  const user = await db.user.create({
+    data: {
+      email: `equipment-review-${label}-${Date.now()}-${seed}@test.dev`,
+      passwordHash: 'unused',
+    },
+  });
+  const gym = await db.gym.create({ data: { userId: user.id, name: `${label} gym ${seed}` } });
+  return { user, gym };
+}
+
+beforeEach(() => mockUserId.mockReset());
+
+describe('gym equipment maintainer-review regressions', () => {
+  it('returns 200 for a name-matched update and preserves omitted mutable fields', async () => {
+    const { user, gym } = await seedUser('preserve');
+    const exercise = await db.exercise.create({
+      data: {
+        userId: user.id,
+        name: `Cable row ${seed}`,
+        muscleGroup: 'BACK_THICKNESS',
+        category: 'COMPOUND',
+        equipmentType: 'CABLE',
+      },
+    });
+    const existing = await db.gymEquipment.create({
+      data: {
+        gymId: gym.id,
+        name: 'Cable station',
+        equipmentType: 'CABLE',
+        quantity: 3,
+        weightOptions: [10, 20],
+        exerciseLinks: { create: { exerciseId: exercise.id } },
+      },
+    });
+    mockUserId.mockResolvedValue(user.id);
+
+    const response = await upsertEquipment(
+      request(`http://test.local/api/gyms/${gym.id}/equipment`, 'POST', {
+        name: 'CABLE STATION',
+        equipmentType: 'CABLE',
+      }),
+      params(gym.id),
+    );
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).created).toBe(false);
+    const saved = await db.gymEquipment.findUnique({
+      where: { id: existing.id },
+      include: { exerciseLinks: true },
+    });
+    expect(saved).toMatchObject({ quantity: 3, weightOptions: [10, 20] });
+    expect(saved?.exerciseLinks.map((link) => link.exerciseId)).toEqual([exercise.id]);
+  });
+
+  it('enforces the per-gym REST creation cap without blocking updates', async () => {
+    const { user, gym } = await seedUser('cap');
+    await db.gymEquipment.createMany({
+      data: Array.from({ length: MAX_GYM_EQUIPMENT_PER_GYM }, (_, index) => ({
+        gymId: gym.id,
+        name: `Station ${index}`,
+        equipmentType: 'MACHINE' as const,
+      })),
+    });
+    mockUserId.mockResolvedValue(user.id);
+
+    const updateResponse = await upsertEquipment(
+      request(`http://test.local/api/gyms/${gym.id}/equipment`, 'POST', {
+        name: 'Station 0',
+        equipmentType: 'MACHINE',
+        description: 'Still editable at the cap',
+      }),
+      params(gym.id),
+    );
+    expect(updateResponse.status).toBe(200);
+
+    const createResponse = await upsertEquipment(
+      request(`http://test.local/api/gyms/${gym.id}/equipment`, 'POST', {
+        name: 'One station too many',
+        equipmentType: 'MACHINE',
+      }),
+      params(gym.id),
+    );
+    expect(createResponse.status).toBe(400);
+    expect(await db.gymEquipment.count({ where: { gymId: gym.id } })).toBe(
+      MAX_GYM_EQUIPMENT_PER_GYM,
+    );
+  });
+
+  it('rejects malformed backup equipment images before replacing existing data', async () => {
+    const { user } = await seedUser('preflight');
+    const existingExercise = await db.exercise.create({
+      data: {
+        userId: user.id,
+        name: `Keep me ${seed}`,
+        muscleGroup: 'CHEST',
+        category: 'COMPOUND',
+      },
+    });
+    mockUserId.mockResolvedValue(user.id);
+
+    const response = await restoreBackup(
+      request('http://test.local/api/backup', 'POST', {
+        confirmReplace: true,
+        payload: {
+          version: 4,
+          exercises: [],
+          programs: [],
+          sessions: [],
+          gyms: [
+            {
+              name: 'Imported gym',
+              dumbbellWeights: [],
+              plateWeights: [],
+              barWeights: [],
+              exerciseConfigs: [],
+              equipment: [
+                {
+                  name: 'Tampered station',
+                  equipmentType: 'MACHINE',
+                  description: null,
+                  manufacturer: null,
+                  modelName: null,
+                  quantity: 1,
+                  weightOptions: [],
+                  imageUrl: null,
+                  imageMimeType: 'image/png',
+                  imageBase64: Buffer.from('not a png').toString('base64'),
+                  exerciseNames: [],
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await db.exercise.findUnique({ where: { id: existingExercise.id } })).not.toBeNull();
+    expect(await db.exercise.count({ where: { userId: user.id } })).toBe(1);
+  });
+});

--- a/tests/integration/route-ownership-coverage.test.ts
+++ b/tests/integration/route-ownership-coverage.test.ts
@@ -17,6 +17,9 @@ const COVERED_ELSEWHERE: Record<string, string> = {
   'app/api/bodyweight/[id]/route.ts': 'tests/integration/bodyweight-route.test.ts',
   'app/api/goals/[id]/route.ts': 'tests/integration/goals-route.test.ts',
   'app/api/measurements/[id]/route.ts': 'tests/integration/measurements-route.test.ts',
+  'app/api/gym-equipment/[id]/route.ts': 'tests/integration/gym-equipment-api.test.ts',
+  'app/api/gym-equipment/[id]/image/route.ts': 'tests/integration/gym-equipment-api.test.ts',
+  'app/api/gyms/[id]/equipment/route.ts': 'tests/integration/gym-equipment-api.test.ts',
   'app/api/progress-photos/[id]/route.ts': 'tests/integration/progress-photos-route.test.ts',
   'app/api/progress-photos/[id]/image/route.ts': 'tests/integration/progress-photos-route.test.ts',
 };

--- a/tests/integration/set-equipment-history.test.ts
+++ b/tests/integration/set-equipment-history.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { db } from '@/lib/db';
+import { getCurrentUserId } from '@/lib/auth';
+
+vi.mock('@/lib/auth', () => ({ getCurrentUserId: vi.fn() }));
+const mockUserId = vi.mocked(getCurrentUserId);
+
+import { POST as createSet } from '@/app/api/sessions/[id]/sets/route';
+
+function request(sessionId: string, body: unknown): Request {
+  return new Request(`http://test.local/api/sessions/${sessionId}/sets`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function params(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+async function seed() {
+  const user = await db.user.create({
+    data: { email: `set-equipment-${Date.now()}@test.dev`, passwordHash: 'unused' },
+  });
+  const exercise = await db.exercise.create({
+    data: {
+      userId: user.id,
+      name: 'Equipment history row',
+      muscleGroup: 'BACK_THICKNESS',
+      category: 'COMPOUND',
+      equipmentType: 'CABLE',
+    },
+  });
+  const gym = await db.gym.create({ data: { userId: user.id, name: 'Frozen gym' } });
+  const otherGym = await db.gym.create({ data: { userId: user.id, name: 'Other gym' } });
+  const equipment = await db.gymEquipment.create({
+    data: {
+      gymId: gym.id,
+      name: 'Cable station original',
+      equipmentType: 'CABLE',
+      manufacturer: 'GymCo',
+      modelName: 'Cable-1',
+      weightOptions: [10, 20, 30],
+      exerciseLinks: { create: { exerciseId: exercise.id } },
+    },
+  });
+  const wrongGymEquipment = await db.gymEquipment.create({
+    data: {
+      gymId: otherGym.id,
+      name: 'Cable station other gym',
+      equipmentType: 'CABLE',
+      weightOptions: [10, 20, 30],
+      exerciseLinks: { create: { exerciseId: exercise.id } },
+    },
+  });
+  const unlinked = await db.gymEquipment.create({
+    data: {
+      gymId: gym.id,
+      name: 'Unlinked cable',
+      equipmentType: 'CABLE',
+      weightOptions: [5, 10],
+    },
+  });
+  const session = await db.session.create({
+    data: { userId: user.id, gymId: gym.id },
+  });
+  return { user, exercise, gym, equipment, wrongGymEquipment, unlinked, session };
+}
+
+beforeEach(() => mockUserId.mockReset());
+
+describe('set equipment history', () => {
+  it('freezes equipment facts on the set and keeps them after rename and deletion', async () => {
+    const { user, exercise, equipment, session } = await seed();
+    mockUserId.mockResolvedValue(user.id);
+
+    const response = await createSet(
+      request(session.id, {
+        exerciseId: exercise.id,
+        gymEquipmentId: equipment.id,
+        setNumber: 1,
+        weight: 20,
+        reps: 10,
+        rir: 2,
+      }),
+      params(session.id),
+    );
+    expect(response.status).toBe(201);
+    const created = await response.json();
+    expect(created).toMatchObject({
+      gymEquipmentId: equipment.id,
+      equipmentNameSnapshot: 'Cable station original',
+      selectedLoadKg: 20,
+      selectedLoadMultiplierSnapshot: null,
+      nominalResistanceKg: null,
+      equipmentLoadSnapshot: {
+        version: 1,
+        equipmentType: 'CABLE',
+        manufacturer: 'GymCo',
+        modelName: 'Cable-1',
+        weightOptions: [10, 20, 30],
+      },
+    });
+
+    await db.gymEquipment.update({ where: { id: equipment.id }, data: { name: 'Renamed station' } });
+    const afterRename = await db.set.findUniqueOrThrow({ where: { id: created.id } });
+    expect(afterRename.gymEquipmentId).toBe(equipment.id);
+    expect(afterRename.equipmentNameSnapshot).toBe('Cable station original');
+
+    await db.gymEquipment.delete({ where: { id: equipment.id } });
+    const afterDelete = await db.set.findUniqueOrThrow({ where: { id: created.id } });
+    expect(afterDelete.gymEquipmentId).toBeNull();
+    expect(afterDelete.equipmentNameSnapshot).toBe('Cable station original');
+    expect(afterDelete.selectedLoadKg).toBe(20);
+    expect(afterDelete.equipmentLoadSnapshot).toMatchObject({
+      version: 1,
+      equipmentType: 'CABLE',
+      manufacturer: 'GymCo',
+      modelName: 'Cable-1',
+    });
+  });
+
+  it('rejects equipment outside the frozen session gym or not linked to the exercise', async () => {
+    const { user, exercise, wrongGymEquipment, unlinked, session } = await seed();
+    mockUserId.mockResolvedValue(user.id);
+
+    const wrongGym = await createSet(
+      request(session.id, {
+        exerciseId: exercise.id,
+        gymEquipmentId: wrongGymEquipment.id,
+        setNumber: 1,
+        weight: 20,
+        reps: 10,
+      }),
+      params(session.id),
+    );
+    expect(wrongGym.status).toBe(400);
+    expect(await wrongGym.json()).toEqual({
+      error: 'Equipment must belong to the gym frozen on this session.',
+    });
+
+    const notLinked = await createSet(
+      request(session.id, {
+        exerciseId: exercise.id,
+        gymEquipmentId: unlinked.id,
+        setNumber: 1,
+        weight: 10,
+        reps: 10,
+      }),
+      params(session.id),
+    );
+    expect(notLinked.status).toBe(400);
+    expect(await notLinked.json()).toEqual({ error: 'Equipment is not available for this exercise.' });
+
+    expect(await db.set.count({ where: { sessionId: session.id } })).toBe(0);
+  });
+});

--- a/tests/integration/set-equipment-history.test.ts
+++ b/tests/integration/set-equipment-history.test.ts
@@ -91,9 +91,6 @@ describe('set equipment history', () => {
     expect(created).toMatchObject({
       gymEquipmentId: equipment.id,
       equipmentNameSnapshot: 'Cable station original',
-      selectedLoadKg: 20,
-      selectedLoadMultiplierSnapshot: null,
-      nominalResistanceKg: null,
       equipmentLoadSnapshot: {
         version: 1,
         equipmentType: 'CABLE',
@@ -103,7 +100,10 @@ describe('set equipment history', () => {
       },
     });
 
-    await db.gymEquipment.update({ where: { id: equipment.id }, data: { name: 'Renamed station' } });
+    await db.gymEquipment.update({
+      where: { id: equipment.id },
+      data: { name: 'Renamed station' },
+    });
     const afterRename = await db.set.findUniqueOrThrow({ where: { id: created.id } });
     expect(afterRename.gymEquipmentId).toBe(equipment.id);
     expect(afterRename.equipmentNameSnapshot).toBe('Cable station original');
@@ -112,7 +112,6 @@ describe('set equipment history', () => {
     const afterDelete = await db.set.findUniqueOrThrow({ where: { id: created.id } });
     expect(afterDelete.gymEquipmentId).toBeNull();
     expect(afterDelete.equipmentNameSnapshot).toBe('Cable station original');
-    expect(afterDelete.selectedLoadKg).toBe(20);
     expect(afterDelete.equipmentLoadSnapshot).toMatchObject({
       version: 1,
       equipmentType: 'CABLE',
@@ -121,8 +120,8 @@ describe('set equipment history', () => {
     });
   });
 
-  it('rejects equipment outside the frozen session gym or not linked to the exercise', async () => {
-    const { user, exercise, wrongGymEquipment, unlinked, session } = await seed();
+  it('drops stale optional equipment references and still records the training sets', async () => {
+    const { user, exercise, equipment, wrongGymEquipment, unlinked, session } = await seed();
     mockUserId.mockResolvedValue(user.id);
 
     const wrongGym = await createSet(
@@ -135,24 +134,62 @@ describe('set equipment history', () => {
       }),
       params(session.id),
     );
-    expect(wrongGym.status).toBe(400);
-    expect(await wrongGym.json()).toEqual({
-      error: 'Equipment must belong to the gym frozen on this session.',
+    expect(wrongGym.status).toBe(201);
+    const wrongGymSet = await wrongGym.json();
+    expect(wrongGymSet).toMatchObject({
+      gymEquipmentId: null,
+      equipmentNameSnapshot: null,
+      weight: 20,
+      reps: 10,
     });
+    const [nullState] = await db.$queryRaw<Array<{ isDbNull: boolean; isJsonNull: boolean }>>`
+      SELECT
+        "equipmentLoadSnapshot" IS NULL AS "isDbNull",
+        "equipmentLoadSnapshot" = 'null'::jsonb AS "isJsonNull"
+      FROM "Set"
+      WHERE "id" = ${wrongGymSet.id}
+    `;
+    expect(nullState).toEqual({ isDbNull: false, isJsonNull: true });
 
     const notLinked = await createSet(
       request(session.id, {
         exerciseId: exercise.id,
         gymEquipmentId: unlinked.id,
-        setNumber: 1,
+        setNumber: 2,
         weight: 10,
         reps: 10,
       }),
       params(session.id),
     );
-    expect(notLinked.status).toBe(400);
-    expect(await notLinked.json()).toEqual({ error: 'Equipment is not available for this exercise.' });
+    expect(notLinked.status).toBe(201);
+    expect(await notLinked.json()).toMatchObject({
+      gymEquipmentId: null,
+      equipmentNameSnapshot: null,
+      weight: 10,
+      reps: 10,
+    });
 
-    expect(await db.set.count({ where: { sessionId: session.id } })).toBe(0);
+    await db.gymEquipment.delete({ where: { id: equipment.id } });
+    const deleted = await createSet(
+      request(session.id, {
+        exerciseId: exercise.id,
+        gymEquipmentId: equipment.id,
+        setNumber: 3,
+        weight: 15,
+        reps: 12,
+        rir: 1,
+      }),
+      params(session.id),
+    );
+    expect(deleted.status).toBe(201);
+    expect(await deleted.json()).toMatchObject({
+      gymEquipmentId: null,
+      equipmentNameSnapshot: null,
+      weight: 15,
+      reps: 12,
+      rir: 1,
+    });
+
+    expect(await db.set.count({ where: { sessionId: session.id } })).toBe(3);
   });
 });


### PR DESCRIPTION
## Summary

Adds workout-history support for concrete physical gym equipment on top of #312.

- Lets a user select a linked physical machine/equipment item while logging a set.
- Stores the equipment id plus server-derived name/load metadata snapshots on the set so history remains meaningful after inventory rename/deletion.
- Preserves the selected equipment through IndexedDB offline queueing, sync, and server hydration.
- Treats equipment as optional metadata: deleted, unlinked, foreign, or frozen-session-gym-mismatched references are dropped while the weight/reps/RIR set is still recorded. The offline client also retries once without a rejected optional reference for compatibility with older server behavior.
- Keeps the live session RSC payload lightweight by selecting only equipment id/name/exercise links; image blobs are not selected.

## Schema / backup

The set-history migration is strict Prisma-compatible DDL (no `IF NOT EXISTS` guards) and adds only:

- `Set.gymEquipmentId` (nullable FK, `ON DELETE SET NULL`)
- `Set.equipmentNameSnapshot`
- `Set.equipmentLoadSnapshot` JSON

Unused null-only columns, the duplicate selected-load column, and the unused equipment-history index were removed before merge.

Backup format moves from v4 to **v5** to preserve set equipment history. Restore remains backward-compatible with earlier backup versions. JSON null handling uses `Prisma.JsonNull` consistently for `equipmentLoadSnapshot`.

## Verification

- Targeted offline sync / session payload / set input unit tests: green.
- Targeted Postgres integration: set equipment history + backup route green (13/13).
- Prisma validate, typecheck, lint and production build: green locally.
- Full Windows unit run: 996/999 green; the only failures are the repository's pre-existing POSIX-specific progress-photo path/permission assertions on Windows. Linux GitHub CI is authoritative for the full gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added gym equipment inventory management, including creation, editing, deletion, exercise linking, and image handling.
  * Added equipment selection during workout set entry, with recent selections remembered.
  * Workout history now preserves equipment names and load details.
  * Backups now include gym equipment, images, links, and equipment history.

* **Bug Fixes**
  * Improved backup validation and safe restoration of equipment data.
  * Added compatibility handling for older offline workout records.

* **Localization**
  * Added equipment-selection labels in English and Russian.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->