### PR TITLE
feat(ci): publish the production image to GHCR on every push to main

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,56 @@
+# Publish the production image to GHCR on every push to main, so self-hosters
+# can pull instead of building locally and registry watchers (Watchtower, Diun)
+# have digests to compare (issue #310, operator-approved 2026-08-27).
+#
+# Uses the same Dockerfile the docker-smoke CI job builds and probes on every
+# PR, and the built-in GITHUB_TOKEN - no extra secrets. Tags: a moving :latest
+# plus an immutable :sha-<short> per commit. linux/amd64 only for now; arm64
+# needs QEMU emulation that multiplies build time and is tracked as a
+# follow-up rather than a blocker.
+name: Publish image
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: publish-image
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Build and push to GHCR
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=sha-
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,16 +1,30 @@
-# Publish the production image to GHCR on every push to main, so self-hosters
-# can pull instead of building locally and registry watchers (Watchtower, Diun)
-# have digests to compare (issue #310, operator-approved 2026-08-27).
+# Publish the production image to GHCR so self-hosters can pull instead of
+# building locally and registry watchers (Watchtower, Diun) have digests to
+# compare (issue #310, operator-approved 2026-08-27).
+#
+# Runs only after the CI workflow SUCCEEDS on a main commit (workflow_run
+# gate), so a commit whose main-branch CI goes red never reaches :latest -
+# green CI stays the trust boundary for self-hosters too. workflow_dispatch
+# is the manual re-run escape hatch and is restricted to main as well.
 #
 # Uses the same Dockerfile the docker-smoke CI job builds and probes on every
-# PR, and the built-in GITHUB_TOKEN - no extra secrets. Tags: a moving :latest
-# plus an immutable :sha-<short> per commit. linux/amd64 only for now; arm64
-# needs QEMU emulation that multiplies build time and is tracked as a
-# follow-up rather than a blocker.
+# PR, and the built-in GITHUB_TOKEN - no extra secrets. Tags: a moving
+# :latest plus an immutable :sha-<short> per commit. linux/amd64 only for
+# now; arm64 needs QEMU emulation that multiplies build time and is tracked
+# as a follow-up rather than a blocker. Docker actions ride the same mutable
+# major tags as ci.yml; pinning them by SHA across both workflows is a
+# possible hardening follow-up.
+#
+# One-time operator step after the first run: GHCR packages are born PRIVATE.
+# Open https://github.com/users/Julien-Au/packages/container/gymcoach/settings
+# and set visibility to Public, or anonymous `docker pull` fails with
+# "denied". The setting sticks for all later pushes.
 name: Publish image
 
 on:
-  push:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
     branches: [main]
   workflow_dispatch:
 
@@ -20,15 +34,30 @@ permissions:
 
 concurrency:
   group: publish-image
-  cancel-in-progress: true
+  # Do not cancel an in-flight publish: each commit should get its immutable
+  # sha- tag, and pushes are idempotent.
+  cancel-in-progress: false
 
 jobs:
   publish:
     name: Build and push to GHCR
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # Fork guard + green-CI gate; manual dispatch only from main.
+    if: >-
+      github.repository == 'Julien-Au/gymcoach' &&
+      (
+        (github.event_name == 'workflow_run' &&
+         github.event.workflow_run.conclusion == 'success' &&
+         github.event.workflow_run.head_branch == 'main') ||
+        (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+      )
     steps:
       - uses: actions/checkout@v5
+        with:
+          # For workflow_run, github.sha is not necessarily the commit the CI
+          # run validated; build exactly the SHA that went green.
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
       - uses: docker/setup-buildx-action@v3
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -36,21 +65,18 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Image tags
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=raw,value=latest
-            type=sha,prefix=sha-
+      - name: Compute the short SHA tag
+        id: vars
+        run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
           platforms: linux/amd64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          # Image name is the lowercased repository (GHCR requires lowercase).
+          tags: |
+            ghcr.io/julien-au/gymcoach:latest
+            ghcr.io/julien-au/gymcoach:sha-${{ steps.vars.outputs.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -310,6 +310,20 @@ docker compose -f docker-compose.prod.yml up -d --build
 docker compose -f docker-compose.prod.yml exec app npx prisma migrate deploy
 ```
 
+### Pulling the prebuilt image
+
+Every push to `main` publishes a linux/amd64 image to GHCR, so you can pull
+instead of building on your own hardware, and registry watchers (Watchtower,
+Diun) have digests to compare:
+
+- `ghcr.io/julien-au/gymcoach:latest` - moving tag, follows `main`
+- `ghcr.io/julien-au/gymcoach:sha-<short>` - immutable, one per commit
+
+To use it, replace the `build:` block of the `app` service in
+`docker-compose.prod.yml` with `image: ghcr.io/julien-au/gymcoach:latest`
+(the compose file keeps `build:` as its default so existing setups and forks
+keep working unchanged).
+
 ### Deploying a public demo instance
 
 Set `NEXT_PUBLIC_DEMO_MODE=true` (plus the throwaway demo credentials) in the

--- a/README.md
+++ b/README.md
@@ -312,9 +312,10 @@ docker compose -f docker-compose.prod.yml exec app npx prisma migrate deploy
 
 ### Pulling the prebuilt image
 
-Every push to `main` publishes a linux/amd64 image to GHCR, so you can pull
-instead of building on your own hardware, and registry watchers (Watchtower,
-Diun) have digests to compare:
+Every `main` commit whose CI run is green publishes a linux/amd64 image to
+GHCR, so you can pull instead of building on your own hardware, and registry
+watchers (Watchtower, Diun) have digests to compare (a commit whose CI fails
+is never published):
 
 - `ghcr.io/julien-au/gymcoach:latest` - moving tag, follows `main`
 - `ghcr.io/julien-au/gymcoach:sha-<short>` - immutable, one per commit


### PR DESCRIPTION
Implements #310 (requested by @mvnixon; the workflow surface is hard-blocked per docs/loops/10-external-contributions.md, and the operator green-lit this implementation in-session on 2026-08-27).

- New `.github/workflows/publish-image.yml`: on push to main (+ manual dispatch), build the same Dockerfile the docker-smoke job already validates on every PR, log in to ghcr.io with the built-in `GITHUB_TOKEN` (`packages: write` scoped to this workflow), push `:latest` + immutable `:sha-<short>`, GHA layer cache shared with CI. linux/amd64; arm64 is a follow-up (QEMU multiplies build time).
- README: documents pulling `ghcr.io/julien-au/gymcoach` instead of building; `docker-compose.prod.yml` keeps `build:` as default so existing setups and forks are unchanged.

This PR is also the live test that the new branch protection ruleset still lets the loop auto-merge its own work on green CI.

## How I tested

- `bash scripts/verify.sh` green (workflow + README only; app code untouched).
- Workflow YAML parse-checked. The publish job itself can only run post-merge (push to main); first run to be watched after merge, with `workflow_dispatch` available for a re-run.

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012otoLMg46wo2YJGTiJPUNm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated publishing of production Docker images after successful builds.
  * Images are available in GHCR with `latest` and immutable commit-specific tags for Linux/amd64.
  * Added support for manually triggering image publishing from the main branch.

* **Documentation**
  * Added instructions for pulling published Docker images.
  * Documented how to configure production Compose to use a prebuilt image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->