### PR TITLE
fix: make progress photo paths portable across platforms

### DIFF
--- a/lib/progress-photo.ts
+++ b/lib/progress-photo.ts
@@ -80,7 +80,7 @@ export function photoRelativePath(
   photoId: string,
   mime: ProgressPhotoMime,
 ): string {
-  return path.join(userId, `${photoId}.${extensionForMime(mime)}`);
+  return path.posix.join(userId, `${photoId}.${extensionForMime(mime)}`);
 }
 
 // Real path of the deepest component of `target` that exists on disk. A path


### PR DESCRIPTION
## Motivation

photoRelativePath currently uses path.join, so the persisted storage path becomes platform-dependent. On Windows this can produce backslashes even though the stored path is later treated as a portable relative path.

## What changed

- Build progress-photo storage paths with path.posix.join.
- Keep filesystem path handling unchanged elsewhere.

## Tests

- npx vitest run lib/progress-photo.test.ts - 18/18 passed on Linux/ext4.
- bash scripts/verify.sh - green: lint, typecheck, 106 test files / 1031 tests, and production build.

The full gate was run from a Linux/ext4 copy because the existing file-permission tests rely on Unix mode bits that are not represented correctly in the Windows/NTFS worktree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized stored photo paths across platforms for more consistent photo handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->