### PR TITLE
feat(session): tell the user when an equipment selection was not recorded

### DIFF
--- a/components/session/session-runner.tsx
+++ b/components/session/session-runner.tsx
@@ -40,7 +40,7 @@ import {
   SUPERSET_TRANSITION_REST_SEC,
 } from '@/lib/supersets';
 import { isReadinessAutoRegulationEnabled } from '@/lib/preferences';
-import { bindAutoSync, flushPendingSets, queueSet } from '@/lib/sync';
+import { bindAutoSync, flushPendingSets, onEquipmentDropped, queueSet } from '@/lib/sync';
 import { hydrateFromServerSets } from '@/lib/sync-hydration';
 import { ExerciseCard } from '@/components/session/exercise-card';
 import { SetsList } from '@/components/session/sets-list';
@@ -151,6 +151,11 @@ export function SessionRunner({
   // the suggestion falls back to pure programmed progression (pre-#55 behavior).
   const effectiveReadiness = readinessForSuggestion(readiness, autoRegulate);
 
+  // Equipment ids the server refused to attach during this session (issue
+  // #326): the item was deleted, unlinked or moved. They are withdrawn from the
+  // picker so the next set does not resend a reference that will be dropped.
+  const [droppedEquipmentIds, setDroppedEquipmentIds] = useState<string[]>([]);
+
   // Hydrate IndexedDB with the server sets, then enable auto-sync.
   useEffect(() => {
     setAutoRegulate(isReadinessAutoRegulationEnabled());
@@ -161,10 +166,22 @@ export function SessionRunner({
     void acquireWakeLock();
     const cleanupVisibility = bindWakeLockToVisibility();
     const cleanupSync = bindAutoSync();
+    // The flush runs in the background, so a dropped equipment reference is
+    // reported here rather than returned to handleValidate. The set itself is
+    // saved; the user only learns that the machine was not recorded.
+    const cleanupDropped = onEquipmentDropped((dropped) => {
+      const mine = dropped.filter((entry) => entry.sessionId === session.id);
+      if (mine.length === 0) return;
+      setDroppedEquipmentIds((prev) => [
+        ...new Set([...prev, ...mine.map((entry) => entry.gymEquipmentId)]),
+      ]);
+      toast.warning(t('equipmentDropped'));
+    });
     return () => {
       void releaseWakeLock();
       cleanupVisibility();
       cleanupSync();
+      cleanupDropped();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -534,8 +551,10 @@ export function SessionRunner({
             recommendation={currentRecommendation}
             returnRecommendation={currentReturnRecommendation}
             loadConstraints={loadConstraintsFor(currentTarget)}
-            equipmentOptions={(session.gym?.equipment ?? []).filter((item) =>
-              item.exerciseLinks.some((link) => link.exerciseId === currentPE.exerciseId),
+            equipmentOptions={(session.gym?.equipment ?? []).filter(
+              (item) =>
+                !droppedEquipmentIds.includes(item.id) &&
+                item.exerciseLinks.some((link) => link.exerciseId === currentPE.exerciseId),
             )}
             onSubmit={handleValidate}
           />

--- a/components/session/set-input.test.tsx
+++ b/components/session/set-input.test.tsx
@@ -458,6 +458,40 @@ describe('SetInput AI parse', () => {
     expect(screen.getByRole('combobox')).toHaveValue('machine-1');
   });
 
+  it('clears a selected machine the gym no longer offers (issue #326)', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const props = {
+      programExercise: pe,
+      existingSets: [],
+      lastPerformance: undefined,
+      readiness: null,
+      deloadActive: false,
+      unit: 'KG' as const,
+      onSubmit,
+    };
+    const { rerender } = render(
+      <SetInput
+        {...props}
+        equipmentOptions={[
+          { id: 'machine-1', name: 'Hammer Strength Squat' },
+          { id: 'machine-2', name: 'Plate-loaded Squat' },
+        ]}
+      />,
+    );
+    await user.selectOptions(screen.getByRole('combobox'), 'machine-1');
+    expect(screen.getByRole('combobox')).toHaveValue('machine-1');
+
+    // The runner withdraws the item once the server dropped it from a set.
+    rerender(
+      <SetInput {...props} equipmentOptions={[{ id: 'machine-2', name: 'Plate-loaded Squat' }]} />,
+    );
+
+    expect(screen.getByRole('combobox')).toHaveValue('');
+    await user.click(screen.getByRole('button', { name: /log the set/i }));
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ gymEquipmentId: null }));
+  });
+
   it('ignores a cardio parse on a strength exercise (wrong shape)', async () => {
     const user = userEvent.setup();
     stubFetch({ kind: 'cardio', durationSec: 1500 });

--- a/components/session/set-input.tsx
+++ b/components/session/set-input.tsx
@@ -142,6 +142,14 @@ export function SetInput({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [programExercise.id, existingSets.length]);
 
+  // A selected machine the gym no longer offers (issue #326: the server dropped
+  // it from a saved set and the runner withdrew it) must not be resent.
+  useEffect(() => {
+    if (gymEquipmentId && !equipmentOptions.some((equipment) => equipment.id === gymEquipmentId)) {
+      setGymEquipmentId('');
+    }
+  }, [equipmentOptions, gymEquipmentId]);
+
   const incrementKg = weightIncrement(programExercise.exercise.category);
   // Increment shown in the user's unit (clean plate jumps), applied to the
   // kg-stored weight. The form value stays in kg; only display/input convert.

--- a/lib/sync.test.ts
+++ b/lib/sync.test.ts
@@ -8,7 +8,7 @@ vi.mock('@/lib/indexeddb', async (importOriginal) => {
   return { ...actual, getDB: mockGetDB };
 });
 
-import { flushPendingSets } from '@/lib/sync';
+import { flushPendingSets, onEquipmentDropped } from '@/lib/sync';
 
 function pendingSet(): PendingSet {
   return {
@@ -29,6 +29,22 @@ function pendingSet(): PendingSet {
     syncedAt: null,
     attempts: 0,
     lastError: null,
+  };
+}
+
+// Minimal Dexie table stand-in: one queued item, patched in place by update().
+function fakeTable(item: PendingSet) {
+  return {
+    where: vi.fn(() => ({
+      anyOf: vi.fn(() => ({
+        sortBy: vi.fn(async () => [item]),
+        count: vi.fn(async () => (item.status === 'synced' ? 0 : 1)),
+      })),
+    })),
+    update: vi.fn(async (_id: string, patch: Partial<PendingSet>) => {
+      Object.assign(item, patch);
+      return 1;
+    }),
   };
 }
 
@@ -91,6 +107,79 @@ describe('offline set sync', () => {
     expect(item.status).toBe('synced');
     expect(item.serverId).toBe('server-set-1');
     expect(updates.at(-1)).toMatchObject({ status: 'synced', serverId: 'server-set-1' });
-    expect(result).toEqual({ flushed: 1, failed: 0, pending: 0 });
+    // The retry recorded the set without its equipment: that is a dropped
+    // reference like any other, so it is cleared locally and reported.
+    expect(item.gymEquipmentId).toBeNull();
+    expect(result).toEqual({
+      flushed: 1,
+      failed: 0,
+      pending: 0,
+      droppedEquipment: [
+        { localId: 'local-1', sessionId: 'session-1', gymEquipmentId: 'stale-equipment' },
+      ],
+    });
+  });
+
+  it('clears and reports an equipment reference the server recorded as null (issue #326)', async () => {
+    const item = pendingSet();
+    mockGetDB.mockReturnValue({ pendingSets: fakeTable(item) });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: 'server-set-2', gymEquipmentId: null }), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const listener = vi.fn();
+    const unsubscribe = onEquipmentDropped(listener);
+
+    const result = await flushPendingSets();
+    unsubscribe();
+
+    expect(item.status).toBe('synced');
+    expect(item.gymEquipmentId).toBeNull();
+    expect(result.droppedEquipment).toEqual([
+      { localId: 'local-1', sessionId: 'session-1', gymEquipmentId: 'stale-equipment' },
+    ]);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(result.droppedEquipment);
+  });
+
+  it('keeps an equipment reference the server attached and stays silent', async () => {
+    const item = pendingSet();
+    mockGetDB.mockReturnValue({ pendingSets: fakeTable(item) });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: 'server-set-3', gymEquipmentId: 'stale-equipment' }), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const listener = vi.fn();
+    const unsubscribe = onEquipmentDropped(listener);
+
+    const result = await flushPendingSets();
+    unsubscribe();
+
+    expect(item.gymEquipmentId).toBe('stale-equipment');
+    expect(result.droppedEquipment).toEqual([]);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('does not report a set that never carried an equipment reference', async () => {
+    const item = { ...pendingSet(), gymEquipmentId: null };
+    mockGetDB.mockReturnValue({ pendingSets: fakeTable(item) });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: 'server-set-4', gymEquipmentId: null }), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const listener = vi.fn();
+    const unsubscribe = onEquipmentDropped(listener);
+
+    const result = await flushPendingSets();
+    unsubscribe();
+
+    expect(result.droppedEquipment).toEqual([]);
+    expect(listener).not.toHaveBeenCalled();
   });
 });

--- a/lib/sync.ts
+++ b/lib/sync.ts
@@ -17,6 +17,31 @@ export interface FlushResult {
   flushed: number;
   failed: number;
   pending: number;
+  // Sets the server recorded WITHOUT the equipment reference that was sent
+  // (issue #326): the item was deleted, unlinked, belongs to another gym or
+  // another user. The set itself is saved; only the decoration was dropped.
+  droppedEquipment: DroppedEquipment[];
+}
+
+export interface DroppedEquipment {
+  localId: string;
+  sessionId: string;
+  gymEquipmentId: string;
+}
+
+type DroppedEquipmentListener = (dropped: DroppedEquipment[]) => void;
+
+const droppedEquipmentListeners = new Set<DroppedEquipmentListener>();
+
+// Subscribe to equipment references the server dropped while flushing. The
+// flush runs in the background (queueSet does not await it), so the session
+// UI cannot read the result directly; it listens here instead. Returns the
+// unsubscribe function.
+export function onEquipmentDropped(listener: DroppedEquipmentListener): () => void {
+  droppedEquipmentListeners.add(listener);
+  return () => {
+    droppedEquipmentListeners.delete(listener);
+  };
 }
 
 let inFlight: Promise<FlushResult> | null = null;
@@ -41,6 +66,7 @@ async function doFlush(): Promise<FlushResult> {
 
   let flushed = 0;
   let failed = 0;
+  const droppedEquipment: DroppedEquipment[] = [];
 
   for (const item of pending) {
     if (!navigator.onLine) {
@@ -93,13 +119,27 @@ async function doFlush(): Promise<FlushResult> {
         continue;
       }
 
-      const created = (await res.json()) as { id: string };
+      const created = (await res.json()) as { id: string; gymEquipmentId?: string | null };
+      // The server degrades a stale/foreign equipment reference to null rather
+      // than rejecting the set (issue #313). Mirror that on the local record so
+      // the next set does not pre-select a machine that was never attached, and
+      // report it so the UI can tell the user (issue #326).
+      const sentEquipmentId = payload.gymEquipmentId;
+      const equipmentDropped = sentEquipmentId !== null && !created.gymEquipmentId;
       await db.pendingSets.update(item.localId, {
         status: 'synced',
         serverId: created.id,
         syncedAt: Date.now(),
         lastError: null,
+        ...(equipmentDropped ? { gymEquipmentId: null } : {}),
       });
+      if (equipmentDropped) {
+        droppedEquipment.push({
+          localId: item.localId,
+          sessionId: item.sessionId,
+          gymEquipmentId: sentEquipmentId,
+        });
+      }
       flushed += 1;
     } catch (err) {
       // Network error (offline, timeout): we keep 'pending' to retry later.
@@ -113,7 +153,12 @@ async function doFlush(): Promise<FlushResult> {
   }
 
   const remaining = await db.pendingSets.where('status').anyOf(['pending', 'failed']).count();
-  return { flushed, failed, pending: remaining };
+  if (droppedEquipment.length > 0) {
+    for (const listener of droppedEquipmentListeners) {
+      listener(droppedEquipment);
+    }
+  }
+  return { flushed, failed, pending: remaining, droppedEquipment };
 }
 
 // Helper: adds a set to the queue (status pending) and triggers a flush.

--- a/messages/en/session.ts
+++ b/messages/en/session.ts
@@ -26,6 +26,8 @@ export const session = {
   setDeleteError: 'Could not delete the set.',
   finished: 'Session finished.',
   finishError: 'Could not finish the session.',
+  equipmentDropped:
+    'Set saved, but the equipment was not attached: it is no longer available in this gym.',
   rest: {
     title: 'Rest',
     seconds: 's',

--- a/messages/fr/session.ts
+++ b/messages/fr/session.ts
@@ -29,6 +29,8 @@ export const session = {
   setDeleteError: 'Impossible de supprimer la série.',
   finished: 'Séance terminée.',
   finishError: 'Impossible de terminer la séance.',
+  equipmentDropped:
+    'Série enregistrée, mais le matériel n’a pas été associé : il n’est plus disponible dans cette salle.',
   rest: {
     title: 'Repos',
     seconds: 's',

--- a/messages/ru/session.ts
+++ b/messages/ru/session.ts
@@ -29,6 +29,8 @@ export const session = {
   setDeleteError: 'Не удалось удалить подход.',
   finished: 'Тренировка завершена.',
   finishError: 'Не удалось завершить тренировку.',
+  equipmentDropped:
+    'Подход сохранён, но тренажёр не привязан: он больше недоступен в этом зале.',
   rest: {
     title: 'Отдых',
     seconds: 'с',

--- a/tests/integration/route-ownership.test.ts
+++ b/tests/integration/route-ownership.test.ts
@@ -424,6 +424,43 @@ describe('route ownership: nested creation and activation routes', () => {
     expect(await db.set.count({ where: { sessionId: session.id } })).toBe(1);
   });
 
+  it("saves a set but never attaches someone else's equipment to it", async () => {
+    const { b, exerciseB, gym } = await seed();
+    // Worst case on purpose: the stranger's session sits on the owner's gym
+    // and the owner's equipment is linked to the stranger's exercise (states
+    // the app never creates), so only the `gym: { userId }` scope in
+    // lib/set-equipment.ts stands between the caller and the foreign row.
+    // Equipment is optional decoration, so the set is saved (201) with the
+    // reference degraded to null rather than rejected (issue #313, #326).
+    const foreignEquipment = await db.gymEquipment.create({
+      data: {
+        gymId: gym.id,
+        name: 'Owner leg press',
+        equipmentType: 'MACHINE',
+        weightOptions: [50, 100],
+        exerciseLinks: { create: { exerciseId: exerciseB.id } },
+      },
+    });
+    const sessionB = await db.session.create({ data: { userId: b.id, gymId: gym.id } });
+    actAs(b.id);
+    const res = await addSet(
+      jsonReq('POST', {
+        exerciseId: exerciseB.id,
+        gymEquipmentId: foreignEquipment.id,
+        setNumber: 1,
+        weight: 100,
+        reps: 5,
+      }),
+      idParams(sessionB.id),
+    );
+    expect(res.status).toBe(201);
+    const created = await res.json();
+    expect(created.gymEquipmentId).toBeNull();
+    expect(created.equipmentNameSnapshot).toBeNull();
+    expect(created.equipmentLoadSnapshot).toBeNull();
+    expect(await db.set.count({ where: { gymEquipmentId: foreignEquipment.id } })).toBe(0);
+  });
+
   it("returns 404 when a stranger activates someone else's gym and keeps their setting", async () => {
     const { b, gym } = await seed();
     actAs(b.id);


### PR DESCRIPTION
## Summary

Since #313 a set whose equipment reference went stale (item deleted, unlinked from the exercise, wrong gym, or another user's row) is saved with `gymEquipmentId: null` instead of being rejected. That was silent: the request returned 201, the picker kept the machine selected, and nothing told the user the equipment was not attached.

- **`lib/sync.ts`**: when the 201 comes back with a null `gymEquipmentId` although one was sent, the local IndexedDB record is nulled too (so the next set does not pre-select a machine that was never attached), the drop is reported in `FlushResult.droppedEquipment`, and `onEquipmentDropped` subscribers are notified. The flush runs in the background (`queueSet` does not await it), so a subscription is the only way the session UI can learn about it. The existing 400-retry-without-equipment path is reported the same way, since it records the set without its equipment as well.
- **`components/session/session-runner.tsx`**: subscribes for the current session, shows a brief non-blocking `toast.warning` and withdraws the dropped ids from the equipment picker for the rest of the session.
- **`components/session/set-input.tsx`**: clears a selection the options no longer offer, so it is not resent with the next set.
- **i18n**: `session.equipmentDropped` added to `en`, `ru` and `fr`.
- **Tests**: `lib/sync.test.ts` covers the dropped / attached / never-sent paths and the listener; `set-input.test.tsx` covers the cleared selection; the cross-user equipment id case is added to `tests/integration/route-ownership.test.ts`, which already enumerates `sessions/[id]/sets`. It seeds the worst case on purpose (stranger's session on the owner's gym, owner's equipment linked to the stranger's exercise) so only the `gym: { userId }` scope in `lib/set-equipment.ts` stands between the caller and the foreign row: the set is saved (201) with `gymEquipmentId` and both snapshots null, and no set references the foreign row.

No schema or migration changes.

Closes #326

## How I tested

```
npm ci && npm rebuild bcrypt && npx prisma generate
DATABASE_URL=postgresql://gymcoach_test:gymcoach_test@localhost:5434/gymcoach_test npx prisma migrate deploy
bash scripts/verify.sh --full
```

`scripts/verify.sh --full` passed, exit 0:

- prisma generate, lint, typecheck: green
- unit: 104 files, 1008 tests passed
- production build: green
- integration: 32 files, 296 tests passed (ran after waiting on the shared-infra flock held by a concurrent tick)
- E2E: 18 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFnkrDYab4mFtJyaHeFUEF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Saved sets now remain valid when referenced equipment is unavailable or removed.
  - Unavailable equipment associations are cleared before submission and no longer appear in subsequent equipment selections.
  - Users are notified when a set is saved without its unavailable equipment association.

- **Localization**
  - Added English, French, and Russian messages for unavailable equipment notifications.

- **Tests**
  - Added coverage for equipment removal, synchronization cleanup, dropped references, and ownership-related equipment restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->