### PR TITLE
chore: English comments in tailwind.config.ts, and why tap is 64px

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -57,14 +57,18 @@ const config: Config = {
         sm: 'calc(var(--radius) - 4px)',
       },
       minHeight: {
-        // Bouton "tap" minimum imposé par la spec UX (mains poudreuses)
+        // Minimum tap target, deliberately 4rem (64px) rather than the usual
+        // 44px: these are pressed mid-set with gloved or chalky hands. The size
+        // has a cost worth knowing — three tap targets in a card's trailing
+        // column is what starved the exercise name at 400px (#330, #336), so
+        // widen the row or drop a control rather than shrinking this.
         tap: '4rem',
       },
       minWidth: {
         tap: '4rem',
       },
       fontSize: {
-        // Pour le compteur de chrono géant
+        // For the oversized rest-timer readout.
         timer: ['6rem', { lineHeight: '1', fontWeight: '700' }],
       },
     },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -59,7 +59,7 @@ const config: Config = {
       minHeight: {
         // Minimum tap target, deliberately 4rem (64px) rather than the usual
         // 44px: these are pressed mid-set with gloved or chalky hands. The size
-        // has a cost worth knowing — three tap targets in a card's trailing
+        // has a cost worth knowing. Three tap targets in a card's trailing
         // column is what starved the exercise name at 400px (#330, #336), so
         // widen the row or drop a control rather than shrinking this.
         tap: '4rem',


### PR DESCRIPTION
Fixes #339

## Two, not one

The issue names line 60, but the file carried **two** French comments — the `tap` min-height, and the `timer` font size a few lines below:

```ts
// Bouton "tap" minimum imposé par la spec UX (mains poudreuses)
// Pour le compteur de chrono géant
```

Both are replaced. The acceptance asks for a sweep, so here it is, and it comes back empty afterwards:

```
grep -rnP '^\s*(//|\*|/\*).*[àâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇœ]' \
  --include='*.ts' --include='*.tsx' .
```

excluding `node_modules`, `messages/` and `i18n/`, which are meant to be French. Before: those two lines. After: nothing.

## The tap comment

Written as a constraint *with its cost*, since that is the part the #330 tick had to rediscover:

```ts
// Minimum tap target, deliberately 4rem (64px) rather than the usual
// 44px: these are pressed mid-set with gloved or chalky hands. The size
// has a cost worth knowing — three tap targets in a card's trailing
// column is what starved the exercise name at 400px (#330, #336), so
// widen the row or drop a control rather than shrinking this.
```

The last clause is the point: a comment that only says "64px, deliberate" invites the next person to shrink it when a row gets tight, which is exactly what #336 was cleaning up after. Naming the alternative makes the next decision the right one by default.

## Checks

Comments only, no behaviour change. **1011 tests pass**, `tsc --noEmit` clean.

`tailwind.config.ts` fails `prettier --check` on **unmodified `main`** too, so I left it rather than folding a reformat into a comment change. `npm run lint` doesn't run on this machine (`Failed to load config "next/core-web-vitals"`) and fails the same way on `main`.

Noting for triage: `tailwind.config.ts` is on the never-auto-merged list in `docs/loops/10-external-contributions.md` as an executable config, so this one needs a human either way.

Signed off per CONTRIBUTING (DCO).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated configuration comments to clarify tap-target sizing constraints and the oversized rest-timer display.
  * No user-facing behavior or configuration values changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->