### PR TITLE
perf(db): index the referencing side of Set.gymEquipmentId

### DIFF
--- a/prisma/migrations/20260904090000_index_set_gym_equipment/migration.sql
+++ b/prisma/migrations/20260904090000_index_set_gym_equipment/migration.sql
@@ -1,0 +1,5 @@
+-- Index the referencing side of Set.gymEquipmentId (issue #325). The foreign
+-- key's ON DELETE SET NULL is executed by Postgres, which does not index the
+-- referencing column on its own, so deleting an equipment item (or a gym,
+-- which cascades to its equipment) had to scan the whole "Set" table per row.
+CREATE INDEX IF NOT EXISTS "Set_gymEquipmentId_completedAt_idx" ON "Set"("gymEquipmentId", "completedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -374,6 +374,11 @@ model Set {
   completedAt                    DateTime      @default(now())
 
   @@index([exerciseId, completedAt])
+  // Leading on gymEquipmentId so the FK referential action (ON DELETE SET
+  // NULL, executed by Postgres since relationMode is unset) can locate the
+  // referencing rows without a full scan when equipment or a gym is deleted;
+  // completedAt also serves per-equipment history queries (issue #325).
+  @@index([gymEquipmentId, completedAt])
 }
 
 // Per-exercise target goal (issue #90): a concrete "weight x reps" the user


### PR DESCRIPTION
## Summary

`Set.gymEquipmentId` is a foreign key to `GymEquipment` with `onDelete: SetNull`, and `relationMode` is unset, so Postgres executes the referential action itself. Postgres does not index the referencing side of a foreign key, and the only index on `Set` was `[exerciseId, completedAt]`, so deleting one equipment item, deleting a gym (cascades to its equipment) or restoring a backup (`gym.deleteMany({ where: { userId } })`) had to scan the whole `Set` table once per equipment row.

This restores the composite `[gymEquipmentId, completedAt]` index that the #313 review removed as reader-less. Its reader is the referential action, not an application query, and the leading column serves it; `completedAt` also serves any future per-equipment history query.

- `prisma/schema.prisma`: `@@index([gymEquipmentId, completedAt])` on `model Set`, with a comment naming the FK-side reader.
- `prisma/migrations/20260904090000_index_set_gym_equipment/migration.sql`: `CREATE INDEX IF NOT EXISTS "Set_gymEquipmentId_completedAt_idx" ...`. Same name Prisma generates for the `@@index`. `IF NOT EXISTS` because the original index was dropped by editing the earlier migration in place rather than with a drop migration, so a dev database that applied the pre-review version still holds it and would otherwise fail this migration.

No CHANGELOG edit: that file is maintained by the write-up ticks.

Closes #325

## How I tested

- `DATABASE_URL=<test :5434> npx prisma migrate deploy`: applies `20260904090000_index_set_gym_equipment` cleanly.
- `DATABASE_URL=<test :5434> npx prisma migrate diff --from-config-datasource --to-schema prisma/schema.prisma --exit-code`: "No difference detected", exit 0 (migration and schema agree).
- `bash scripts/verify.sh --full`: GREEN-GATE PASSED. prisma generate, lint, typecheck, unit 1004/1004 (104 files), production build, integration 295/295 (32 files), E2E 18 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFnkrDYab4mFtJyaHeFUEF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved handling of equipment-related history queries and deletion operations.
  * Added database indexing to support faster retrieval of completed sets by equipment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->