### PR TITLE
docs: thank @shaurya703 in the README and credit #342 and #343 in the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -380,6 +380,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A dropped-equipment notice no longer gets lost when the sync completes with
+  no session screen open. The notice is written to the queued set itself and
+  drained, exactly once, by the next session screen that mounts, so logging a
+  set offline, closing the app and reopening it later still tells you the
+  machine was not recorded. Community contribution by @shaurya703 (#342).
+- The two remaining French comments in the Tailwind config are in English, and
+  the 64px tap-target token now documents why it is that size and what it
+  costs. Community contribution by @shaurya703 (#343).
 - The logger no longer stays silent when the equipment you picked was not
   recorded. A set whose equipment reference had gone stale by the time it
   reached the server (the item was deleted, unlinked from the exercise, or

--- a/README.md
+++ b/README.md
@@ -402,6 +402,9 @@ Notable changes are tracked in the [CHANGELOG](CHANGELOG.md).
   proposed making MCP a first-class "external deep coach" interface (#331); the
   sequencing is answered on that issue, and its one web-app-only piece is
   tracked as #333.
+- [@shaurya703](https://github.com/shaurya703) - picked up three of the loop's
+  own follow-up issues within hours of their filing and turned each into a
+  clean PR, including the persisted dropped-equipment notice (#342).
 - [@mvnixon](https://github.com/mvnixon) - reported the `GET /mcp` hang that
   stopped MCP clients probing with GET from connecting at all (#314), and
   made the case for publishing the production image so self-hosters can pull


### PR DESCRIPTION
Adds the new contributor to the README Thanks section (short, not a full list) and credits the two merged community PRs (#342, #343) in the Unreleased Fixed section. #341 gets its line once it merges.

## How I tested

`bash scripts/verify.sh` - GREEN-GATE PASSED (prisma generate, lint, typecheck, unit, build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFnkrDYab4mFtJyaHeFUEF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Dropped-equipment synchronization notices now remain available until they are displayed once on the next mounted session screen, reducing the chance of missed updates.

- **Documentation**
  - Updated project documentation and acknowledgments, including guidance for the 64px tap-target size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->