### PR TITLE
fix(mcp): return 405 for GET /mcp instead of hanging on the stateless transport

### DIFF
--- a/app/mcp/route.ts
+++ b/app/mcp/route.ts
@@ -57,7 +57,16 @@ export async function POST(req: Request) {
 }
 
 export async function GET(req: Request) {
-  return handle(req);
+  // The transport is stateless (sessionIdGenerator: undefined), so there is no
+  // session to attach an SSE stream to and a GET routed into handle() would
+  // hang with no response at all (issue #316). The Streamable HTTP spec says a
+  // server that offers no SSE stream on GET responds 405 so clients fall back
+  // to POST. If session support is ever added, this must become conditional on
+  // whether a session id generator is configured.
+  return withCors(
+    req,
+    new Response(null, { status: 405, headers: { Allow: 'POST, DELETE, OPTIONS' } }),
+  );
 }
 
 export async function DELETE(req: Request) {

--- a/tests/integration/mcp-route.test.ts
+++ b/tests/integration/mcp-route.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { GET, OPTIONS, POST } from '@/app/mcp/route';
+
+// Issue #316: with the stateless transport (sessionIdGenerator: undefined) a
+// GET routed into the shared handler produced no response at all - the request
+// hung until client timeout, so MCP clients that probe with GET before POSTing
+// initialize could never connect. GET must answer 405 promptly instead.
+describe('MCP route method handling', () => {
+  it('answers GET with 405 and an Allow header instead of hanging', async () => {
+    const res = await GET(new Request('http://test.local/mcp'));
+    expect(res.status).toBe(405);
+    expect(res.headers.get('allow')).toBe('POST, DELETE, OPTIONS');
+  });
+
+  it('answers an authenticated-looking SSE probe GET with 405 too', async () => {
+    const res = await GET(
+      new Request('http://test.local/mcp', {
+        headers: {
+          authorization: 'Bearer gmc_not_a_real_token',
+          accept: 'text/event-stream',
+        },
+      }),
+    );
+    expect(res.status).toBe(405);
+  });
+
+  it('still rejects an unauthenticated POST with 401', async () => {
+    const res = await POST(
+      new Request('http://test.local/mcp', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', method: 'ping', id: 1 }),
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('still answers OPTIONS with 204', async () => {
+    const res = await OPTIONS(new Request('http://test.local/mcp', { method: 'OPTIONS' }));
+    expect(res.status).toBe(204);
+  });
+});

--- a/tests/integration/mcp-route.test.ts
+++ b/tests/integration/mcp-route.test.ts
@@ -13,7 +13,11 @@ describe('MCP route method handling', () => {
     expect(res.headers.get('allow')).toBe('POST, DELETE, OPTIONS');
   });
 
-  it('answers an authenticated-looking SSE probe GET with 405 too', async () => {
+  // Both GET tests use unauthenticated requests (the old code 401'd them
+  // before reaching the transport), so they pin the fix and its before-auth
+  // ordering rather than reproducing the literal hang, which needed a valid
+  // seeded token.
+  it('answers an SSE probe GET carrying a bearer token with 405 too', async () => {
     const res = await GET(
       new Request('http://test.local/mcp', {
         headers: {


### PR DESCRIPTION
GET /mcp routed into the shared handler with a stateless transport (sessionIdGenerator: undefined), which has no session to attach an SSE stream to - an authenticated GET therefore hung with no response until client timeout. Unauthenticated GETs 401 early, which hid the bug from anonymous probes. MCP clients that open a GET stream before POSTing initialize (Claude Desktop's custom connector) could never connect.

Fix: GET now short-circuits (before auth, consistent with OPTIONS) to 405 with `Allow: POST, DELETE, OPTIONS`, CORS headers preserved via withCors, per the Streamable HTTP spec's behavior for servers that offer no SSE stream on GET. If session support is ever added the 405 must become conditional (noted in a comment).

Reported by @mvnixon in #314 - verified against the code and adopted as #316 under the new external-contributions policy. Credit to the reporter.

## How I tested

- New `tests/integration/mcp-route.test.ts`: GET returns 405 + Allow (with and without an SSE-probe Authorization header), unauthenticated POST still 401, OPTIONS still 204 - 4/4 green locally against the test Postgres.
- `bash scripts/verify.sh` green.

Closes #316
Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012otoLMg46wo2YJGTiJPUNm