### PR TITLE
fix(api): make route ownership checks structural instead of deletable

### DIFF
--- a/app/api/bodyweight/[id]/route.ts
+++ b/app/api/bodyweight/[id]/route.ts
@@ -16,8 +16,11 @@ export async function DELETE(_req: Request, props: Params) {
   const params = await props.params;
   try {
     const userId = await requireApiUserId();
-    const entry = await db.bodyweightEntry.findUnique({ where: { id: params.id } });
-    if (!entry || entry.userId !== userId) {
+    // Ownership lives in the query scope itself (issue #317).
+    const entry = await db.bodyweightEntry.findFirst({
+      where: { id: params.id, userId },
+    });
+    if (!entry) {
       throw new ApiError(404, 'Entry not found.');
     }
 
@@ -25,7 +28,7 @@ export async function DELETE(_req: Request, props: Params) {
       // Lock the user row first so the re-sync serializes with concurrent
       // bodyweight mutations (issue #107), matching the POST route.
       await tx.$queryRaw`SELECT id FROM "User" WHERE id = ${userId} FOR UPDATE`;
-      await tx.bodyweightEntry.delete({ where: { id: params.id } });
+      await tx.bodyweightEntry.delete({ where: { id: params.id, userId } });
       const remaining = await tx.bodyweightEntry.findMany({
         where: { userId },
         orderBy: [{ measuredAt: 'asc' }, { id: 'asc' }],

--- a/app/api/coach/[id]/apply/route.ts
+++ b/app/api/coach/[id]/apply/route.ts
@@ -118,8 +118,10 @@ export async function POST(req: Request, props: Params) {
       applied.push({ exerciseName: adj.exerciseName, programExerciseIds: ids });
     }
 
+    // The write carries userId too (issue #317): marking a debrief applied
+    // stays scoped even if the ownership check above is ever removed.
     const updated = await db.coachSession.update({
-      where: { id: params.id },
+      where: { id: params.id, userId },
       data: { appliedAt: new Date() },
     });
 

--- a/app/api/coach/[id]/apply/route.ts
+++ b/app/api/coach/[id]/apply/route.ts
@@ -19,10 +19,12 @@ export async function POST(req: Request, props: Params) {
     const userId = await requireApiUserId();
     const { adjustments } = await parseJsonBody(req, applyAdjustmentsSchema);
 
-    const coachSession = await db.coachSession.findUnique({
-      where: { id: params.id },
+    // Scoped read (issue #317): ownership is part of the query, not a
+    // separate comparison that a later edit could drop.
+    const coachSession = await db.coachSession.findFirst({
+      where: { id: params.id, userId },
     });
-    if (!coachSession || coachSession.userId !== userId) {
+    if (!coachSession) {
       throw new ApiError(404, 'Debrief not found.');
     }
 

--- a/app/api/coach/chat/[id]/route.ts
+++ b/app/api/coach/chat/[id]/route.ts
@@ -2,24 +2,23 @@ import { NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { ApiError, handleApiError, requireApiUserId } from '@/lib/api';
 
-async function ensureOwnership(id: string, userId: string) {
-  const conv = await db.conversation.findUnique({
-    where: { id },
-    select: { userId: true },
-  });
-  if (!conv || conv.userId !== userId) {
-    throw new ApiError(404, 'Conversation not found.');
-  }
-}
+// Ownership is enforced by scoping every query with the owning user (issue
+// #317): the message read is constrained through the conversation relation,
+// and the delete carries userId in its own where, so neither survives the
+// removal of the other.
 
 // GET /api/coach/chat/[id]: messages of a conversation (owner only).
 export async function GET(_req: Request, props: { params: Promise<{ id: string }> }) {
   const params = await props.params;
   try {
     const userId = await requireApiUserId();
-    await ensureOwnership(params.id, userId);
+    const conv = await db.conversation.findFirst({
+      where: { id: params.id, userId },
+      select: { id: true },
+    });
+    if (!conv) throw new ApiError(404, 'Conversation not found.');
     const messages = await db.message.findMany({
-      where: { conversationId: params.id },
+      where: { conversationId: params.id, conversation: { userId } },
       orderBy: { createdAt: 'asc' },
       select: { id: true, role: true, content: true, createdAt: true },
     });
@@ -34,8 +33,7 @@ export async function DELETE(_req: Request, props: { params: Promise<{ id: strin
   const params = await props.params;
   try {
     const userId = await requireApiUserId();
-    await ensureOwnership(params.id, userId);
-    await db.conversation.delete({ where: { id: params.id } });
+    await db.conversation.delete({ where: { id: params.id, userId } });
     return NextResponse.json({ ok: true });
   } catch (err) {
     return handleApiError(err);

--- a/app/api/coach/chat/route.ts
+++ b/app/api/coach/chat/route.ts
@@ -35,11 +35,13 @@ export async function POST(req: Request) {
 
     let conversationId: string;
     if (existingId) {
-      const conv = await db.conversation.findUnique({
-        where: { id: existingId },
-        select: { userId: true },
+      // Scoped read (issue #317): ownership is part of the query, not a
+      // separate comparison that a later edit could drop.
+      const conv = await db.conversation.findFirst({
+        where: { id: existingId, userId },
+        select: { id: true },
       });
-      if (!conv || conv.userId !== userId) {
+      if (!conv) {
         throw new ApiError(404, 'Conversation not found.');
       }
       conversationId = existingId;
@@ -100,7 +102,7 @@ export async function POST(req: Request) {
               .create({ data: { conversationId, role: 'ASSISTANT', content: assistant } })
               .catch(() => {});
             await db.conversation
-              .update({ where: { id: conversationId }, data: { updatedAt: new Date() } })
+              .update({ where: { id: conversationId, userId }, data: { updatedAt: new Date() } })
               .catch(() => {});
           }
           controller.close();

--- a/app/api/exercises/[id]/route.ts
+++ b/app/api/exercises/[id]/route.ts
@@ -7,19 +7,16 @@ interface Params {
   params: Promise<{ id: string }>;
 }
 
-async function ensureOwnership(id: string, userId: string) {
-  const exercise = await db.exercise.findUnique({ where: { id } });
-  if (!exercise || exercise.userId !== userId) {
-    throw new ApiError(404, 'Exercise not found.');
-  }
-  return exercise;
-}
+// Ownership is enforced by scoping every query with userId (issue #317):
+// the reads that serve the responses are themselves the checks, and the
+// writes carry userId in their where, so a stranger's id yields 404.
 
 export async function GET(_req: Request, props: Params) {
   const params = await props.params;
   try {
     const userId = await requireApiUserId();
-    const exercise = await ensureOwnership(params.id, userId);
+    const exercise = await db.exercise.findFirst({ where: { id: params.id, userId } });
+    if (!exercise) throw new ApiError(404, 'Exercise not found.');
     return NextResponse.json(exercise);
   } catch (err) {
     return handleApiError(err);
@@ -30,10 +27,9 @@ export async function PUT(req: Request, props: Params) {
   const params = await props.params;
   try {
     const userId = await requireApiUserId();
-    await ensureOwnership(params.id, userId);
     const data = await parseJsonBody(req, exerciseInputSchema);
     const updated = await db.exercise.update({
-      where: { id: params.id },
+      where: { id: params.id, userId },
       data: { ...data, notes: data.notes ?? null },
     });
     return NextResponse.json(updated);
@@ -46,25 +42,25 @@ export async function DELETE(_req: Request, props: Params) {
   const params = await props.params;
   try {
     const userId = await requireApiUserId();
-    await ensureOwnership(params.id, userId);
 
     // Check whether the exercise is used in an active program or in sets.
     // If so, we refuse to avoid breaking the data. The user must first remove
     // the exercise from the programs or create a variant.
-    const usage = await db.exercise.findUnique({
-      where: { id: params.id },
+    const usage = await db.exercise.findFirst({
+      where: { id: params.id, userId },
       select: {
         _count: { select: { programExercises: true, sets: true } },
       },
     });
-    if (usage && (usage._count.programExercises > 0 || usage._count.sets > 0)) {
+    if (!usage) throw new ApiError(404, 'Exercise not found.');
+    if (usage._count.programExercises > 0 || usage._count.sets > 0) {
       throw new ApiError(
         409,
         'Exercise used in a program or in history. Remove it first.',
       );
     }
 
-    await db.exercise.delete({ where: { id: params.id } });
+    await db.exercise.delete({ where: { id: params.id, userId } });
     return NextResponse.json({ ok: true });
   } catch (err) {
     return handleApiError(err);

--- a/app/api/goals/[id]/route.ts
+++ b/app/api/goals/[id]/route.ts
@@ -11,11 +11,12 @@ export async function DELETE(_req: Request, props: Params) {
   const params = await props.params;
   try {
     const userId = await requireApiUserId();
-    const goal = await db.exerciseGoal.findUnique({ where: { id: params.id } });
-    if (!goal || goal.userId !== userId) {
+    // Ownership lives in the query scope itself (issue #317).
+    const goal = await db.exerciseGoal.findFirst({ where: { id: params.id, userId } });
+    if (!goal) {
       throw new ApiError(404, 'Goal not found.');
     }
-    await db.exerciseGoal.delete({ where: { id: params.id } });
+    await db.exerciseGoal.delete({ where: { id: params.id, userId } });
     return NextResponse.json({ ok: true });
   } catch (err) {
     return handleApiError(err);

--- a/app/api/gyms/[id]/route.ts
+++ b/app/api/gyms/[id]/route.ts
@@ -22,10 +22,12 @@ export async function PUT(req: Request, props: Params) {
     const input = await parseJsonBody(req, gymUpdateSchema);
     const exerciseConfigs = await validateGymExerciseConfigs(userId, input.exerciseConfigs);
 
+    // The writes carry the owner scope too (issue #317): they stay scoped
+    // even if the requireOwnedGym check is ever removed.
     const updated = await db.$transaction(async (tx) => {
-      await tx.gymExerciseConfig.deleteMany({ where: { gymId: id } });
+      await tx.gymExerciseConfig.deleteMany({ where: { gymId: id, gym: { userId } } });
       return tx.gym.update({
-        where: { id },
+        where: { id, userId },
         data: {
           name: input.name,
           dumbbellWeights: input.dumbbellWeights,
@@ -48,7 +50,7 @@ export async function DELETE(_req: Request, props: Params) {
     const userId = await requireApiUserId();
     await requireOwnedGym(id, userId);
     await db.$transaction(async (tx) => {
-      await tx.gym.delete({ where: { id } });
+      await tx.gym.delete({ where: { id, userId } });
       const user = await tx.user.findUnique({
         where: { id: userId },
         select: { activeGymId: true },

--- a/app/api/history/csv/route.ts
+++ b/app/api/history/csv/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import type { Prisma } from '@prisma/client';
+import type { Prisma } from '@/prisma/generated/client';
 import { db } from '@/lib/db';
 import { handleApiError, requireApiUserId } from '@/lib/api';
 import { csvEscape, HISTORY_CSV_HEADERS } from '@/lib/csv';
@@ -17,8 +17,9 @@ export async function GET(req: Request) {
     const programId = url.searchParams.get('programId');
     const month = url.searchParams.get('month');
 
-    // Typed where (issue #317): with Record<string, unknown> the compiler
-    // could not see the userId scope, so deleting it produced no type error.
+    // The where stays typed as a real Prisma filter (issue #317) so its
+    // shape is checked; the userId scope itself is pinned by the cross-user
+    // case in tests/integration/route-ownership.test.ts.
     const where: Prisma.SessionWhereInput = {
       userId,
       finishedAt: { not: null },

--- a/app/api/history/csv/route.ts
+++ b/app/api/history/csv/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import type { Prisma } from '@prisma/client';
 import { db } from '@/lib/db';
 import { handleApiError, requireApiUserId } from '@/lib/api';
 import { csvEscape, HISTORY_CSV_HEADERS } from '@/lib/csv';
@@ -16,7 +17,9 @@ export async function GET(req: Request) {
     const programId = url.searchParams.get('programId');
     const month = url.searchParams.get('month');
 
-    const where: Record<string, unknown> = {
+    // Typed where (issue #317): with Record<string, unknown> the compiler
+    // could not see the userId scope, so deleting it produced no type error.
+    const where: Prisma.SessionWhereInput = {
       userId,
       finishedAt: { not: null },
     };

--- a/app/api/mcp-tokens/[id]/route.ts
+++ b/app/api/mcp-tokens/[id]/route.ts
@@ -11,7 +11,9 @@ export async function DELETE(_req: Request, props: Params) {
     const { id } = await props.params;
     const token = await db.mcpAccessToken.findFirst({ where: { id, userId, revokedAt: null } });
     if (!token) throw new ApiError(404, 'MCP token not found.');
-    await db.mcpAccessToken.update({ where: { id }, data: { revokedAt: new Date() } });
+    // The write carries userId too (issue #317): the revoke stays scoped even
+    // if the check above is ever removed.
+    await db.mcpAccessToken.update({ where: { id, userId }, data: { revokedAt: new Date() } });
     return Response.json({ ok: true });
   } catch (err) {
     return handleApiError(err);

--- a/app/api/measurements/[id]/route.ts
+++ b/app/api/measurements/[id]/route.ts
@@ -13,11 +13,14 @@ export async function DELETE(_req: Request, props: Params) {
   const params = await props.params;
   try {
     const userId = await requireApiUserId();
-    const entry = await db.bodyMeasurement.findUnique({ where: { id: params.id } });
-    if (!entry || entry.userId !== userId) {
+    // Ownership lives in the query scope itself (issue #317).
+    const entry = await db.bodyMeasurement.findFirst({
+      where: { id: params.id, userId },
+    });
+    if (!entry) {
       throw new ApiError(404, 'Measurement not found.');
     }
-    await db.bodyMeasurement.delete({ where: { id: params.id } });
+    await db.bodyMeasurement.delete({ where: { id: params.id, userId } });
     return NextResponse.json({ ok: true });
   } catch (err) {
     return handleApiError(err);

--- a/app/api/program-exercises/[id]/route.ts
+++ b/app/api/program-exercises/[id]/route.ts
@@ -7,31 +7,34 @@ interface Params {
   params: Promise<{ id: string }>;
 }
 
-async function ensureOwnership(id: string, userId: string) {
-  const pe = await db.programExercise.findUnique({
-    where: { id },
-    include: { workout: { include: { program: { select: { userId: true } } } } },
-  });
-  if (!pe || pe.workout.program.userId !== userId) {
-    throw new ApiError(404, 'Program exercise not found.');
-  }
-  return pe;
-}
+// Ownership is enforced by scoping the writes themselves through the owning
+// program (issue #317): a stranger's id makes Prisma throw P2025, which
+// handleApiError maps to 404. No separate check to delete.
 
 export async function PUT(req: Request, props: Params) {
   const params = await props.params;
   try {
     const userId = await requireApiUserId();
-    await ensureOwnership(params.id, userId);
+    // Scoped existence probe so a stranger gets 404 before any 400 about the
+    // body; the update below carries the same scope, so this probe is about
+    // the status code, not the security boundary.
+    const owned = await db.programExercise.findFirst({
+      where: { id: params.id, workout: { program: { userId } } },
+      select: { id: true },
+    });
+    if (!owned) throw new ApiError(404, 'Program exercise not found.');
+
     const data = await parseJsonBody(req, programExerciseInputSchema);
 
-    const exercise = await db.exercise.findUnique({ where: { id: data.exerciseId } });
-    if (!exercise || exercise.userId !== userId) {
+    const exercise = await db.exercise.findFirst({
+      where: { id: data.exerciseId, userId },
+    });
+    if (!exercise) {
       throw new ApiError(400, 'Invalid exercise.');
     }
 
     const updated = await db.programExercise.update({
-      where: { id: params.id },
+      where: { id: params.id, workout: { program: { userId } } },
       data: {
         exerciseId: data.exerciseId,
         targetSets: data.targetSets,
@@ -60,8 +63,9 @@ export async function DELETE(_req: Request, props: Params) {
   const params = await props.params;
   try {
     const userId = await requireApiUserId();
-    await ensureOwnership(params.id, userId);
-    await db.programExercise.delete({ where: { id: params.id } });
+    await db.programExercise.delete({
+      where: { id: params.id, workout: { program: { userId } } },
+    });
     return NextResponse.json({ ok: true });
   } catch (err) {
     return handleApiError(err);

--- a/app/api/programs/[id]/activate/route.ts
+++ b/app/api/programs/[id]/activate/route.ts
@@ -14,8 +14,10 @@ export async function POST(req: Request, props: Params) {
   const params = await props.params;
   try {
     const userId = await requireApiUserId();
-    const program = await db.program.findUnique({ where: { id: params.id } });
-    if (!program || program.userId !== userId) {
+    // Ownership lives in the query scope itself (issue #317): the read and
+    // both writes carry userId, so none survives the removal of the others.
+    const program = await db.program.findFirst({ where: { id: params.id, userId } });
+    if (!program) {
       throw new ApiError(404, 'Program not found.');
     }
 
@@ -28,13 +30,13 @@ export async function POST(req: Request, props: Params) {
           where: { userId, isActive: true, id: { not: params.id } },
           data: { isActive: false },
         }),
-        db.program.update({ where: { id: params.id }, data: { isActive: true } }),
+        db.program.update({ where: { id: params.id, userId }, data: { isActive: true } }),
       ]);
     } else {
-      await db.program.update({ where: { id: params.id }, data: { isActive: false } });
+      await db.program.update({ where: { id: params.id, userId }, data: { isActive: false } });
     }
 
-    const updated = await db.program.findUnique({ where: { id: params.id } });
+    const updated = await db.program.findFirst({ where: { id: params.id, userId } });
     return NextResponse.json(updated);
   } catch (err) {
     return handleApiError(err);

--- a/app/api/programs/[id]/route.ts
+++ b/app/api/programs/[id]/route.ts
@@ -7,21 +7,16 @@ interface Params {
   params: Promise<{ id: string }>;
 }
 
-async function ensureOwnership(id: string, userId: string) {
-  const program = await db.program.findUnique({ where: { id } });
-  if (!program || program.userId !== userId) {
-    throw new ApiError(404, 'Program not found.');
-  }
-  return program;
-}
+// Ownership is enforced by scoping every query with userId (issue #317):
+// there is no separate check to delete, so a stranger's id yields 404 via a
+// null read or Prisma P2025, which handleApiError maps to 404.
 
 export async function GET(_req: Request, props: Params) {
   const params = await props.params;
   try {
     const userId = await requireApiUserId();
-    await ensureOwnership(params.id, userId);
-    const program = await db.program.findUnique({
-      where: { id: params.id },
+    const program = await db.program.findFirst({
+      where: { id: params.id, userId },
       include: {
         workouts: {
           orderBy: { order: 'asc' },
@@ -34,6 +29,7 @@ export async function GET(_req: Request, props: Params) {
         },
       },
     });
+    if (!program) throw new ApiError(404, 'Program not found.');
     return NextResponse.json(program);
   } catch (err) {
     return handleApiError(err);
@@ -44,10 +40,9 @@ export async function PUT(req: Request, props: Params) {
   const params = await props.params;
   try {
     const userId = await requireApiUserId();
-    await ensureOwnership(params.id, userId);
     const data = await parseJsonBody(req, programInputSchema);
     const program = await db.program.update({
-      where: { id: params.id },
+      where: { id: params.id, userId },
       data: {
         name: data.name,
         phase: data.phase,
@@ -64,11 +59,10 @@ export async function DELETE(_req: Request, props: Params) {
   const params = await props.params;
   try {
     const userId = await requireApiUserId();
-    await ensureOwnership(params.id, userId);
     // onDelete: Cascade on Workout removes workouts + programExercises.
     // Linked Sessions have a nullable programId so they will be detached
     // (Prisma sets null by default on optional relations).
-    await db.program.delete({ where: { id: params.id } });
+    await db.program.delete({ where: { id: params.id, userId } });
     return NextResponse.json({ ok: true });
   } catch (err) {
     return handleApiError(err);

--- a/app/api/programs/[id]/workouts/route.ts
+++ b/app/api/programs/[id]/workouts/route.ts
@@ -13,8 +13,10 @@ export async function POST(req: Request, props: Params) {
   const params = await props.params;
   try {
     const userId = await requireApiUserId();
-    const program = await db.program.findUnique({ where: { id: params.id } });
-    if (!program || program.userId !== userId) {
+    // Scoped read (issue #317): ownership is part of the query, not a
+    // separate comparison that a later edit could drop.
+    const program = await db.program.findFirst({ where: { id: params.id, userId } });
+    if (!program) {
       throw new ApiError(404, 'Program not found.');
     }
 

--- a/app/api/progress-photos/[id]/image/route.ts
+++ b/app/api/progress-photos/[id]/image/route.ts
@@ -18,10 +18,11 @@ export async function GET(_req: Request, props: Params) {
   const params = await props.params;
   try {
     const userId = await requireApiUserId();
-    const photo = await db.progressPhoto.findUnique({
-      where: { id: params.id },
+    // Ownership lives in the query scope itself (issue #317).
+    const photo = await db.progressPhoto.findFirst({
+      where: { id: params.id, userId },
     });
-    if (!photo || photo.userId !== userId) {
+    if (!photo) {
       throw new ApiError(404, 'Photo not found.');
     }
 

--- a/app/api/progress-photos/[id]/route.ts
+++ b/app/api/progress-photos/[id]/route.ts
@@ -17,15 +17,16 @@ export async function DELETE(_req: Request, props: Params) {
   const params = await props.params;
   try {
     const userId = await requireApiUserId();
-    const photo = await db.progressPhoto.findUnique({
-      where: { id: params.id },
+    // Ownership lives in the query scope itself (issue #317).
+    const photo = await db.progressPhoto.findFirst({
+      where: { id: params.id, userId },
     });
-    if (!photo || photo.userId !== userId) {
+    if (!photo) {
       throw new ApiError(404, 'Photo not found.');
     }
 
     await deletePhotoFile(photo.storagePath);
-    await db.progressPhoto.delete({ where: { id: photo.id } });
+    await db.progressPhoto.delete({ where: { id: photo.id, userId } });
     return NextResponse.json({ ok: true });
   } catch (err) {
     return handleApiError(err);

--- a/app/api/sessions/[id]/route.ts
+++ b/app/api/sessions/[id]/route.ts
@@ -7,21 +7,17 @@ interface Params {
   params: Promise<{ id: string }>;
 }
 
-async function ensureOwnership(id: string, userId: string) {
-  const session = await db.session.findUnique({ where: { id } });
-  if (!session || session.userId !== userId) {
-    throw new ApiError(404, 'Session not found.');
-  }
-  return session;
-}
+// Ownership is enforced by scoping every query with userId (issue #317):
+// the read that serves the response is itself the check, and the writes
+// carry userId in their where, so a stranger's id yields 404 (null read or
+// Prisma P2025 via handleApiError).
 
 export async function GET(_req: Request, props: Params) {
   const params = await props.params;
   try {
     const userId = await requireApiUserId();
-    await ensureOwnership(params.id, userId);
-    const session = await db.session.findUnique({
-      where: { id: params.id },
+    const session = await db.session.findFirst({
+      where: { id: params.id, userId },
       include: {
         workout: {
           include: {
@@ -35,6 +31,7 @@ export async function GET(_req: Request, props: Params) {
         sets: { orderBy: [{ exerciseId: 'asc' }, { setNumber: 'asc' }] },
       },
     });
+    if (!session) throw new ApiError(404, 'Session not found.');
     return NextResponse.json(session);
   } catch (err) {
     return handleApiError(err);
@@ -45,11 +42,12 @@ export async function PUT(req: Request, props: Params) {
   const params = await props.params;
   try {
     const userId = await requireApiUserId();
-    const session = await ensureOwnership(params.id, userId);
+    const session = await db.session.findFirst({ where: { id: params.id, userId } });
+    if (!session) throw new ApiError(404, 'Session not found.');
     const data = await parseJsonBody(req, sessionUpdateSchema);
 
     const updated = await db.session.update({
-      where: { id: params.id },
+      where: { id: params.id, userId },
       data: {
         notes: data.notes ?? session.notes,
         finishedAt: data.finish ? new Date() : session.finishedAt,
@@ -65,8 +63,7 @@ export async function DELETE(_req: Request, props: Params) {
   const params = await props.params;
   try {
     const userId = await requireApiUserId();
-    await ensureOwnership(params.id, userId);
-    await db.session.delete({ where: { id: params.id } });
+    await db.session.delete({ where: { id: params.id, userId } });
     return NextResponse.json({ ok: true });
   } catch (err) {
     return handleApiError(err);

--- a/app/api/sessions/[id]/sets/route.ts
+++ b/app/api/sessions/[id]/sets/route.ts
@@ -16,8 +16,10 @@ export async function POST(req: Request, props: Params) {
   try {
     const userId = await requireApiUserId();
 
-    const session = await db.session.findUnique({ where: { id: params.id } });
-    if (!session || session.userId !== userId) {
+    // Scoped reads (issue #317): ownership is part of each query, not a
+    // separate comparison that a later edit could drop.
+    const session = await db.session.findFirst({ where: { id: params.id, userId } });
+    if (!session) {
       throw new ApiError(404, 'Session not found.');
     }
     if (session.finishedAt) {
@@ -27,8 +29,10 @@ export async function POST(req: Request, props: Params) {
     const data = await parseJsonBody(req, setInputSchema);
 
     // Validation: the exercise must belong to the user.
-    const exercise = await db.exercise.findUnique({ where: { id: data.exerciseId } });
-    if (!exercise || exercise.userId !== userId) {
+    const exercise = await db.exercise.findFirst({
+      where: { id: data.exerciseId, userId },
+    });
+    if (!exercise) {
       throw new ApiError(400, 'Invalid exercise.');
     }
 

--- a/app/api/sets/[id]/route.ts
+++ b/app/api/sets/[id]/route.ts
@@ -14,14 +14,16 @@ export async function DELETE(_req: Request, props: Params) {
   const params = await props.params;
   try {
     const userId = await requireApiUserId();
-    const set = await db.set.findUnique({
-      where: { id: params.id },
-      include: { session: { select: { userId: true } } },
+    // Ownership lives in the query scope itself (issue #317): both the read
+    // and the delete carry the owner, so neither survives the removal of the
+    // other.
+    const set = await db.set.findFirst({
+      where: { id: params.id, session: { userId } },
     });
-    if (!set || set.session.userId !== userId) {
+    if (!set) {
       throw new ApiError(404, 'Set not found.');
     }
-    await db.set.delete({ where: { id: params.id } });
+    await db.set.delete({ where: { id: params.id, session: { userId } } });
     // Best-effort, mirroring the stamping at set-save: the set is already
     // gone, so a failure here must never fail the deletion. A stale
     // achievedAt also self-heals on goal re-creation.

--- a/app/api/workouts/[id]/program-exercises/route.ts
+++ b/app/api/workouts/[id]/program-exercises/route.ts
@@ -14,19 +14,22 @@ export async function POST(req: Request, props: Params) {
   const params = await props.params;
   try {
     const userId = await requireApiUserId();
-    const workout = await db.workout.findUnique({
-      where: { id: params.id },
-      include: { program: { select: { userId: true } } },
+    // Scoped reads (issue #317): ownership is part of each query, not a
+    // separate comparison that a later edit could drop.
+    const workout = await db.workout.findFirst({
+      where: { id: params.id, program: { userId } },
     });
-    if (!workout || workout.program.userId !== userId) {
+    if (!workout) {
       throw new ApiError(404, 'Session not found.');
     }
 
     const data = await parseJsonBody(req, programExerciseInputSchema);
 
-    // Check that the exercise belongs to the user.
-    const exercise = await db.exercise.findUnique({ where: { id: data.exerciseId } });
-    if (!exercise || exercise.userId !== userId) {
+    // The exercise must belong to the user too.
+    const exercise = await db.exercise.findFirst({
+      where: { id: data.exerciseId, userId },
+    });
+    if (!exercise) {
       throw new ApiError(400, 'Invalid exercise.');
     }
 

--- a/app/api/workouts/[id]/route.ts
+++ b/app/api/workouts/[id]/route.ts
@@ -1,31 +1,23 @@
 import { NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { workoutInputSchema } from '@/lib/schemas/workout';
-import { ApiError, handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
+import { handleApiError, parseJsonBody, requireApiUserId } from '@/lib/api';
 
 interface Params {
   params: Promise<{ id: string }>;
 }
 
-async function ensureOwnership(workoutId: string, userId: string) {
-  const workout = await db.workout.findUnique({
-    where: { id: workoutId },
-    include: { program: { select: { userId: true } } },
-  });
-  if (!workout || workout.program.userId !== userId) {
-    throw new ApiError(404, 'Session not found.');
-  }
-  return workout;
-}
+// Ownership is enforced by scoping the write itself through the owning
+// program (issue #317): a stranger's id makes Prisma throw P2025, which
+// handleApiError maps to 404. No separate check to delete.
 
 export async function PUT(req: Request, props: Params) {
   const params = await props.params;
   try {
     const userId = await requireApiUserId();
-    await ensureOwnership(params.id, userId);
     const data = await parseJsonBody(req, workoutInputSchema);
     const updated = await db.workout.update({
-      where: { id: params.id },
+      where: { id: params.id, program: { userId } },
       data: { name: data.name, dayOfWeek: data.dayOfWeek ?? null },
     });
     return NextResponse.json(updated);
@@ -38,8 +30,7 @@ export async function DELETE(_req: Request, props: Params) {
   const params = await props.params;
   try {
     const userId = await requireApiUserId();
-    await ensureOwnership(params.id, userId);
-    await db.workout.delete({ where: { id: params.id } });
+    await db.workout.delete({ where: { id: params.id, program: { userId } } });
     return NextResponse.json({ ok: true });
   } catch (err) {
     return handleApiError(err);

--- a/tests/integration/route-ownership-coverage.test.ts
+++ b/tests/integration/route-ownership-coverage.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+// Ratchet for issue #317: every API route addressed by a resource id must be
+// referenced by an ownership-aware integration test, so a new [id] route
+// cannot ship without a cross-user case and an existing one cannot silently
+// lose its coverage. This test needs no database; it only reads the tree.
+
+const ROOT = process.cwd();
+const API_DIR = join(ROOT, 'app', 'api');
+
+// Routes whose cross-user coverage lives in a dedicated suite instead of
+// route-ownership.test.ts. The mapped file must exist AND reference the
+// route; the quality of its cross-user assertions is review's job.
+const COVERED_ELSEWHERE: Record<string, string> = {
+  'app/api/bodyweight/[id]/route.ts': 'tests/integration/bodyweight-route.test.ts',
+  'app/api/goals/[id]/route.ts': 'tests/integration/goals-route.test.ts',
+  'app/api/measurements/[id]/route.ts': 'tests/integration/measurements-route.test.ts',
+  'app/api/progress-photos/[id]/route.ts': 'tests/integration/progress-photos-route.test.ts',
+  'app/api/progress-photos/[id]/image/route.ts': 'tests/integration/progress-photos-route.test.ts',
+};
+
+function findIdRoutes(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...findIdRoutes(full));
+    } else if (entry.name === 'route.ts' && full.includes('[id]')) {
+      out.push(relative(ROOT, full));
+    }
+  }
+  return out;
+}
+
+describe('ownership-test coverage ratchet (issue #317)', () => {
+  const idRoutes = findIdRoutes(API_DIR);
+  const ownershipSource = readFileSync(
+    join(ROOT, 'tests', 'integration', 'route-ownership.test.ts'),
+    'utf8',
+  );
+
+  it('finds the [id] routes (sanity: the glob is not silently empty)', () => {
+    expect(idRoutes.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it.each(idRoutes)('%s is referenced by an ownership-aware test', (routePath) => {
+    // Import specifiers drop the .ts extension.
+    const specifier = routePath.replace(/\.ts$/, '');
+    if (ownershipSource.includes(specifier)) return;
+    const mapped = COVERED_ELSEWHERE[routePath];
+    if (!mapped) {
+      throw new Error(
+        `${routePath} is not referenced by route-ownership.test.ts and has no ` +
+          `COVERED_ELSEWHERE entry. Add a cross-user case for it (or map its ` +
+          `dedicated suite here).`,
+      );
+    }
+    const mappedSource = readFileSync(join(ROOT, mapped), 'utf8');
+    expect(
+      mappedSource.includes(specifier),
+      `${mapped} no longer references ${routePath}; its coverage claim is stale.`,
+    ).toBe(true);
+  });
+});

--- a/tests/integration/route-ownership.test.ts
+++ b/tests/integration/route-ownership.test.ts
@@ -214,6 +214,7 @@ describe('route ownership: /api/programs/[id]', () => {
       idParams(program.id),
     );
     expect(put.status).toBe(200);
+    expect((await db.program.findUnique({ where: { id: program.id } }))?.name).toBe('Block 2');
   });
 
   it('returns 404 to a stranger on GET, PUT and DELETE and leaves the program intact', async () => {
@@ -242,6 +243,7 @@ describe('route ownership: /api/workouts/[id]', () => {
       idParams(workout.id),
     );
     expect(res.status).toBe(200);
+    expect((await db.workout.findUnique({ where: { id: workout.id } }))?.name).toBe('Push B');
   });
 
   it('returns 404 to a stranger on PUT and DELETE and leaves the workout intact', async () => {
@@ -343,6 +345,7 @@ describe('route ownership: /api/gyms/[id]', () => {
     actAs(a.id);
     const res = await putGym(jsonReq('PUT', { name: 'Garage' }), idParams(gym.id));
     expect(res.status).toBe(200);
+    expect((await db.gym.findUnique({ where: { id: gym.id } }))?.name).toBe('Garage');
   });
 
   it('returns 404 to a stranger on PUT and DELETE and leaves the gym intact', async () => {

--- a/tests/integration/route-ownership.test.ts
+++ b/tests/integration/route-ownership.test.ts
@@ -8,8 +8,36 @@ vi.mock('@/lib/auth', () => ({ getCurrentUserId: vi.fn() }));
 const mockUserId = vi.mocked(getCurrentUserId);
 
 import { DELETE as deleteSet } from '@/app/api/sets/[id]/route';
-import { PUT as putSession } from '@/app/api/sessions/[id]/route';
-import { GET as getExercise } from '@/app/api/exercises/[id]/route';
+import {
+  GET as getSession,
+  PUT as putSession,
+  DELETE as deleteSession,
+} from '@/app/api/sessions/[id]/route';
+import {
+  GET as getExercise,
+  PUT as putExercise,
+  DELETE as deleteExercise,
+} from '@/app/api/exercises/[id]/route';
+import {
+  GET as getProgram,
+  PUT as putProgram,
+  DELETE as deleteProgram,
+} from '@/app/api/programs/[id]/route';
+import { PUT as putWorkout, DELETE as deleteWorkout } from '@/app/api/workouts/[id]/route';
+import {
+  PUT as putProgramExercise,
+  DELETE as deleteProgramExercise,
+} from '@/app/api/program-exercises/[id]/route';
+import { GET as getChat, DELETE as deleteChat } from '@/app/api/coach/chat/[id]/route';
+import { POST as activateProgram } from '@/app/api/programs/[id]/activate/route';
+import { POST as addWorkout } from '@/app/api/programs/[id]/workouts/route';
+import { POST as addProgramExercise } from '@/app/api/workouts/[id]/program-exercises/route';
+import { POST as addSet } from '@/app/api/sessions/[id]/sets/route';
+import { POST as activateGym } from '@/app/api/gyms/[id]/activate/route';
+import { DELETE as deleteMcpToken } from '@/app/api/mcp-tokens/[id]/route';
+import { PUT as putGym, DELETE as deleteGym } from '@/app/api/gyms/[id]/route';
+import { POST as postCoachApply } from '@/app/api/coach/[id]/apply/route';
+import { GET as getHistoryCsv } from '@/app/api/history/csv/route';
 
 function actAs(userId: string) {
   mockUserId.mockResolvedValue(userId);
@@ -23,7 +51,11 @@ function jsonReq(method: string, body: unknown): Request {
   });
 }
 
-// Seed two users; user A owns an exercise, a session, and a set.
+function idParams(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+// Seed two users; user A owns one of everything an [id] route can address.
 async function seed() {
   const [a, b] = await Promise.all([
     db.user.create({ data: { email: 'owner@test.dev', passwordHash: 'x' } }),
@@ -32,11 +64,68 @@ async function seed() {
   const exercise = await db.exercise.create({
     data: { userId: a.id, name: 'Bench', muscleGroup: 'CHEST', category: 'COMPOUND' },
   });
+  const exerciseB = await db.exercise.create({
+    data: { userId: b.id, name: 'Row', muscleGroup: 'BACK_WIDTH', category: 'COMPOUND' },
+  });
   const session = await db.session.create({ data: { userId: a.id, notes: 'original' } });
   const set = await db.set.create({
     data: { sessionId: session.id, exerciseId: exercise.id, setNumber: 1, weight: 60, reps: 10 },
   });
-  return { a, b, exercise, session, set };
+  const program = await db.program.create({
+    data: { userId: a.id, name: 'Block 1', phase: 'hypertrophy' },
+  });
+  const workout = await db.workout.create({
+    data: { programId: program.id, name: 'Push A', order: 0 },
+  });
+  const programExercise = await db.programExercise.create({
+    data: {
+      workoutId: workout.id,
+      exerciseId: exercise.id,
+      order: 0,
+      targetSets: 3,
+      targetRepsMin: 8,
+      targetRepsMax: 12,
+      targetRIR: 2,
+      restSec: 120,
+    },
+  });
+  const conversation = await db.conversation.create({ data: { userId: a.id } });
+  await db.message.create({
+    data: { conversationId: conversation.id, role: 'USER', content: 'private words' },
+  });
+  const mcpToken = await db.mcpAccessToken.create({
+    data: {
+      userId: a.id,
+      name: 'cli',
+      tokenHash: 'ownership-test-hash',
+      tokenPrefix: 'gmc_test.....',
+    },
+  });
+  const gym = await db.gym.create({ data: { userId: a.id, name: 'Home gym' } });
+  const coachSession = await db.coachSession.create({
+    data: {
+      userId: a.id,
+      weekStart: new Date('2026-08-17'),
+      weekEnd: new Date('2026-08-23'),
+      prompt: 'p',
+      response: 'r',
+    },
+  });
+  return {
+    a,
+    b,
+    exercise,
+    exerciseB,
+    session,
+    set,
+    program,
+    workout,
+    programExercise,
+    conversation,
+    mcpToken,
+    gym,
+    coachSession,
+  };
 }
 
 beforeEach(() => {
@@ -47,9 +136,7 @@ describe('route ownership: DELETE /api/sets/[id]', () => {
   it('lets the owner delete their set', async () => {
     const { a, set } = await seed();
     actAs(a.id);
-    const res = await deleteSet(new Request('http://t/api', { method: 'DELETE' }), {
-      params: Promise.resolve({ id: set.id }),
-    });
+    const res = await deleteSet(new Request('http://t/api', { method: 'DELETE' }), idParams(set.id));
     expect(res.status).toBe(200);
     expect(await db.set.findUnique({ where: { id: set.id } })).toBeNull();
   });
@@ -57,50 +144,300 @@ describe('route ownership: DELETE /api/sets/[id]', () => {
   it("returns 404 and keeps the set when a stranger tries to delete it", async () => {
     const { b, set } = await seed();
     actAs(b.id);
-    const res = await deleteSet(new Request('http://t/api', { method: 'DELETE' }), {
-      params: Promise.resolve({ id: set.id }),
-    });
+    const res = await deleteSet(new Request('http://t/api', { method: 'DELETE' }), idParams(set.id));
     expect(res.status).toBe(404);
     // The set must still exist - no cross-user deletion.
     expect(await db.set.findUnique({ where: { id: set.id } })).not.toBeNull();
   });
 });
 
-describe('route ownership: PUT /api/sessions/[id]', () => {
-  it('lets the owner update their session', async () => {
+describe('route ownership: /api/sessions/[id]', () => {
+  it('lets the owner read and update their session', async () => {
     const { a, session } = await seed();
     actAs(a.id);
-    const res = await putSession(jsonReq('PUT', { notes: 'mine' }), {
-      params: Promise.resolve({ id: session.id }),
-    });
-    expect(res.status).toBe(200);
+    const get = await getSession(new Request('http://t/api'), idParams(session.id));
+    expect(get.status).toBe(200);
+    const put = await putSession(jsonReq('PUT', { notes: 'mine' }), idParams(session.id));
+    expect(put.status).toBe(200);
     expect((await db.session.findUnique({ where: { id: session.id } }))?.notes).toBe('mine');
   });
 
-  it("returns 404 and leaves the session untouched for a stranger", async () => {
+  it('returns 404 to a stranger on GET, PUT and DELETE and leaves the session intact', async () => {
     const { b, session } = await seed();
     actAs(b.id);
-    const res = await putSession(jsonReq('PUT', { notes: 'hacked' }), {
-      params: Promise.resolve({ id: session.id }),
-    });
-    expect(res.status).toBe(404);
-    expect((await db.session.findUnique({ where: { id: session.id } }))?.notes).toBe('original');
+    expect((await getSession(new Request('http://t/api'), idParams(session.id))).status).toBe(404);
+    expect(
+      (await putSession(jsonReq('PUT', { notes: 'hacked' }), idParams(session.id))).status,
+    ).toBe(404);
+    expect(
+      (await deleteSession(new Request('http://t/api', { method: 'DELETE' }), idParams(session.id)))
+        .status,
+    ).toBe(404);
+    const row = await db.session.findUnique({ where: { id: session.id } });
+    expect(row?.notes).toBe('original');
   });
 });
 
-describe('route ownership: GET /api/exercises/[id]', () => {
+describe('route ownership: /api/exercises/[id]', () => {
   it('lets the owner read their exercise', async () => {
     const { a, exercise } = await seed();
     actAs(a.id);
-    const res = await getExercise(new Request('http://t/api'), { params: Promise.resolve({ id: exercise.id }) });
+    const res = await getExercise(new Request('http://t/api'), idParams(exercise.id));
     expect(res.status).toBe(200);
     expect((await res.json()).id).toBe(exercise.id);
   });
 
-  it("returns 404 for a stranger reading someone else's exercise", async () => {
+  it('returns 404 to a stranger on GET, PUT and DELETE and leaves the exercise intact', async () => {
     const { b, exercise } = await seed();
     actAs(b.id);
-    const res = await getExercise(new Request('http://t/api'), { params: Promise.resolve({ id: exercise.id }) });
+    expect((await getExercise(new Request('http://t/api'), idParams(exercise.id))).status).toBe(404);
+    const put = await putExercise(
+      jsonReq('PUT', { name: 'Hacked', muscleGroup: 'CHEST', category: 'COMPOUND' }),
+      idParams(exercise.id),
+    );
+    expect(put.status).toBe(404);
+    expect(
+      (await deleteExercise(new Request('http://t/api', { method: 'DELETE' }), idParams(exercise.id)))
+        .status,
+    ).toBe(404);
+    expect((await db.exercise.findUnique({ where: { id: exercise.id } }))?.name).toBe('Bench');
+  });
+});
+
+describe('route ownership: /api/programs/[id]', () => {
+  it('lets the owner read and update their program', async () => {
+    const { a, program } = await seed();
+    actAs(a.id);
+    expect((await getProgram(new Request('http://t/api'), idParams(program.id))).status).toBe(200);
+    const put = await putProgram(
+      jsonReq('PUT', { name: 'Block 2', phase: 'strength' }),
+      idParams(program.id),
+    );
+    expect(put.status).toBe(200);
+  });
+
+  it('returns 404 to a stranger on GET, PUT and DELETE and leaves the program intact', async () => {
+    const { b, program } = await seed();
+    actAs(b.id);
+    expect((await getProgram(new Request('http://t/api'), idParams(program.id))).status).toBe(404);
+    expect(
+      (await putProgram(jsonReq('PUT', { name: 'Stolen', phase: 'x' }), idParams(program.id)))
+        .status,
+    ).toBe(404);
+    expect(
+      (await deleteProgram(new Request('http://t/api', { method: 'DELETE' }), idParams(program.id)))
+        .status,
+    ).toBe(404);
+    const row = await db.program.findUnique({ where: { id: program.id } });
+    expect(row?.name).toBe('Block 1');
+  });
+});
+
+describe('route ownership: /api/workouts/[id]', () => {
+  it('lets the owner update their workout', async () => {
+    const { a, workout } = await seed();
+    actAs(a.id);
+    const res = await putWorkout(
+      jsonReq('PUT', { name: 'Push B', dayOfWeek: 1 }),
+      idParams(workout.id),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 404 to a stranger on PUT and DELETE and leaves the workout intact', async () => {
+    const { b, workout } = await seed();
+    actAs(b.id);
+    expect(
+      (await putWorkout(jsonReq('PUT', { name: 'Stolen', dayOfWeek: 1 }), idParams(workout.id)))
+        .status,
+    ).toBe(404);
+    expect(
+      (await deleteWorkout(new Request('http://t/api', { method: 'DELETE' }), idParams(workout.id)))
+        .status,
+    ).toBe(404);
+    expect((await db.workout.findUnique({ where: { id: workout.id } }))?.name).toBe('Push A');
+  });
+});
+
+describe('route ownership: /api/program-exercises/[id]', () => {
+  it('returns 404 to a stranger (using their own exercise id) and leaves the row intact', async () => {
+    const { b, exercise, exerciseB, programExercise } = await seed();
+    actAs(b.id);
+    // The stranger passes their own valid exercise so the exercise check
+    // cannot mask the program-exercise ownership check.
+    const body = {
+      exerciseId: exerciseB.id,
+      targetSets: 5,
+      targetRepsMin: 5,
+      targetRepsMax: 8,
+      targetRIR: 1,
+      restSec: 90,
+    };
+    expect((await putProgramExercise(jsonReq('PUT', body), idParams(programExercise.id))).status).toBe(
+      404,
+    );
+    expect(
+      (
+        await deleteProgramExercise(
+          new Request('http://t/api', { method: 'DELETE' }),
+          idParams(programExercise.id),
+        )
+      ).status,
+    ).toBe(404);
+    const row = await db.programExercise.findUnique({ where: { id: programExercise.id } });
+    expect(row?.exerciseId).toBe(exercise.id);
+    expect(row?.targetSets).toBe(3);
+  });
+});
+
+describe('route ownership: /api/coach/chat/[id]', () => {
+  it('lets the owner read their conversation', async () => {
+    const { a, conversation } = await seed();
+    actAs(a.id);
+    const res = await getChat(new Request('http://t/api'), idParams(conversation.id));
+    expect(res.status).toBe(200);
+    expect((await res.json()).messages).toHaveLength(1);
+  });
+
+  it('returns 404 to a stranger on GET and DELETE and keeps the conversation', async () => {
+    const { b, conversation } = await seed();
+    actAs(b.id);
+    expect((await getChat(new Request('http://t/api'), idParams(conversation.id))).status).toBe(404);
+    expect(
+      (await deleteChat(new Request('http://t/api', { method: 'DELETE' }), idParams(conversation.id)))
+        .status,
+    ).toBe(404);
+    expect(await db.conversation.findUnique({ where: { id: conversation.id } })).not.toBeNull();
+  });
+});
+
+describe('route ownership: DELETE /api/mcp-tokens/[id]', () => {
+  it('lets the owner revoke their token', async () => {
+    const { a, mcpToken } = await seed();
+    actAs(a.id);
+    const res = await deleteMcpToken(
+      new Request('http://t/api', { method: 'DELETE' }),
+      idParams(mcpToken.id),
+    );
+    expect(res.status).toBe(200);
+    expect(
+      (await db.mcpAccessToken.findUnique({ where: { id: mcpToken.id } }))?.revokedAt,
+    ).not.toBeNull();
+  });
+
+  it("returns 404 and leaves the token active when a stranger tries to revoke it", async () => {
+    const { b, mcpToken } = await seed();
+    actAs(b.id);
+    const res = await deleteMcpToken(
+      new Request('http://t/api', { method: 'DELETE' }),
+      idParams(mcpToken.id),
+    );
     expect(res.status).toBe(404);
+    expect((await db.mcpAccessToken.findUnique({ where: { id: mcpToken.id } }))?.revokedAt).toBeNull();
+  });
+});
+
+describe('route ownership: /api/gyms/[id]', () => {
+  it('lets the owner rename their gym', async () => {
+    const { a, gym } = await seed();
+    actAs(a.id);
+    const res = await putGym(jsonReq('PUT', { name: 'Garage' }), idParams(gym.id));
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 404 to a stranger on PUT and DELETE and leaves the gym intact', async () => {
+    const { b, gym } = await seed();
+    actAs(b.id);
+    expect((await putGym(jsonReq('PUT', { name: 'Stolen' }), idParams(gym.id))).status).toBe(404);
+    expect(
+      (await deleteGym(new Request('http://t/api', { method: 'DELETE' }), idParams(gym.id))).status,
+    ).toBe(404);
+    expect((await db.gym.findUnique({ where: { id: gym.id } }))?.name).toBe('Home gym');
+  });
+});
+
+describe('route ownership: POST /api/coach/[id]/apply', () => {
+  it("returns 404 and does not mark the debrief applied for a stranger", async () => {
+    const { b, coachSession } = await seed();
+    actAs(b.id);
+    const res = await postCoachApply(
+      jsonReq('POST', { adjustments: [{ exerciseName: 'Bench', summary: 'go up' }] }),
+      idParams(coachSession.id),
+    );
+    expect(res.status).toBe(404);
+    expect(
+      (await db.coachSession.findUnique({ where: { id: coachSession.id } }))?.appliedAt,
+    ).toBeNull();
+  });
+});
+
+describe('route ownership: nested creation and activation routes', () => {
+  it("returns 404 when a stranger activates someone else's program and leaves it inactive", async () => {
+    const { b, program } = await seed();
+    actAs(b.id);
+    const res = await activateProgram(jsonReq('POST', {}), idParams(program.id));
+    expect(res.status).toBe(404);
+    expect((await db.program.findUnique({ where: { id: program.id } }))?.isActive).toBe(false);
+  });
+
+  it("returns 404 when a stranger adds a workout to someone else's program", async () => {
+    const { b, program } = await seed();
+    actAs(b.id);
+    const res = await addWorkout(jsonReq('POST', { name: 'Injected' }), idParams(program.id));
+    expect(res.status).toBe(404);
+    expect(await db.workout.count({ where: { programId: program.id } })).toBe(1);
+  });
+
+  it("returns 404 when a stranger adds an exercise to someone else's workout", async () => {
+    const { b, exerciseB, workout } = await seed();
+    actAs(b.id);
+    const res = await addProgramExercise(
+      jsonReq('POST', {
+        exerciseId: exerciseB.id,
+        targetSets: 3,
+        targetRepsMin: 8,
+        targetRepsMax: 12,
+        targetRIR: 2,
+        restSec: 120,
+      }),
+      idParams(workout.id),
+    );
+    expect(res.status).toBe(404);
+    expect(await db.programExercise.count({ where: { workoutId: workout.id } })).toBe(1);
+  });
+
+  it("returns 404 when a stranger logs a set into someone else's session", async () => {
+    const { b, exerciseB, session } = await seed();
+    actAs(b.id);
+    const res = await addSet(
+      jsonReq('POST', { exerciseId: exerciseB.id, setNumber: 2, weight: 100, reps: 5 }),
+      idParams(session.id),
+    );
+    expect(res.status).toBe(404);
+    expect(await db.set.count({ where: { sessionId: session.id } })).toBe(1);
+  });
+
+  it("returns 404 when a stranger activates someone else's gym and keeps their setting", async () => {
+    const { b, gym } = await seed();
+    actAs(b.id);
+    const res = await activateGym(new Request('http://t/api', { method: 'POST' }), idParams(gym.id));
+    expect(res.status).toBe(404);
+    expect((await db.user.findUnique({ where: { id: b.id } }))?.activeGymId).toBeNull();
+  });
+});
+
+describe('route ownership: GET /api/history/csv', () => {
+  it("exports only the caller's own sets", async () => {
+    const { a, b, session } = await seed();
+    await db.session.update({
+      where: { id: session.id, userId: a.id },
+      data: { finishedAt: new Date() },
+    });
+    actAs(b.id);
+    const res = await getHistoryCsv(new Request('http://t/api/history/csv'));
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    // User A's exercise must not leak into user B's export.
+    expect(body).not.toContain('Bench');
   });
 });


### PR DESCRIPTION
Implements #317, green-lit by the operator in-session (auth surface). Born from the external-contributions security challenge: the fetch-then-compare ownership shape meant a one-line deletion inside plausible feature code could expose cross-user reads/writes while compiling and passing CI.

## What changed

- **Ownership is now the query, not a check before the query.** Reads: `findFirst({ id, userId })` (or relation-scoped: `program: { userId }`, `workout: { program: { userId } }`, `conversation: { userId }`). Writes: `update`/`delete` carry the owner scope in their own `where` (Prisma 7 filtered unique where); a stranger's id becomes P2025, which `handleApiError` already maps to 404.
- 11 route files hardened: programs, sessions, exercises, workouts, program-exercises, coach/chat, gyms, mcp-tokens, coach/apply, programs/activate + workouts, workouts/program-exercises, sessions/sets, history/csv (typed `Prisma.SessionWhereInput` so deleting the `userId` scope is a compile-visible change).
- **Behavior is unchanged for owners**; strangers keep getting 404 (one deliberate fix: program-exercises PUT kept its 404-before-400 ordering via a scoped probe - the pre-existing superset ownership test caught the regression during development and the route was fixed, not the test).

## Tests

- `route-ownership.test.ts`: 3 routes covered before, 12 now - owner + stranger cases per verb with data-intact assertions, plus a cross-user history CSV leak check.
- New **coverage ratchet** `route-ownership-coverage.test.ts`: every `app/api/**/[id]**/route.ts` must be referenced by an ownership-aware suite or be explicitly mapped to its dedicated one; a new [id] route without a cross-user test fails CI. It caught 3 routes with zero ownership coverage (gym/program activate, program workouts) during this change - now covered.

## Verification

- `bash scripts/verify.sh --full` green locally (integration 269/269 including the 45 ownership tests, E2E 17/17).

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012otoLMg46wo2YJGTiJPUNm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Strengthened ownership checks across sessions, exercises, programs, workouts, gyms, coach chats, tokens, photos, measurements, goals, and related operations.
  * Prevented unauthorized users from viewing, modifying, deleting, exporting, or applying changes to resources they do not own.
  * Standardized unauthorized resource responses to avoid exposing protected data.

* **Tests**
  * Expanded integration coverage for ownership and access-control behavior across API routes.
  * Added automated coverage checks to ensure resource routes remain represented by ownership tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->