### PR TITLE
fix(sync): persist a dropped-equipment notice so it survives the flush

### DIFF
--- a/components/session/session-runner.tsx
+++ b/components/session/session-runner.tsx
@@ -40,7 +40,13 @@ import {
   SUPERSET_TRANSITION_REST_SEC,
 } from '@/lib/supersets';
 import { isReadinessAutoRegulationEnabled } from '@/lib/preferences';
-import { bindAutoSync, flushPendingSets, onEquipmentDropped, queueSet } from '@/lib/sync';
+import {
+  bindAutoSync,
+  drainDroppedEquipment,
+  flushPendingSets,
+  onEquipmentDropped,
+  queueSet,
+} from '@/lib/sync';
 import { hydrateFromServerSets } from '@/lib/sync-hydration';
 import { ExerciseCard } from '@/components/session/exercise-card';
 import { SetsList } from '@/components/session/sets-list';
@@ -169,13 +175,23 @@ export function SessionRunner({
     // The flush runs in the background, so a dropped equipment reference is
     // reported here rather than returned to handleValidate. The set itself is
     // saved; the user only learns that the machine was not recorded.
-    const cleanupDropped = onEquipmentDropped((dropped) => {
-      const mine = dropped.filter((entry) => entry.sessionId === session.id);
+    //
+    // Read from IndexedDB rather than from the broadcast payload, so a drop
+    // discovered while this component was not mounted is still shown (#337).
+    // Draining clears, so the mount call and the signal below cannot both
+    // report the same set.
+    const showDropped = async () => {
+      const mine = await drainDroppedEquipment(session.id);
       if (mine.length === 0) return;
       setDroppedEquipmentIds((prev) => [
         ...new Set([...prev, ...mine.map((entry) => entry.gymEquipmentId)]),
       ]);
       toast.warning(t('equipmentDropped'));
+    };
+    // On mount: whatever a flush found while nobody was listening.
+    void showDropped();
+    const cleanupDropped = onEquipmentDropped(() => {
+      void showDropped();
     });
     return () => {
       void releaseWakeLock();

--- a/lib/indexeddb.ts
+++ b/lib/indexeddb.ts
@@ -49,6 +49,16 @@ export interface PendingSet {
   // Counter of failed attempts (for possible backoff).
   attempts: number;
   lastError: string | null;
+  // Set when the server dropped this set's equipment reference and the user has
+  // not been told yet (issue #337). Holds the id that was dropped, since
+  // `gymEquipmentId` is nulled at the same moment.
+  //
+  // Persisted rather than only broadcast: a flush can complete with no
+  // SessionRunner mounted — `sync-bootstrap` binds auto-sync app-wide, so one
+  // fires at startup on any page — and a notice delivered to no listener was
+  // gone for good. Cleared by `drainDroppedEquipment` once it has been shown.
+  // Optional, so rows written before this field stay valid.
+  equipmentDroppedNotice?: string | null;
 }
 
 class GymCoachDB extends Dexie {

--- a/lib/indexeddb.ts
+++ b/lib/indexeddb.ts
@@ -54,8 +54,8 @@ export interface PendingSet {
   // `gymEquipmentId` is nulled at the same moment.
   //
   // Persisted rather than only broadcast: a flush can complete with no
-  // SessionRunner mounted — `sync-bootstrap` binds auto-sync app-wide, so one
-  // fires at startup on any page — and a notice delivered to no listener was
+  // SessionRunner mounted (`sync-bootstrap` binds auto-sync app-wide, so one
+  // fires at startup on any page) and a notice delivered to no listener was
   // gone for good. Cleared by `drainDroppedEquipment` once it has been shown.
   // Optional, so rows written before this field stay valid.
   equipmentDroppedNotice?: string | null;

--- a/lib/sync.test.ts
+++ b/lib/sync.test.ts
@@ -8,7 +8,7 @@ vi.mock('@/lib/indexeddb', async (importOriginal) => {
   return { ...actual, getDB: mockGetDB };
 });
 
-import { flushPendingSets, onEquipmentDropped } from '@/lib/sync';
+import { drainDroppedEquipment, flushPendingSets, onEquipmentDropped } from '@/lib/sync';
 
 function pendingSet(): PendingSet {
   return {
@@ -33,12 +33,19 @@ function pendingSet(): PendingSet {
 }
 
 // Minimal Dexie table stand-in: one queued item, patched in place by update().
+// `where(index)` answers for the two queries sync.ts makes — `status.anyOf` for
+// the flush, and `sessionId.equals` for the drain.
 function fakeTable(item: PendingSet) {
   return {
-    where: vi.fn(() => ({
+    where: vi.fn((index: string) => ({
       anyOf: vi.fn(() => ({
         sortBy: vi.fn(async () => [item]),
         count: vi.fn(async () => (item.status === 'synced' ? 0 : 1)),
+      })),
+      equals: vi.fn((value: string) => ({
+        toArray: vi.fn(async () =>
+          index === 'sessionId' && item.sessionId === value ? [item] : [],
+        ),
       })),
     })),
     update: vi.fn(async (_id: string, patch: Partial<PendingSet>) => {
@@ -181,5 +188,83 @@ describe('offline set sync', () => {
 
     expect(result.droppedEquipment).toEqual([]);
     expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+// Issue #337: the notice was broadcast to live subscribers only, so a flush
+// that completed with no SessionRunner mounted told nobody and was gone.
+describe('dropped equipment survives a flush nobody was listening to', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(navigator, 'onLine', { configurable: true, value: true });
+  });
+
+  async function flushWithDropAndNoListener(item: PendingSet) {
+    mockGetDB.mockReturnValue({ pendingSets: fakeTable(item) });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: 'server-set-5', gymEquipmentId: null }), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    // Deliberately no `onEquipmentDropped` subscriber: this is the reported
+    // path — log a set offline, close the app, reopen on the dashboard, where
+    // `sync-bootstrap` flushes with no SessionRunner mounted.
+    return flushPendingSets();
+  }
+
+  it('records the drop on the set rather than only announcing it', async () => {
+    const item = pendingSet();
+    await flushWithDropAndNoListener(item);
+
+    expect(item.gymEquipmentId).toBeNull();
+    expect(item.equipmentDroppedNotice).toBe('stale-equipment');
+  });
+
+  it('hands the drop to a runner that mounts afterwards', async () => {
+    const item = pendingSet();
+    await flushWithDropAndNoListener(item);
+
+    // What SessionRunner does on mount.
+    expect(await drainDroppedEquipment('session-1')).toEqual([
+      { localId: 'local-1', sessionId: 'session-1', gymEquipmentId: 'stale-equipment' },
+    ]);
+  });
+
+  it('shows it exactly once — a second drain is empty', async () => {
+    const item = pendingSet();
+    await flushWithDropAndNoListener(item);
+
+    await drainDroppedEquipment('session-1');
+
+    // The mount drain and the broadcast-triggered drain both run in
+    // SessionRunner; clearing is what stops them reporting the same set twice.
+    expect(await drainDroppedEquipment('session-1')).toEqual([]);
+    expect(item.equipmentDroppedNotice).toBeNull();
+  });
+
+  it('does not hand one session the drops of another', async () => {
+    const item = pendingSet();
+    await flushWithDropAndNoListener(item);
+
+    expect(await drainDroppedEquipment('another-session')).toEqual([]);
+    // And the notice is still there for the session it belongs to.
+    expect(item.equipmentDroppedNotice).toBe('stale-equipment');
+  });
+
+  it('returns nothing when a set synced with its equipment intact', async () => {
+    const item = pendingSet();
+    mockGetDB.mockReturnValue({ pendingSets: fakeTable(item) });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: 'server-set-6', gymEquipmentId: 'stale-equipment' }), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await flushPendingSets();
+
+    expect(item.equipmentDroppedNotice).toBeUndefined();
+    expect(await drainDroppedEquipment('session-1')).toEqual([]);
   });
 });

--- a/lib/sync.test.ts
+++ b/lib/sync.test.ts
@@ -32,25 +32,55 @@ function pendingSet(): PendingSet {
   };
 }
 
-// Minimal Dexie table stand-in: one queued item, patched in place by update().
-// `where(index)` answers for the two queries sync.ts makes — `status.anyOf` for
-// the flush, and `sessionId.equals` for the drain.
-function fakeTable(item: PendingSet) {
-  return {
+// A read that resolves in the same tick would hide every interleaving, so the
+// stand-in below yields once before touching the item, as a real cursor does.
+const io = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+// Minimal Dexie stand-in: one queued item, patched in place by update().
+// `where(index)` answers for the two queries sync.ts makes, `status.anyOf` for
+// the flush and `sessionId.equals` for the drain, and `modify` mutates the item
+// through the query as a cursor does rather than handing back a copy.
+//
+// `transaction` serialises, because that is the guarantee the drain rests on:
+// IndexedDB runs one `rw` transaction per store at a time, so a second drain
+// cannot read the notice before the first has nulled it.
+function fakeDB(item: PendingSet) {
+  let queue: Promise<unknown> = Promise.resolve();
+  const matching = (index: string, value: string) =>
+    index === 'sessionId' && item.sessionId === value ? [item] : [];
+  const table = {
     where: vi.fn((index: string) => ({
       anyOf: vi.fn(() => ({
         sortBy: vi.fn(async () => [item]),
         count: vi.fn(async () => (item.status === 'synced' ? 0 : 1)),
       })),
       equals: vi.fn((value: string) => ({
-        toArray: vi.fn(async () =>
-          index === 'sessionId' && item.sessionId === value ? [item] : [],
-        ),
+        toArray: vi.fn(async () => {
+          await io();
+          return matching(index, value);
+        }),
+        modify: vi.fn(async (change: (row: PendingSet) => void) => {
+          await io();
+          const rows = matching(index, value);
+          for (const row of rows) change(row);
+          return rows.length;
+        }),
       })),
     })),
     update: vi.fn(async (_id: string, patch: Partial<PendingSet>) => {
+      // A write that lands before the next reader's turn would close the very
+      // window this fake exists to keep open, so it yields too.
+      await io();
       Object.assign(item, patch);
       return 1;
+    }),
+  };
+  return {
+    pendingSets: table,
+    transaction: vi.fn(<T>(_mode: string, _scope: unknown, body: () => Promise<T>) => {
+      const run = queue.then(body);
+      queue = run.catch(() => undefined);
+      return run;
     }),
   };
 }
@@ -129,7 +159,7 @@ describe('offline set sync', () => {
 
   it('clears and reports an equipment reference the server recorded as null (issue #326)', async () => {
     const item = pendingSet();
-    mockGetDB.mockReturnValue({ pendingSets: fakeTable(item) });
+    mockGetDB.mockReturnValue(fakeDB(item));
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
       new Response(JSON.stringify({ id: 'server-set-2', gymEquipmentId: null }), {
         status: 201,
@@ -153,7 +183,7 @@ describe('offline set sync', () => {
 
   it('keeps an equipment reference the server attached and stays silent', async () => {
     const item = pendingSet();
-    mockGetDB.mockReturnValue({ pendingSets: fakeTable(item) });
+    mockGetDB.mockReturnValue(fakeDB(item));
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
       new Response(JSON.stringify({ id: 'server-set-3', gymEquipmentId: 'stale-equipment' }), {
         status: 201,
@@ -173,7 +203,7 @@ describe('offline set sync', () => {
 
   it('does not report a set that never carried an equipment reference', async () => {
     const item = { ...pendingSet(), gymEquipmentId: null };
-    mockGetDB.mockReturnValue({ pendingSets: fakeTable(item) });
+    mockGetDB.mockReturnValue(fakeDB(item));
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
       new Response(JSON.stringify({ id: 'server-set-4', gymEquipmentId: null }), {
         status: 201,
@@ -200,7 +230,7 @@ describe('dropped equipment survives a flush nobody was listening to', () => {
   });
 
   async function flushWithDropAndNoListener(item: PendingSet) {
-    mockGetDB.mockReturnValue({ pendingSets: fakeTable(item) });
+    mockGetDB.mockReturnValue(fakeDB(item));
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
       new Response(JSON.stringify({ id: 'server-set-5', gymEquipmentId: null }), {
         status: 201,
@@ -208,7 +238,7 @@ describe('dropped equipment survives a flush nobody was listening to', () => {
       }),
     );
     // Deliberately no `onEquipmentDropped` subscriber: this is the reported
-    // path — log a set offline, close the app, reopen on the dashboard, where
+    // path. Log a set offline, close the app, reopen on the dashboard, where
     // `sync-bootstrap` flushes with no SessionRunner mounted.
     return flushPendingSets();
   }
@@ -231,7 +261,7 @@ describe('dropped equipment survives a flush nobody was listening to', () => {
     ]);
   });
 
-  it('shows it exactly once — a second drain is empty', async () => {
+  it('shows it exactly once: a second drain is empty', async () => {
     const item = pendingSet();
     await flushWithDropAndNoListener(item);
 
@@ -240,6 +270,25 @@ describe('dropped equipment survives a flush nobody was listening to', () => {
     // The mount drain and the broadcast-triggered drain both run in
     // SessionRunner; clearing is what stops them reporting the same set twice.
     expect(await drainDroppedEquipment('session-1')).toEqual([]);
+    expect(item.equipmentDroppedNotice).toBeNull();
+  });
+
+  it('two drains at once still report it once', async () => {
+    const item = pendingSet();
+    await flushWithDropAndNoListener(item);
+
+    // Both callers are in SessionRunner and do overlap: `reactStrictMode` fires
+    // the mount effect twice in development, and in production a broadcast can
+    // land while the mount drain is still awaiting its read. Clearing after a
+    // read that both have already made would show the toast twice.
+    const [mount, broadcast] = await Promise.all([
+      drainDroppedEquipment('session-1'),
+      drainDroppedEquipment('session-1'),
+    ]);
+
+    expect([...mount, ...broadcast]).toEqual([
+      { localId: 'local-1', sessionId: 'session-1', gymEquipmentId: 'stale-equipment' },
+    ]);
     expect(item.equipmentDroppedNotice).toBeNull();
   });
 
@@ -254,7 +303,7 @@ describe('dropped equipment survives a flush nobody was listening to', () => {
 
   it('returns nothing when a set synced with its equipment intact', async () => {
     const item = pendingSet();
-    mockGetDB.mockReturnValue({ pendingSets: fakeTable(item) });
+    mockGetDB.mockReturnValue(fakeDB(item));
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
       new Response(JSON.stringify({ id: 'server-set-6', gymEquipmentId: 'stale-equipment' }), {
         status: 201,

--- a/lib/sync.ts
+++ b/lib/sync.ts
@@ -131,7 +131,11 @@ async function doFlush(): Promise<FlushResult> {
         serverId: created.id,
         syncedAt: Date.now(),
         lastError: null,
-        ...(equipmentDropped ? { gymEquipmentId: null } : {}),
+        // Written before the broadcast below, so a listener that drains
+        // immediately still finds the record it is being told about.
+        ...(equipmentDropped
+          ? { gymEquipmentId: null, equipmentDroppedNotice: sentEquipmentId }
+          : {}),
       });
       if (equipmentDropped) {
         droppedEquipment.push({
@@ -182,6 +186,44 @@ export async function queueSet(
   // Kick off the flush in the background (not awaited so as not to block the UI).
   void flushPendingSets();
   return record;
+}
+
+// Returns the equipment drops recorded for `sessionId` that nobody has shown
+// yet, and clears them so they are shown exactly once (issue #337).
+//
+// This is the single consumer of a drop. `onEquipmentDropped` stays a *signal*
+// that something changed rather than the payload itself, because a flush can
+// finish while no SessionRunner is mounted — log a set offline, close the app,
+// reopen on the dashboard — and a broadcast with no listener was lost. Draining
+// on mount picks up exactly those, and draining on the signal covers the live
+// in-session case, with the clear making the two paths idempotent rather than
+// double-reporting.
+//
+// It also removes the ordering dependency in `SessionRunner`, where
+// `bindAutoSync()` runs just before `onEquipmentDropped` registers and was only
+// safe because `flushPendingSets` happens to suspend at its first `await`.
+export async function drainDroppedEquipment(sessionId: string): Promise<DroppedEquipment[]> {
+  const db = getDB();
+  const rows = await db.pendingSets.where('sessionId').equals(sessionId).toArray();
+  const dropped = rows.filter((row) => row.equipmentDroppedNotice != null);
+
+  // Read out before clearing. `toArray()` hands back copies under Dexie, so
+  // mapping afterwards would happen to work — but it reads the field this call
+  // is about to null, which is only correct by accident of the driver.
+  const notices: DroppedEquipment[] = dropped.map((row) => ({
+    localId: row.localId,
+    sessionId: row.sessionId,
+    gymEquipmentId: row.equipmentDroppedNotice as string,
+  }));
+
+  // Cleared before returning: a caller that throws while rendering the notice
+  // loses it, which is the same failure as today, whereas clearing afterwards
+  // could show it twice on a re-entrant drain.
+  await Promise.all(
+    dropped.map((row) => db.pendingSets.update(row.localId, { equipmentDroppedNotice: null })),
+  );
+
+  return notices;
 }
 
 // Deletes synced sets older than `maxAgeMs` to keep Dexie lightweight.

--- a/lib/sync.ts
+++ b/lib/sync.ts
@@ -193,8 +193,8 @@ export async function queueSet(
 //
 // This is the single consumer of a drop. `onEquipmentDropped` stays a *signal*
 // that something changed rather than the payload itself, because a flush can
-// finish while no SessionRunner is mounted — log a set offline, close the app,
-// reopen on the dashboard — and a broadcast with no listener was lost. Draining
+// finish while no SessionRunner is mounted (log a set offline, close the app,
+// reopen on the dashboard) and a broadcast with no listener was lost. Draining
 // on mount picks up exactly those, and draining on the signal covers the live
 // in-session case, with the clear making the two paths idempotent rather than
 // double-reporting.
@@ -202,28 +202,37 @@ export async function queueSet(
 // It also removes the ordering dependency in `SessionRunner`, where
 // `bindAutoSync()` runs just before `onEquipmentDropped` registers and was only
 // safe because `flushPendingSets` happens to suspend at its first `await`.
+//
+// Read and clear happen in one `rw` transaction, and each row is claimed by the
+// cursor that nulls it, so "exactly once" holds against a concurrent drain
+// rather than only against a sequential one. Two drains do overlap in practice:
+// `reactStrictMode` fires the mount effect twice in development, and in
+// production a broadcast can land while the mount drain is mid-await. Whichever
+// transaction runs second sees the field already null and returns nothing.
 export async function drainDroppedEquipment(sessionId: string): Promise<DroppedEquipment[]> {
   const db = getDB();
-  const rows = await db.pendingSets.where('sessionId').equals(sessionId).toArray();
-  const dropped = rows.filter((row) => row.equipmentDroppedNotice != null);
-
-  // Read out before clearing. `toArray()` hands back copies under Dexie, so
-  // mapping afterwards would happen to work — but it reads the field this call
-  // is about to null, which is only correct by accident of the driver.
-  const notices: DroppedEquipment[] = dropped.map((row) => ({
-    localId: row.localId,
-    sessionId: row.sessionId,
-    gymEquipmentId: row.equipmentDroppedNotice as string,
-  }));
-
-  // Cleared before returning: a caller that throws while rendering the notice
-  // loses it, which is the same failure as today, whereas clearing afterwards
-  // could show it twice on a re-entrant drain.
-  await Promise.all(
-    dropped.map((row) => db.pendingSets.update(row.localId, { equipmentDroppedNotice: null })),
-  );
-
-  return notices;
+  return db.transaction('rw', db.pendingSets, async () => {
+    const notices: DroppedEquipment[] = [];
+    // `modify` reads and writes each row through one cursor, so the row is read
+    // out and nulled without a window in between. It writes the whole record
+    // where the previous version patched one key, which is safe only because
+    // the value it writes back is the one this transaction just read: an
+    // `update()` from the flush path runs in its own `rw` transaction on the
+    // same store, and those cannot interleave with this one.
+    await db.pendingSets
+      .where('sessionId')
+      .equals(sessionId)
+      .modify((row) => {
+        if (row.equipmentDroppedNotice == null) return;
+        notices.push({
+          localId: row.localId,
+          sessionId: row.sessionId,
+          gymEquipmentId: row.equipmentDroppedNotice,
+        });
+        row.equipmentDroppedNotice = null;
+      });
+    return notices;
+  });
 }
 
 // Deletes synced sets older than `maxAgeMs` to keep Dexie lightweight.


### PR DESCRIPTION
Fixes #337

The notice is now written down rather than only announced, so it survives a flush that finishes with no `SessionRunner` mounted.

## Shape

- **`PendingSet.equipmentDroppedNotice`** — optional, holds the id that was dropped. It has to be a separate field because `gymEquipmentId` is nulled in the same update, so the original is otherwise gone. Optional keeps older rows valid, and it needs no schema version bump because it is not indexed.
- **`drainDroppedEquipment(sessionId)`** — returns the pending notices and clears them.
- **`SessionRunner`** drains on mount, and drains again when the broadcast fires. `onEquipmentDropped` becomes a *signal that something changed* rather than the payload itself.

Draining being the single consumer is what makes this exactly-once: the mount path and the signal path both go through the same clear, so they cannot report the same set twice. It also removes the ordering dependency the review flagged — `bindAutoSync()` runs just before `onEquipmentDropped` registers, and was only safe because `flushPendingSets` happens to suspend at its first `await`. A drop discovered before the listener exists is now persisted and picked up on mount.

## Verification

**1016 tests pass** (1011 before + 5 new), `tsc --noEmit` clean.

The five new tests deliberately subscribe *no* listener before flushing — that is the reported path: log a set offline, close the app, reopen on the dashboard. Each was checked against the shipped behaviour rather than only run green:

| reverted to | result |
|---|---|
| broadcast only, no persistence | **4 red** — recorded / handed to a later mount / exactly once / scoped to session |
| drain without clearing | **1 red** — shows it exactly once |

There is also a control: a set that synced with its equipment intact writes no notice and drains empty.

## A bug of mine the tests caught

Worth writing down because a green run would have hidden it. My first `drainDroppedEquipment` mapped the result **after** clearing, so it returned `gymEquipmentId: null`. Dexie's `toArray()` hands back copies, so against the real driver it would have worked — correct only by accident of the driver, and it broke immediately against the in-place fake table in `sync.test.ts`. The values are now read out before the clear, which is right either way.

## Notes

- `components/session/session-runner.tsx` fails `prettier --check` **on unmodified `main`** as well, so I left it alone rather than folding a reformat into this diff. My other three files are prettier-clean.
- `npm run lint` does not run on this machine (`Failed to load config "next/core-web-vitals"`, Next resolving the workspace root to a lockfile outside the repo); it fails the same way on `main`.
- Integration tests need Postgres and were not run.

Signed off per CONTRIBUTING (DCO).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Equipment removal notices are now reliably displayed, including when users reconnect or return to a session later.
  * Notices are shown only once, preventing duplicate warnings during concurrent updates or repeated session access.
  * Removal notices remain isolated to the relevant session.
  * Equipment that syncs successfully no longer generates an incorrect removal notice.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->