### PR TITLE
docs: write up the 2026-09-04 wave (#334-#336) and answer the MCP direction proposal (#331)

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -58,7 +58,14 @@ for repo conventions; this skill assumes them.
 5. **Green-gate (self-verify).** Run `bash scripts/verify.sh`. (In a fresh checkout or git
    worktree, first `npm ci` - worktrees do not share `node_modules` - then `npm rebuild
    bcrypt` if its native binding is missing, and `prisma migrate deploy` against the test
-   Postgres on :5434 before the integration/E2E tiers. Lesson L4.) If it fails:
+   Postgres on :5434 before the integration/E2E tiers. Lesson L4.)
+   **Run bootstrap and the gate synchronously - never end the turn waiting on a background
+   process.** A tick is not re-woken when a backgrounded `npm ci`, `npm run build` or
+   `next start` finishes: the turn simply ends and the orchestrator has to resume it, which
+   is what happened to two of the three dev ticks on 2026-09-04 (lesson L21). Give the call
+   a long timeout instead of backgrounding it, and when a server is genuinely needed, poll
+   it until it answers rather than reporting "waiting for the background job".
+   If it fails:
    - Read the failing step (acknowledge what it actually says), fix the cause, re-run.
    - **Fix the code, never the test** (CLAUDE.md): never delete/skip a test, loosen an
      assertion, or silence an error to get green - that is a defect, not a fix.

--- a/.claude/skills/ship-pr/SKILL.md
+++ b/.claude/skills/ship-pr/SKILL.md
@@ -42,8 +42,14 @@ changes on.
    Also skip if: draft, `state != OPEN`, `reviewDecision == CHANGES_REQUESTED`, or not
    targeting `main`. Report why it was skipped.
 
-2. **Watch CI.** `gh pr checks <n> --watch` (blocks until checks settle), or poll
-   `gh pr checks <n>`. Three outcomes:
+2. **Watch CI.** `gh pr checks <n> --watch` blocks until the checks settle - but do not
+   rely on it: this environment's `gh` is 2.4.0 and has no `--watch`, so it prints
+   `unknown flag: --watch` and **exits 0**, which reads as "all green" to anything that
+   checks the exit status (lesson L5). **Poll instead:**
+   `gh pr view <n> --json statusCheckRollup` (or `gh pr checks <n>` in a loop) until every
+   check has a conclusion, and decide on the conclusions themselves, never on an exit
+   code. Resolve them against the head SHA you are about to merge, not against the PR
+   (lesson L19). Three outcomes:
    - **All green** -> go to step 4 (review).
    - **Some red** -> step 3 (fix).
    - **Stuck pending** for an unreasonable time -> stop, report; do not merge.
@@ -86,6 +92,11 @@ changes on.
    commit for stacks, no `--delete-branch` on a fork, and the SHA pin makes a push race
    between review and merge fail closed). Confirm it merged
    (`gh pr view <n> --json state,mergedAt`).
+   **`--delete-branch` fails after a successful merge when the branch is checked out in a
+   worktree**: `gh` cannot delete a branch that some working tree still has checked out, so
+   it exits 1 *after* the merge landed - the PR is merged and the remote branch survives.
+   Never re-run the merge on that exit code. Confirm the merge, then clean up by hand:
+   `git push origin --delete <branch>` and `git worktree remove <path>`.
 
 6. **Report.** PR -> merged (with the merge commit), or skipped/blocked with the reason.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- French as a third interface language: the whole UI is now available in
+  English, French and Russian, picked in Settings, with an unknown locale still
+  falling back to English.
 - Physical gym equipment inventory: each saved gym can now hold the concrete
   stations and items you actually train on (name, type, description,
   manufacturer, model, quantity, item-specific weight options), linked to the
@@ -377,6 +380,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The logger no longer stays silent when the equipment you picked was not
+  recorded. A set whose equipment reference had gone stale by the time it
+  reached the server (the item was deleted, unlinked from the exercise, or
+  belongs to another gym) is still saved, with the equipment simply dropped -
+  but nothing said so, and the picker kept offering the same stale machine for
+  the next set. Sets now come back through the background sync with that signal
+  attached: the session shows a non-blocking warning, withdraws the dropped item
+  from the picker, and clears a selection the picker no longer offers.
+- The exercise catalog is readable at phone width again. Each card now leads
+  with a fixed technique thumbnail (or a muted placeholder when the exercise has
+  no media), the exercise name takes the remaining width and wraps to two lines
+  instead of truncating mid-word, the equipment badge became a compact label
+  that shares one line with the rest time, and edit/delete moved to their own
+  row on narrow screens.
+- Deleting a piece of gym equipment, deleting a gym, or restoring a backup no
+  longer scans the whole set table once per equipment item. `Set.gymEquipmentId`
+  is the referencing side of a foreign key with `ON DELETE SET NULL`, and
+  Postgres does not index that side on its own, so the composite index it needs
+  is back.
 - An authenticated `GET /mcp` no longer hangs forever. The endpoint serves the
   MCP Streamable HTTP transport statelessly, so there is no event stream for a
   GET to attach to and the response was never written or closed; unauthenticated

--- a/README.md
+++ b/README.md
@@ -82,10 +82,12 @@ on your own key - all self-hosted.
 - **Your actual gym, not a generic one** - describe the concrete stations and
   items you train on (type, manufacturer, model, quantity, item-specific weight
   options, an optional photo), link them to the exercises they serve, and the
-  equipment you used is recorded on every set you log.
-- **Quality-of-life** - kilograms or pounds per user, an interface in English or
-  Russian (extensible message catalogs), multi-user with strict per-user data
-  isolation, and an installable PWA with offline logging.
+  equipment you used is recorded on every set you log. If a selection cannot be
+  recorded (the item was deleted or unlinked while you trained), the set is
+  still saved and the logger says so instead of dropping it silently.
+- **Quality-of-life** - kilograms or pounds per user, an interface in English,
+  French or Russian (extensible message catalogs), multi-user with strict
+  per-user data isolation, and an installable PWA with offline logging.
 
 ### Track progress
 
@@ -372,7 +374,8 @@ than CI reaching in to a small VPS.
 - [x] Free-text (AI-parsed) set logging (opt-in "Parse with AI" fills the set
       form from plain language; you confirm before it logs)
 - [x] Progress photos (local-only upload with side-by-side compare)
-- [x] Interface localization (English and Russian, extensible message catalogs)
+- [x] Interface localization (English, French and Russian, extensible message
+      catalogs)
 - [x] Muscle heat map (body silhouettes tinted by weekly volume vs MEV/MRV)
 - [x] Physical gym equipment inventory, with the equipment used recorded on
       each logged set
@@ -395,7 +398,10 @@ Notable changes are tracked in the [CHANGELOG](CHANGELOG.md).
   (#276). Along the way they also found and fixed a latent `.gitignore` bug
   that shadowed an API route in fresh clones. Then a second series:
   return-to-training calibration (#311), the physical gym equipment inventory
-  (#312) and the equipment recorded on each logged set (#313).
+  (#312) and the equipment recorded on each logged set (#313). They also
+  proposed making MCP a first-class "external deep coach" interface (#331); the
+  sequencing is answered on that issue, and its one web-app-only piece is
+  tracked as #333.
 - [@mvnixon](https://github.com/mvnixon) - reported the `GET /mcp` hang that
   stopped MCP clients probing with GET from connecting at all (#314), and
   made the case for publishing the production image so self-hosters can pull

--- a/docs/loops/06-orchestration.md
+++ b/docs/loops/06-orchestration.md
@@ -116,3 +116,17 @@ reverted forward, re-shipped as PR #279).
 - **If a commit still lands on `main`, revert forward** (a revert commit restoring `main`'s
   content), never `git push --force` shared history (it is denied anyway), then re-ship the
   work through a proper PR.
+
+**Confirmed pattern (2026-09-04): worktree-per-tick is the way to run dev ticks in
+parallel.** Three dev ticks ran at once, each in its own `../gymcoach-wt-<issue>` worktree
+branched from the same base, on issues chosen to be file-disjoint. Result: three PRs, zero
+merge conflicts, three green first-pass CI runs, no `main` breach. The two pieces that make
+it work are both already above - a worktree per tick for the git-state race (L15), and the
+shared-infra `flock` for the test Postgres and dev port (L16), which serialized the three
+`--full` gates without anyone coordinating them. So the recipe is: pick file-disjoint issues
+(step 4's same-file serialization still applies - it decides *what* may run in parallel,
+worktrees only decide *where*), `git worktree add ../gymcoach-wt-<n>` per tick, `npm ci` +
+`npm rebuild bcrypt` + `prisma migrate deploy` in each (L4), let the ticks stop at the PR
+(L3), and ship them one at a time. Clean up with `git worktree remove` after the merge -
+and note that `gh pr merge --delete-branch` exits 1 after a successful merge while the
+branch is still checked out in a worktree (see the `ship-pr` skill, step 5).

--- a/docs/loops/autonomy-log.md
+++ b/docs/loops/autonomy-log.md
@@ -2249,3 +2249,147 @@ ran on Fable per the model-routing directive; all reviews and this write-up ran 
 (tell the user when an equipment selection was not recorded), #320 (browsable exercise library),
 #300-#304 (the rest of the "make it pop" ideas), and the demo-media re-shoot, still the oldest debt
 in the repo and now further behind: the session logger grew an equipment picker this wave.
+
+
+## 2026-09-04 - three dev ticks in parallel worktrees (#334/#335/#336), and an external design proposal answered inside the tick (#331)
+
+**What ran.** Three loop-authored dev ticks in parallel, one `git worktree` each, on three
+file-disjoint issues left over from the previous wave: #325 (the FK index the 08-27 review
+had wrongly told a contributor to delete), #326 (the equipment selection that could be
+dropped silently) and #330 (the exercise catalog card at phone width). Each PR got an
+independent Opus skeptic review before merge - the author never grades its own homework -
+and each was squash-merged on green CI. Alongside them, one external design proposal (#331)
+was vetted and answered, and its one loop-adoptable piece was filed as #333. Triage and
+ideate did not run. Earlier the same day the operator's own French-locale branch merged
+(#332), which is why this write-up also touches the localization lines in the README and
+the CHANGELOG.
+
+**Three ticks, three worktrees, zero coordination.** This is the first batch run as
+deliberate parallel dev work, and it is worth recording as a success because the two
+controls that make it safe were both already in place and neither needed attention during
+the run. Each tick got `../gymcoach-wt-<n>` off the same base (L15: a git checkout is
+single-writer state), and the three `--full` gates serialized themselves on the machine-wide
+`flock` added by #298 (L16: worktrees fix the git race, not the shared test Postgres and dev
+port). Result: three PRs, zero merge conflicts, three green first-pass CI runs, no `main`
+breach. The one thing the orchestrator still owns is the choice of issues - the same-file
+serialization rule decides *what* may run in parallel; worktrees only decide *where*. Now
+written into `06-orchestration.md` as the confirmed pattern rather than a contingency.
+
+**The index the loop had told a contributor to delete (#325 -> #334).** The 08-27 review of
+SHAREN's #313 called `Set_gymEquipmentId_completedAt_idx` reader-less, and SHAREN removed it
+on that basis; the advisory CodeRabbit lens had the mechanism right where the loop's own
+review had it wrong (lesson L20). The reader is the referential action: the FK is
+`ON DELETE SET NULL` with `relationMode` unset, so Postgres itself locates the referencing
+`Set` rows on every equipment deletion - a single delete, a gym delete cascading to its
+equipment, and a backup restore, which cascades across every equipment row the user owns -
+and Postgres does not index the referencing side of a foreign key. The restoring migration
+is guarded with `IF NOT EXISTS`, and the reason is itself the interesting part: the original
+index was removed by editing an already-applied migration in place, so a database that
+applied the pre-review version already has the index while a fresh one does not. Editing an
+applied migration leaves exactly this kind of split-brain behind; the guard is the cost of
+that, paid once.
+
+**The silent drop, and why the fix had to live in the sync layer (#326 -> #335).** Since
+#313 a set whose equipment reference has gone stale is saved with `gymEquipmentId` null
+rather than being rejected - the right call, because rejecting it destroys an offline-logged
+set. But it was silent: the picker kept the machine selected and pre-selected it again for
+the next set. The interesting constraint is that the set POST is fire-and-forget through
+IndexedDB and `flushPendingSets`, so the server's answer is only ever observed inside
+`lib/sync.ts`, in the background, with no component on the stack. There is no return value
+to check and nowhere to `await`. The fix is therefore a subscription rather than a return
+path: sync nulls the local record, reports it in `FlushResult.droppedEquipment` and notifies
+`onEquipmentDropped` subscribers; the session runner subscribes, filters by the current
+session id, shows a non-blocking warning toast and withdraws the option; set-input clears a
+selection the options no longer offer. The review earned its slot twice here - it added a
+cross-user equipment-id case to `tests/integration/route-ownership.test.ts` and then proved
+the test was not vacuous by removing the `gym: { userId }` scope and confirming that exactly
+that test went red, and it found the gap the fix does not close: if no `SessionRunner` is
+mounted when the flush runs (the tab was closed, the user navigated away), the local record
+is still nulled but nobody is listening, so the notice is lost. Filed as **#337** rather
+than bolted on.
+
+**A layout bug whose most visible symptom was not a layout bug (#330 -> #336).** At 400px
+the catalog card gave the exercise name roughly 150px, because three tap targets sat in a
+trailing column and the repo's `tap` token is 4rem - 64px each, which is a deliberate
+accessibility floor and not something to shrink. So the fix moved structure instead: a fixed
+64x64 leading media slot (the technique start frame, or a muted play icon at the same size
+when the catalog has no media, so every card shares one row alignment), the name taking the
+remaining width with `line-clamp-2` instead of truncating mid-word, a compact
+`equipmentTypesShort` label (en/ru/fr) sharing one non-wrapping line with the rest time, and
+edit/delete on their own full-width row below `sm`. The part worth recording is the "large
+grey box" the issue reported in the README screenshot: it was not a rendering bug at all but
+the hover state of a ghost button, painted onto whichever card the resting mouse pointer
+happened to sit over when the screenshot script fired. Fixed at the capture site -
+`scripts/screenshots.mjs` now parks the pointer at (0,0) before each capture - which closes
+a whole class of future false bug reports against the committed media. `catalog.png` was
+re-shot and looked at. Two reviewer follow-ups came out of this one: **#338** (the default
+catalog never sets `equipmentType`, so every seeded exercise is `OTHER` and now reads "Any
+equipment" - pre-existing data, made visible by the new label) and **#339** (a French
+comment surviving in `tailwind.config.ts`, also pre-existing).
+
+**The external proposal: answered as a sequence, not as a yes.** SHAREN filed #331, arguing
+that MCP should be a first-class "external deep coach" interface - GymCoach owning the data,
+the deterministic training logic and the safety boundary, the user's own ChatGPT or Claude
+doing the deep reasoning, MCP as the bridge - with four scenarios (scheduled post-workout
+analysis, a photographed paper log imported through preview, printable sheets, equipment
+onboarding by photo and voice). The vetting pass came back clean (no injection, in scope,
+and it matches the shape of the MCP layer SHAREN already built in #276), and the
+threat-model lens is what shaped the answer. Three findings decided the ordering. `McpAccessToken`
+carries a single `canWrite` boolean that today authorizes program authoring only, so adding
+session, equipment or import writes under that same boolean would retroactively escalate
+every token users have already issued - a token created to let an agent adjust a program
+would become one that can rewrite the training log, and programs are re-derivable where
+completed sets are the app's ground truth. Hence: scopes ship with or before any write
+expansion, never after. Second, `confirmed: true` is asserted by the model and not by the
+human, which is tolerable at one-program-change granularity and materially weaker when one
+`confirmed` covers N mutations, so batch operations come last and behind preview-then-confirm.
+Third, agent-authored equipment text flows back into `get_training_context` and into the
+in-app coach prompt, which makes it a store-and-replay channel and means equipment writes
+need strict enums and length caps rather than free-form passthrough. The answer posted
+inside the tick is a six-PR sequence (session reads, then token scopes with existing
+`canWrite` mapped to `programs:write` only, then a write audit log, then dry-run, then
+session writes, then equipment and batch), plus five questions whose answers change the
+implementation, plus the honest note that PRs 2-6 all touch hard-blocked paths and so are
+human-merged exactly as #311-#313 were. The issue is labeled `enhancement` +
+`needs-maintainer`: the direction call belongs to the operator, not to the loop. The one
+piece that is pure app code and touches no blocked path - the printable A4 workout sheet -
+was adopted as **#333**, crediting SHAREN, and is the loop's to take.
+
+**Green gate.** All three PRs passed the local gate and CI before merge. One process defect
+showed up in the shipping half and is now closed: this machine's `gh` is 2.4.0, where
+`gh pr checks <n> --watch` prints `unknown flag` and then **exits 0** - a missing flag that
+fails loudly is an inconvenience, but one that reports success is a gate that can be read as
+green without a single check having been resolved. `ship-pr` step 2 now polls
+`gh pr view <n> --json statusCheckRollup` and decides on the check conclusions rather than
+on an exit code (lesson **L5**, reinforced and finally graduated). A second, harmless one
+recorded in the same place: with the PR branch still checked out in a worktree,
+`gh pr merge --delete-branch` exits 1 *after* the merge has already landed, which invites a
+pointless retry; the cleanup is `git push origin --delete <branch>` plus `git worktree
+remove`.
+
+**The stall that cost orchestrator attention (L21).** Two of the three dev ticks
+backgrounded a prerequisite - `npm ci` in a fresh worktree, `next start` - and then ended
+their turn saying they were waiting to be notified when it completed. Nothing notifies them:
+a subagent tick is not re-woken by a background job finishing, so both sat done-but-unfinished
+until the orchestrator resumed them. The work was never wrong, only stalled, which is what
+makes it easy to miss and worth a lesson: "run it in the background and wait" is an
+interactive-session habit, and inside a loop tick it converts an autonomous tick into one
+that needs a babysitter. Graduated into `implement-issue` step 5: run bootstrap and the gate
+synchronously, poll a server until it answers, never end a turn waiting on a background
+process.
+
+**One metric.** Accepted-change rate this batch: 3 merged / 0 abandoned (#334, #335, #336),
+plus this docs PR. No reverts, and zero fixup rounds - all three PRs were green and clean on
+their first CI run. 2 follow-up issues filed by the reviewers on the batch's own work (#337,
+#338) plus 1 pre-existing nit (#339). 1 external design proposal answered inside the tick
+(#331), 1 issue adopted from it (#333). Implementing-tick token spend: not recorded
+separately (the three dev ticks ran on Fable per the model-routing directive; the three
+skeptic reviews, the #331 vetting pass and this write-up ran on Opus).
+
+**Deferred.** #333 (printable A4 workout sheet, adopted from #331) and the operator's
+direction call on the rest of #331; #337, #338, #339 from this batch's reviews; #324
+(return-to-training follow-ups from the #311 review), #320 (browsable exercise library),
+#300-#304 (the rest of the "make it pop" ideas). The demo-media debt is now partly paid -
+`catalog.png` was re-shot in #336 and the whole set was refreshed by #329 - but no committed
+clip yet shows the equipment picker or the muscle heat map, so the recorded scenarios remain
+the oldest media debt.

--- a/docs/loops/lessons.md
+++ b/docs/loops/lessons.md
@@ -59,8 +59,18 @@ Format per entry: trigger/evidence, the lesson (actionable), and **Status** = `g
   and `--json authorAssociation` all failed as unknown.
 - **Lesson:** prefer `gh api` (e.g. labels, `author_association`) and two-step flows
   (`gh issue comment` then `gh issue close`); do not assume the newest `gh` surface.
-- **Status:** accepted risk - operational quirk of this environment, not worth encoding in a
-  product skill; recorded here so future runs do not rediscover it.
+- **Reinforced 2026-09-04, and it is worse than "the flag is missing":** `gh pr checks <n>
+  --watch` on this machine's `gh` 2.4.0 prints `unknown flag: --watch` and **exits 0**. A
+  missing flag that fails loudly is an inconvenience; one that fails silently with a success
+  status is a gate that can be read as green without a single check having been resolved -
+  exactly the shape of failure the charter cares about. The general rule: for any `gh` call
+  whose answer is a verdict, decide on the *parsed output* (`--json`), never on the exit
+  status.
+- **Status:** graduated -> `ship-pr` step 2 now says to poll
+  `gh pr view <n> --json statusCheckRollup` (or `gh pr checks <n>` in a loop) instead of
+  `--watch`, and to decide on the check conclusions rather than on an exit code. The broader
+  "this environment's `gh` is old, prefer `gh api` and two-step flows" part stays an accepted
+  operational risk, recorded here so future runs do not rediscover it.
 
 ### L6 - Prisma's generated `Set` model type shadows the global `Set`
 - **Trigger:** the consistency-card lib (#71) needed a `Set<string>` of distinct trained days,
@@ -230,6 +240,11 @@ Format per entry: trigger/evidence, the lesson (actionable), and **Status** = `g
   concurrent dev/ship ticks get isolated `git worktree`s; without isolation, serialize
   same-checkout ticks. Recovery when a commit still lands on `main`: revert forward (never
   force-push shared history), then re-ship via a proper PR.
+  **Confirmed in production 2026-09-04:** three dev ticks ran concurrently in
+  `../gymcoach-wt-<n>` worktrees off the same base, on file-disjoint issues - three PRs, zero
+  conflicts, three green first-pass CI runs, no `main` breach, with the L16 `flock`
+  serializing the three `--full` gates unprompted. Now written into `06-orchestration.md` as
+  the confirmed parallel-dev pattern rather than a contingency.
 
 ### L16 - Isolated worktrees are not enough: the shared test Postgres (:5434) and dev port (:3031) also need a lock
 - **Trigger:** 2026-07-22 batch. Two loop sessions ran `bash scripts/verify.sh --full` at the
@@ -341,3 +356,23 @@ Format per entry: trigger/evidence, the lesson (actionable), and **Status** = `g
   right, and why) written into the issue rather than the index quietly re-added. The general rule
   is a standing review-practice rule; it also stands as the first concrete evidence that the
   advisory third-party lens earns the slot the policy gives it.
+
+### L21 - A tick must never end its turn waiting on a background process
+- **Trigger:** 2026-09-04, the three-worktree parallel batch. Two of the three dev ticks
+  backgrounded a prerequisite (`npm ci`, `next start`) and then ended the turn saying they
+  were waiting to be notified when it finished. Nothing notifies them: a subagent tick is not
+  re-woken by a background job completing, so both sat done-but-unfinished until the
+  orchestrator noticed and resumed them. Both then completed normally - the work was never
+  wrong, only stalled, which is exactly why it is easy to miss.
+- **Lesson:** "start it in the background and wait" is a pattern borrowed from an interactive
+  session, where a human is still at the keyboard to react. Inside a loop tick there is no
+  such observer, so a backgrounded prerequisite converts an autonomous tick into one that
+  needs a babysitter - it spends orchestrator attention, the scarce resource the loop exists
+  to save. Anything a tick NEEDS before it can continue runs synchronously (raise the tool
+  timeout rather than backgrounding it); anything that must run detached, such as a dev
+  server, is polled until it answers. Not to be confused with L3: L3 says stop at the PR and
+  do not block on CI, which is a deliberate hand-off to another tick. This is the opposite
+  failure - stopping mid-task with nothing on the other side of the wait.
+- **Status:** graduated -> `implement-issue` step 5 (green-gate) now states it outright: run
+  bootstrap and the gate synchronously, never end the turn waiting on a background process,
+  poll a server until it answers.

--- a/docs/loops/review-digest.md
+++ b/docs/loops/review-digest.md
@@ -439,3 +439,62 @@ app). The re-shoot is now the highest-value media debt: `progress.png` predates 
 AND the heat map, and no committed clip shows either. Next media tick should seed a couple of
 demo progress photos in `scripts/seed-demo-history.ts`, re-shoot the progress page, and re-record
 the progress scenario in one pass.
+
+## 2026-09-04 - three parallel dev ticks: FK index (#334), dropped-equipment notice (#335), catalog card (#336)
+
+Merged since the last digest: **#332** (French locale, the operator's own branch), **#334**
+(closes #325), **#335** (closes #326) and **#336** (closes #330). The last three are
+loop-authored, ran as three parallel worktree ticks, and each passed CI on its first run plus
+an independent skeptic review. Read these first:
+
+1. **#334 - the only schema change in the batch.** `gh pr diff 334`. A migration ranks top by
+   rule, and this one has a wrinkle worth your eyes: it restores an index that a previous
+   review told a contributor to delete (lesson L20), and it does so with `CREATE INDEX IF NOT
+   EXISTS` because the original index was removed by editing an already-applied migration in
+   place - so a database that applied the pre-review version still has the index while a fresh
+   one does not. Check that you agree the guard is warranted here rather than a habit worth
+   spreading: the general rule in this repo is still that an applied migration is immutable.
+   The index itself is `[gymEquipmentId, completedAt]` on `Set`, and its reader is Postgres
+   executing `ON DELETE SET NULL`, not any application query.
+2. **#335 - core behavior on the offline path, plus one ownership test.** `gh pr diff 335`.
+   Read `lib/sync.ts` first: the set POST is fire-and-forget through IndexedDB, so the
+   server's "your equipment reference was dropped" answer can only be observed inside the
+   background flush, and the fix is a subscriber (`onEquipmentDropped`) rather than a return
+   value. Two things to check: that the local record is nulled on that path (otherwise the
+   next set re-sends a stale id), and that the session-runner subscription filters by session
+   id so a flush belonging to an older session cannot toast into the current one. The
+   integration case added to `tests/integration/route-ownership.test.ts` is the security-
+   relevant line - it pins the `gym: { userId }` scope on the equipment lookup, and the
+   reviewer verified it fails when the scope is removed. Known gap, filed as **#337**, not a
+   regression: with no `SessionRunner` mounted at flush time the record is still nulled but
+   the user is never told.
+3. **#336 - additive UI, ranks last, but read the screenshot-script change.** `gh pr diff
+   336`. The card layout itself is presentation only (a 64x64 leading media slot,
+   `line-clamp-2` on the name, a compact `equipmentTypesShort` label in en/ru/fr, actions on
+   their own row below `sm`). The one line with reach beyond this PR is in
+   `scripts/screenshots.mjs`: the pointer is now parked before each capture, because the
+   "large grey box" the issue reported in the README was a ghost button's hover state under
+   the resting mouse. That is a fix to the committed-media pipeline, so it affects every
+   future shot.
+
+**Skim:** #332 (a third message catalog, mechanically parallel to the existing two) and this
+write-up (CHANGELOG Added/Fixed, the README feature/roadmap/credits lines, lessons L5 and L15
+updated plus new L21, the `ship-pr` and `implement-issue` skill edits, the confirmed
+parallel-dev pattern in `06-orchestration.md`, autonomy-log).
+
+**Also worth ten minutes, and it is not a diff:** the answer posted on **#331** (SHAREN's
+proposal to make MCP a first-class external-coach interface). It commits the project to an
+ordering - token scopes before any write expansion, because `McpAccessToken.canWrite` is a
+single boolean and widening what it authorizes would retroactively escalate every token
+already issued. That is a design call with a security consequence, the issue is labeled
+`needs-maintainer`, and it is yours to confirm or overrule before anyone writes PR 2.
+
+**Carry forward:** #337, #338 (every seeded exercise is `equipmentType: OTHER`, so the new
+label reads "Any equipment" everywhere) and #339 (a French comment in `tailwind.config.ts`)
+came out of this batch's reviews and are unimplemented. #333 (printable A4 sheet, adopted
+from #331), #324, #320 and #300-#304 still stand.
+
+**Media note:** `catalog.png` was re-shot in #336 and inspected, and #329 refreshed the rest,
+so the static screenshots are current. The recorded clips are not: none of them shows the
+equipment picker or the muscle heat map, which makes the scenario re-record the oldest media
+debt in the repo.


### PR DESCRIPTION
Documents the 2026-09-04 batch: three loop-authored PRs run as three parallel worktree ticks, plus the external design proposal answered inside the tick.

## CHANGELOG
- **Fixed**: the logger now surfaces an equipment selection that could not be recorded (#335); the exercise catalog card is readable at phone width (#336); deleting equipment or a gym, and restoring a backup, no longer scan the whole set table once per equipment item (#334).
- **Added**: French as a third interface language (#332, merged the same day and previously undocumented).

Loop-authored entries carry no issue number, per the existing convention that reserves numbers for external contributions and reports.

## README
- The localization feature bullet and the roadmap line now say English, French and Russian.
- The gym-equipment feature bullet states that a selection which cannot be recorded is surfaced rather than dropped silently.
- Thanks credits @SHAREN for the MCP direction proposal (#331) behind the adopted #333. #333 is unshipped, so it is credited here rather than claimed in the CHANGELOG.

## docs/loops
- `autonomy-log.md`: an entry for the batch, including the metric line (3 merged / 0 abandoned, 0 fixup rounds, 2 reviewer-found follow-ups plus 1 pre-existing nit, 1 external proposal answered, 1 issue adopted).
- `review-digest.md`: the prioritized reading list, migration first, and a note that the #331 answer is itself a maintainer decision to confirm.
- `06-orchestration.md`: worktree-per-tick plus the L16 shared-infra flock recorded as the confirmed parallel-dev pattern.

## Lessons graduated (not just recorded)
- **L5 reinforced and graduated** - this machine's `gh` 2.4.0 answers `gh pr checks --watch` with `unknown flag` and **exit 0**, which reads as green. `ship-pr` step 2 now polls `gh pr view <n> --json statusCheckRollup` and decides on the check conclusions, never on an exit code. The same step records that `gh pr merge --delete-branch` exits 1 *after* a successful merge when the branch is checked out in a worktree.
- **L21 (new)** - a tick must never end its turn waiting on a background process; `implement-issue` step 5 now says to run bootstrap and the gate synchronously and to poll a server until it answers.
- **L15 follow-through** - the parallel run confirmed in production, recorded in `06-orchestration.md`.

## How I tested
`bash scripts/verify.sh` -> GREEN-GATE PASSED (docs-only change, but lint/typecheck/unit/build all pass). No media was re-shot: `catalog.png` was already refreshed by #336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFnkrDYab4mFtJyaHeFUEF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added French to the documented supported interface languages, with English fallback for unknown locales.
  * Clarified equipment recording behavior when selected equipment is no longer available.
  * Documented fixes for stale equipment references, narrow-screen exercise catalog layout, and equipment lookup performance.
  * Expanded contributor acknowledgments, localization roadmap details, and development workflow guidance.
  * Added operational notes covering parallel development, CI check verification, synchronous commands, and worktree cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->