### PR TITLE
feat: add calendar-based workout history

### DIFF
--- a/app/(app)/history/page.tsx
+++ b/app/(app)/history/page.tsx
@@ -1,58 +1,45 @@
-import Link from 'next/link';
-import { getFormatter, getLocale, getTranslations } from 'next-intl/server';
-import { Calendar, ChevronRight, History as HistoryIcon } from 'lucide-react';
+import { getLocale, getTranslations } from 'next-intl/server';
+import { CalendarDays } from 'lucide-react';
 import { db } from '@/lib/db';
 import { requireSession } from '@/lib/auth';
-import { Card, CardContent } from '@/components/ui/card';
 import { EmptyState } from '@/components/ui/empty-state';
-import { Badge } from '@/components/ui/badge';
 import { applyBodyweight, totalVolume } from '@/lib/stats';
 import { formatWeight } from '@/lib/units';
 import { formatDistance, formatDuration } from '@/lib/cardio';
 import { HistoryFilters } from '@/components/history/history-filters';
+import {
+  HistoryCalendar,
+  type HistoryCalendarSession,
+} from '@/components/history/history-calendar';
 import { getExerciseDisplayName } from '@/i18n/exercise-names';
 import { getTrainingDisplayName } from '@/i18n/training-names';
+import { formatMonthKey, getMonthQueryRange, parseMonthKey } from '@/lib/history-calendar';
 
 interface SearchParams {
   programId?: string;
-  month?: string; // YYYY-MM
+  month?: string;
+  day?: string;
 }
 
 export default async function HistoryPage(props: { searchParams: Promise<SearchParams> }) {
   const t = await getTranslations('history');
-  const common = await getTranslations('common');
   const locale = await getLocale();
-  const format = await getFormatter();
   const searchParams = await props.searchParams;
-  const session = await requireSession();
-
-  const hasActiveFilters = Boolean(searchParams.programId || searchParams.month);
-
-  // Filters: program and month (YYYY-MM).
+  const auth = await requireSession();
+  const month = parseMonthKey(searchParams.month);
+  const monthKey = formatMonthKey(month);
+  const monthRange = getMonthQueryRange(month);
   const programFilter = searchParams.programId ? { programId: searchParams.programId } : {};
 
-  let dateFilter: { startedAt?: { gte: Date; lt: Date } } = {};
-  if (searchParams.month && /^\d{4}-\d{2}$/.test(searchParams.month)) {
-    const [yStr, mStr] = searchParams.month.split('-');
-    const y = Number(yStr);
-    const m = Number(mStr);
-    dateFilter = {
-      startedAt: {
-        gte: new Date(Date.UTC(y, m - 1, 1)),
-        lt: new Date(Date.UTC(y, m, 1)),
-      },
-    };
-  }
-
-  const [sessions, programs, user] = await Promise.all([
+  const [sessions, programs, user, totalHistoryCount] = await Promise.all([
     db.session.findMany({
       where: {
-        userId: session.userId,
+        userId: auth.userId,
         finishedAt: { not: null },
+        startedAt: monthRange,
         ...programFilter,
-        ...dateFilter,
       },
-      orderBy: { startedAt: 'desc' },
+      orderBy: { startedAt: 'asc' },
       include: {
         workout: { select: { name: true } },
         program: { select: { name: true } },
@@ -68,54 +55,25 @@ export default async function HistoryPage(props: { searchParams: Promise<SearchP
           },
         },
       },
-      take: 100,
     }),
     db.program.findMany({
-      where: { userId: session.userId },
+      where: { userId: auth.userId },
       orderBy: [{ isActive: 'desc' }, { startDate: 'desc' }],
       select: { id: true, name: true },
     }),
     db.user.findUnique({
-      where: { id: session.userId },
+      where: { id: auth.userId },
       select: { bodyweight: true, unit: true },
     }),
+    db.session.count({
+      where: { userId: auth.userId, finishedAt: { not: null } },
+    }),
   ]);
+
   const unit = user?.unit ?? 'KG';
-
-  return (
-    <main className="flex-1 px-4 py-6">
-      <div className="mx-auto flex max-w-2xl flex-col gap-6">
-        <div className="flex items-center gap-3">
-          <HistoryIcon className="size-6" />
-          <h1 className="text-2xl font-bold tracking-tight">{t('title')}</h1>
-        </div>
-
-        <HistoryFilters
-          programs={programs}
-          selectedProgramId={searchParams.programId}
-          selectedMonth={searchParams.month}
-        />
-
-        {sessions.length === 0 ? (
-          hasActiveFilters ? (
-            <Card>
-              <CardContent className="py-8 text-center text-sm text-muted-foreground">
-                {t('noFiltered')}
-              </CardContent>
-            </Card>
-          ) : (
-            <EmptyState
-              icon={HistoryIcon}
-              title={t('emptyTitle')}
-              description={t('emptyDescription')}
-              action={{ label: t('firstSession'), href: '/session/new' }}
-            />
-          )
-        ) : (
-          <ul className="flex flex-col gap-2">
-            {sessions.map((s) => {
+  const calendarSessions: HistoryCalendarSession[] = sessions.map((session) => {
               const enrichedSets = applyBodyweight(
-                s.sets.map((set) => ({
+      session.sets.map((set) => ({
                   weight: set.weight,
                   reps: set.reps,
                   isWarmup: set.isWarmup,
@@ -124,100 +82,83 @@ export default async function HistoryPage(props: { searchParams: Promise<SearchP
                 })),
                 user?.bodyweight,
               );
-              const volume = totalVolume(enrichedSets);
-              const working = s.sets.filter((set) => !set.isWarmup);
-              const workingSets = working.length;
-              const durationMin =
-                s.finishedAt && s.startedAt
-                  ? Math.round((s.finishedAt.getTime() - s.startedAt.getTime()) / 60000)
-                  : null;
-              // A cardio/imported activity (issue #133+): every working set is a
-              // CARDIO set. Render it as the activity (name, distance, duration,
-              // HR) instead of "Free session - 0 kg vol", which reads as empty.
+    const working = session.sets.filter((set) => !set.isWarmup);
               const cardioSets = working.filter(
                 (set) => set.exercise.category === 'CARDIO' && set.durationSec != null,
               );
-              const isCardio = workingSets > 0 && cardioSets.length === workingSets;
-              const cardioName = cardioSets[0]?.exercise.name
-                ? getExerciseDisplayName(cardioSets[0].exercise.name, locale)
-                : t('cardio');
+    const isCardio = working.length > 0 && cardioSets.length === working.length;
               const cardioDistance = cardioSets.reduce((sum, set) => sum + (set.distanceM ?? 0), 0);
               const cardioDurationSec = cardioSets.reduce(
                 (sum, set) => sum + (set.durationSec ?? 0),
                 0,
               );
               const cardioAvgHr = cardioSets.find((set) => set.avgHr != null)?.avgHr ?? null;
-              return (
-                <li key={s.id}>
-                  <Link href={`/history/${s.id}`} className="block">
-                    <Card className="transition-colors hover:bg-accent/40">
-                      <CardContent className="flex items-center justify-between gap-3 p-4">
-                        <div className="min-w-0 flex-1">
-                          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                            <Calendar className="size-3" />
-                            <span>
-                              {format.dateTime(s.startedAt, {
-                                day: '2-digit',
-                                month: 'long',
-                                year: 'numeric',
-                              })}
-                            </span>
-                          </div>
-                          <p className="mt-0.5 truncate text-base font-medium">
-                            {s.workout?.name
-                              ? getTrainingDisplayName(s.workout.name, locale)
+    const durationMin = session.finishedAt
+      ? Math.round((session.finishedAt.getTime() - session.startedAt.getTime()) / 60000)
+      : null;
+    const cardioName = cardioSets[0]?.exercise.name
+      ? getExerciseDisplayName(cardioSets[0].exercise.name, locale)
+      : t('cardio');
+
+    return {
+      id: session.id,
+      startedAt: session.startedAt.toISOString(),
+      title: session.workout?.name
+        ? getTrainingDisplayName(session.workout.name, locale)
                               : isCardio
                                 ? cardioName
-                                : t('freeSession')}
-                          </p>
-                          <div className="mt-1 flex flex-wrap gap-1.5 text-xs">
-                            {s.program && (
-                              <Badge variant="secondary">
-                                {getTrainingDisplayName(s.program.name, locale)}
-                              </Badge>
-                            )}
-                            {isCardio ? (
-                              <>
-                                {cardioDistance > 0 && (
-                                  <Badge variant="outline">{formatDistance(cardioDistance)}</Badge>
-                                )}
-                                <Badge variant="outline">
-                                  {formatDuration(cardioDurationSec || (durationMin ?? 0) * 60)}
-                                </Badge>
-                                {cardioAvgHr != null && (
-                                  <Badge variant="outline">{cardioAvgHr} bpm</Badge>
-                                )}
-                              </>
-                            ) : (
-                              <>
-                                <Badge variant="outline">
-                                  {common('counts.sets', { count: workingSets })}
-                                </Badge>
-                                <Badge variant="outline">
-                                  {t('volumeShort', {
-                                    weight: formatWeight(volume, unit, {
+          : t('freeSession'),
+      programName: session.program?.name
+        ? getTrainingDisplayName(session.program.name, locale)
+        : null,
+      workingSets: working.length,
+      volumeLabel: isCardio
+        ? null
+        : t('volumeShort', {
+            weight: formatWeight(totalVolume(enrichedSets), unit, {
                                       decimals: 0,
                                       locale,
                                     }),
-                                  })}
-                                </Badge>
-                                {durationMin != null && (
-                                  <Badge variant="outline">
-                                    {t('minutes', { count: durationMin })}
-                                  </Badge>
-                                )}
-                              </>
-                            )}
-                          </div>
+          }),
+      durationLabel:
+        !isCardio && durationMin != null ? t('minutes', { count: durationMin }) : null,
+      cardioDistanceLabel: isCardio && cardioDistance > 0 ? formatDistance(cardioDistance) : null,
+      cardioDurationLabel:
+        isCardio && (cardioDurationSec > 0 || durationMin != null)
+          ? formatDuration(cardioDurationSec || (durationMin ?? 0) * 60)
+          : null,
+      cardioHeartRateLabel: isCardio && cardioAvgHr != null ? `${cardioAvgHr} bpm` : null,
+    };
+  });
+
+  return (
+    <main className="flex-1 px-4 py-6">
+      <div className="mx-auto flex max-w-2xl flex-col gap-6">
+        <div className="flex items-center gap-3">
+          <CalendarDays className="size-6" />
+          <h1 className="text-2xl font-bold tracking-tight">{t('title')}</h1>
                         </div>
-                        <ChevronRight className="size-5 shrink-0 text-muted-foreground" />
-                      </CardContent>
-                    </Card>
-                  </Link>
-                </li>
-              );
-            })}
-          </ul>
+
+        <HistoryFilters
+          programs={programs}
+          selectedProgramId={searchParams.programId}
+          selectedMonth={monthKey}
+        />
+
+        {totalHistoryCount === 0 ? (
+          <EmptyState
+            icon={CalendarDays}
+            title={t('emptyTitle')}
+            description={t('emptyDescription')}
+            action={{ label: t('firstSession'), href: '/session/new' }}
+          />
+        ) : (
+          <HistoryCalendar
+            monthKey={monthKey}
+            initialDay={searchParams.day}
+            sessions={calendarSessions}
+            selectedProgramId={searchParams.programId}
+          />
         )}
       </div>
     </main>

--- a/app/(app)/history/page.tsx
+++ b/app/(app)/history/page.tsx
@@ -1,4 +1,4 @@
-import { getLocale, getTranslations } from 'next-intl/server';
+import { getLocale, getTimeZone, getTranslations } from 'next-intl/server';
 import { CalendarDays } from 'lucide-react';
 import { db } from '@/lib/db';
 import { requireSession } from '@/lib/auth';
@@ -24,9 +24,10 @@ interface SearchParams {
 export default async function HistoryPage(props: { searchParams: Promise<SearchParams> }) {
   const t = await getTranslations('history');
   const locale = await getLocale();
+  const timeZone = await getTimeZone();
   const searchParams = await props.searchParams;
   const auth = await requireSession();
-  const month = parseMonthKey(searchParams.month);
+  const month = parseMonthKey(searchParams.month, new Date(), timeZone);
   const monthKey = formatMonthKey(month);
   const monthRange = getMonthQueryRange(month);
   const programFilter = searchParams.programId ? { programId: searchParams.programId } : {};
@@ -158,6 +159,7 @@ export default async function HistoryPage(props: { searchParams: Promise<SearchP
             initialDay={searchParams.day}
             sessions={calendarSessions}
             selectedProgramId={searchParams.programId}
+            timeZone={timeZone}
           />
         )}
       </div>

--- a/components/history/history-calendar.test.tsx
+++ b/components/history/history-calendar.test.tsx
@@ -17,7 +17,7 @@ vi.mock('next/navigation', () => ({
 const sessions: HistoryCalendarSession[] = [
   {
     id: 'session-1',
-    startedAt: '2026-09-12T10:30:00.000Z',
+    startedAt: new Date(2026, 8, 12, 10, 30).toISOString(),
     title: 'Upper body',
     programName: 'Strength',
     workingSets: 4,
@@ -29,7 +29,7 @@ const sessions: HistoryCalendarSession[] = [
   },
   {
     id: 'session-2',
-    startedAt: '2026-09-12T16:00:00.000Z',
+    startedAt: new Date(2026, 8, 12, 16, 0).toISOString(),
     title: 'Evening session',
     programName: null,
     workingSets: 3,
@@ -50,11 +50,16 @@ describe('HistoryCalendar', () => {
 
   it('marks workout days and lists sessions for the selected date', () => {
     render(
-      <HistoryCalendar monthKey="2026-09" initialDay="2026-09-12" sessions={sessions} />,
+      <HistoryCalendar
+        monthKey="2026-09"
+        initialDay="2026-09-12"
+        sessions={sessions}
+        timeZone={Intl.DateTimeFormat().resolvedOptions().timeZone}
+      />,
     );
 
-    const day = screen.getByRole('gridcell', { name: /12.*2 workouts/i });
-    expect(day).toHaveAttribute('aria-selected', 'true');
+    const day = screen.getByRole('button', { name: /12.*2 workouts/i });
+    expect(day).toHaveAttribute('aria-pressed', 'true');
     expect(screen.getByText('Upper body')).toBeInTheDocument();
     expect(screen.getByText('Evening session')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Upper body/i })).toHaveAttribute(
@@ -66,10 +71,15 @@ describe('HistoryCalendar', () => {
   it('updates the selected day in place without navigating away', () => {
     const replaceState = vi.spyOn(window.history, 'replaceState');
     render(
-      <HistoryCalendar monthKey="2026-09" initialDay="2026-09-12" sessions={sessions} />,
+      <HistoryCalendar
+        monthKey="2026-09"
+        initialDay="2026-09-12"
+        sessions={sessions}
+        timeZone={Intl.DateTimeFormat().resolvedOptions().timeZone}
+      />,
     );
 
-    fireEvent.click(screen.getByRole('gridcell', { name: /13/ }));
+    fireEvent.click(screen.getByRole('button', { name: /13/ }));
 
     expect(screen.getByText('No completed workouts on this date.')).toBeInTheDocument();
     expect(replaceState).toHaveBeenLastCalledWith(null, '', '/history?month=2026-09&day=2026-09-13');
@@ -84,6 +94,7 @@ describe('HistoryCalendar', () => {
         initialDay="2026-09-12"
         sessions={sessions}
         selectedProgramId="program-1"
+        timeZone={Intl.DateTimeFormat().resolvedOptions().timeZone}
       />,
     );
 

--- a/components/history/history-calendar.test.tsx
+++ b/components/history/history-calendar.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { HistoryCalendar, type HistoryCalendarSession } from './history-calendar';
+
+const navigation = vi.hoisted(() => ({
+  push: vi.fn(),
+  pathname: '/history',
+  query: 'month=2026-09',
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: navigation.push }),
+  usePathname: () => navigation.pathname,
+  useSearchParams: () => new URLSearchParams(navigation.query),
+}));
+
+const sessions: HistoryCalendarSession[] = [
+  {
+    id: 'session-1',
+    startedAt: '2026-09-12T10:30:00.000Z',
+    title: 'Upper body',
+    programName: 'Strength',
+    workingSets: 4,
+    volumeLabel: '2,400 kg vol.',
+    durationLabel: '45 min',
+    cardioDistanceLabel: null,
+    cardioDurationLabel: null,
+    cardioHeartRateLabel: null,
+  },
+  {
+    id: 'session-2',
+    startedAt: '2026-09-12T16:00:00.000Z',
+    title: 'Evening session',
+    programName: null,
+    workingSets: 3,
+    volumeLabel: '1,500 kg vol.',
+    durationLabel: '30 min',
+    cardioDistanceLabel: null,
+    cardioDurationLabel: null,
+    cardioHeartRateLabel: null,
+  },
+];
+
+describe('HistoryCalendar', () => {
+  beforeEach(() => {
+    navigation.push.mockReset();
+    navigation.query = 'month=2026-09';
+    window.history.replaceState({}, '', '/history?month=2026-09');
+  });
+
+  it('marks workout days and lists sessions for the selected date', () => {
+    render(
+      <HistoryCalendar monthKey="2026-09" initialDay="2026-09-12" sessions={sessions} />,
+    );
+
+    const day = screen.getByRole('gridcell', { name: /12.*2 workouts/i });
+    expect(day).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByText('Upper body')).toBeInTheDocument();
+    expect(screen.getByText('Evening session')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Upper body/i })).toHaveAttribute(
+      'href',
+      '/history/session-1?month=2026-09&day=2026-09-12',
+    );
+  });
+
+  it('updates the selected day in place without navigating away', () => {
+    const replaceState = vi.spyOn(window.history, 'replaceState');
+    render(
+      <HistoryCalendar monthKey="2026-09" initialDay="2026-09-12" sessions={sessions} />,
+    );
+
+    fireEvent.click(screen.getByRole('gridcell', { name: /13/ }));
+
+    expect(screen.getByText('No completed workouts on this date.')).toBeInTheDocument();
+    expect(replaceState).toHaveBeenLastCalledWith(null, '', '/history?month=2026-09&day=2026-09-13');
+    replaceState.mockRestore();
+  });
+
+  it('navigates between months while preserving other query filters', () => {
+    navigation.query = 'programId=program-1&month=2026-09';
+    render(
+      <HistoryCalendar
+        monthKey="2026-09"
+        initialDay="2026-09-12"
+        sessions={sessions}
+        selectedProgramId="program-1"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next month' }));
+
+    expect(navigation.push).toHaveBeenCalledTimes(1);
+    const href = navigation.push.mock.calls[0]?.[0] as string;
+    expect(href).toContain('/history?');
+    const params = new URLSearchParams(href.split('?')[1]);
+    expect(params.get('month')).toBe('2026-10');
+    expect(params.get('programId')).toBe('program-1');
+    expect(params.has('day')).toBe(false);
+  });
+});

--- a/components/history/history-calendar.tsx
+++ b/components/history/history-calendar.tsx
@@ -36,9 +36,16 @@ interface Props {
   initialDay?: string;
   sessions: HistoryCalendarSession[];
   selectedProgramId?: string;
+  timeZone: string;
 }
 
-export function HistoryCalendar({ monthKey, initialDay, sessions, selectedProgramId }: Props) {
+export function HistoryCalendar({
+  monthKey,
+  initialDay,
+  sessions,
+  selectedProgramId,
+  timeZone,
+}: Props) {
   const t = useTranslations('history.calendar');
   const common = useTranslations('common');
   const locale = useLocale();
@@ -51,12 +58,12 @@ export function HistoryCalendar({ monthKey, initialDay, sessions, selectedProgra
   const month = useMemo(() => parseMonthKey(monthKey), [monthKey]);
   const weekStartsOn: 0 | 1 = locale.toLowerCase().startsWith('ru') ? 1 : 0;
   const cells = useMemo(() => buildMonthGrid(month, weekStartsOn), [month, weekStartsOn]);
-  const todayKey = dateKeyInTimeZone(new Date());
+  const todayKey = dateKeyInTimeZone(new Date(), timeZone);
 
   const sessionsByDate = useMemo(() => {
     const grouped = new Map<string, HistoryCalendarSession[]>();
     for (const session of sessions) {
-      const dateKey = dateKeyInTimeZone(session.startedAt);
+      const dateKey = dateKeyInTimeZone(session.startedAt, timeZone);
       if (!dateKey.startsWith(`${monthKey}-`)) continue;
       const daySessions = grouped.get(dateKey) ?? [];
       daySessions.push(session);
@@ -66,7 +73,7 @@ export function HistoryCalendar({ monthKey, initialDay, sessions, selectedProgra
       daySessions.sort((a, b) => a.startedAt.localeCompare(b.startedAt));
     }
     return grouped;
-  }, [monthKey, sessions]);
+  }, [monthKey, sessions, timeZone]);
 
   const defaultDate = useMemo(() => {
     if (isDateKey(initialDay) && initialDay.startsWith(`${monthKey}-`)) return initialDay;
@@ -108,9 +115,7 @@ export function HistoryCalendar({ monthKey, initialDay, sessions, selectedProgra
   }
 
   function goToToday() {
-    const now = new Date();
-    const targetMonth = formatMonthKey({ year: now.getFullYear(), monthIndex: now.getMonth() });
-    updateLocation(targetMonth, todayKey);
+    updateLocation(todayKey.slice(0, 7), todayKey);
   }
 
   function updateLocation(nextMonth: string, day: string | undefined) {
@@ -170,12 +175,11 @@ export function HistoryCalendar({ monthKey, initialDay, sessions, selectedProgra
             </Button>
           </div>
 
-          <div className="grid grid-cols-7 text-center" role="grid" aria-label={monthLabel}>
+          <div className="grid grid-cols-7 text-center" aria-label={monthLabel}>
             {weekdayLabels.map((label, index) => (
               <div
                 key={`${label}-${index}`}
                 className="pb-2 text-xs font-medium uppercase text-muted-foreground"
-                role="columnheader"
               >
                 {label}
               </div>
@@ -202,9 +206,8 @@ export function HistoryCalendar({ monthKey, initialDay, sessions, selectedProgra
                 <button
                   key={cell.dateKey}
                   type="button"
-                  role="gridcell"
                   aria-label={accessibleLabel}
-                  aria-selected={isSelected}
+                  aria-pressed={isSelected}
                   onClick={() => selectDay(cell.dateKey!)}
                   className={cn(
                     'relative flex aspect-square min-h-11 flex-col items-center justify-center rounded-lg border border-transparent text-sm transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',

--- a/components/history/history-calendar.tsx
+++ b/components/history/history-calendar.tsx
@@ -1,0 +1,317 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useMemo, useState, useTransition } from 'react';
+import { useFormatter, useLocale, useTranslations } from 'next-intl';
+import { CalendarDays, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+import {
+  buildMonthGrid,
+  dateKeyInTimeZone,
+  formatMonthKey,
+  isDateKey,
+  parseMonthKey,
+  shiftCalendarMonth,
+} from '@/lib/history-calendar';
+
+export interface HistoryCalendarSession {
+  id: string;
+  startedAt: string;
+  title: string;
+  programName: string | null;
+  workingSets: number;
+  volumeLabel: string | null;
+  durationLabel: string | null;
+  cardioDistanceLabel: string | null;
+  cardioDurationLabel: string | null;
+  cardioHeartRateLabel: string | null;
+}
+
+interface Props {
+  monthKey: string;
+  initialDay?: string;
+  sessions: HistoryCalendarSession[];
+  selectedProgramId?: string;
+}
+
+export function HistoryCalendar({ monthKey, initialDay, sessions, selectedProgramId }: Props) {
+  const t = useTranslations('history.calendar');
+  const common = useTranslations('common');
+  const locale = useLocale();
+  const format = useFormatter();
+  const router = useRouter();
+  const pathname = usePathname();
+  const search = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+
+  const month = useMemo(() => parseMonthKey(monthKey), [monthKey]);
+  const weekStartsOn: 0 | 1 = locale.toLowerCase().startsWith('ru') ? 1 : 0;
+  const cells = useMemo(() => buildMonthGrid(month, weekStartsOn), [month, weekStartsOn]);
+  const todayKey = dateKeyInTimeZone(new Date());
+
+  const sessionsByDate = useMemo(() => {
+    const grouped = new Map<string, HistoryCalendarSession[]>();
+    for (const session of sessions) {
+      const dateKey = dateKeyInTimeZone(session.startedAt);
+      if (!dateKey.startsWith(`${monthKey}-`)) continue;
+      const daySessions = grouped.get(dateKey) ?? [];
+      daySessions.push(session);
+      grouped.set(dateKey, daySessions);
+    }
+    for (const daySessions of grouped.values()) {
+      daySessions.sort((a, b) => a.startedAt.localeCompare(b.startedAt));
+    }
+    return grouped;
+  }, [monthKey, sessions]);
+
+  const defaultDate = useMemo(() => {
+    if (isDateKey(initialDay) && initialDay.startsWith(`${monthKey}-`)) return initialDay;
+    if (todayKey.startsWith(`${monthKey}-`)) return todayKey;
+    return [...sessionsByDate.keys()].sort()[0] ?? `${monthKey}-01`;
+  }, [initialDay, monthKey, sessionsByDate, todayKey]);
+
+  const [selectedDate, setSelectedDate] = useState(defaultDate);
+
+  useEffect(() => {
+    setSelectedDate(defaultDate);
+  }, [defaultDate]);
+
+  const selectedSessions = sessionsByDate.get(selectedDate) ?? [];
+  const weekdayLabels = useMemo(() => {
+    const sunday = new Date(2024, 0, 7, 12);
+    return Array.from({ length: 7 }, (_, index) => {
+      const dayOffset = (weekStartsOn + index) % 7;
+      const date = new Date(sunday);
+      date.setDate(sunday.getDate() + dayOffset);
+      return format.dateTime(date, { weekday: 'short' });
+    });
+  }, [format, weekStartsOn]);
+
+  const monthLabel = format.dateTime(new Date(month.year, month.monthIndex, 1, 12), {
+    month: 'long',
+    year: 'numeric',
+  });
+  const selectedDateLabel = format.dateTime(dateKeyToLocalDate(selectedDate), {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
+
+  function navigateToMonth(delta: number) {
+    const target = shiftCalendarMonth(month, delta);
+    updateLocation(formatMonthKey(target), undefined);
+  }
+
+  function goToToday() {
+    const now = new Date();
+    const targetMonth = formatMonthKey({ year: now.getFullYear(), monthIndex: now.getMonth() });
+    updateLocation(targetMonth, todayKey);
+  }
+
+  function updateLocation(nextMonth: string, day: string | undefined) {
+    const params = new URLSearchParams(search.toString());
+    params.set('month', nextMonth);
+    if (day) params.set('day', day);
+    else params.delete('day');
+    if (selectedProgramId) params.set('programId', selectedProgramId);
+    const href = `${pathname}?${params.toString()}`;
+    startTransition(() => router.push(href));
+  }
+
+  function selectDay(dateKey: string) {
+    setSelectedDate(dateKey);
+    const params = new URLSearchParams(window.location.search);
+    params.set('day', dateKey);
+    window.history.replaceState(null, '', `${pathname}?${params.toString()}`);
+  }
+
+  return (
+    <div className="flex flex-col gap-4" aria-busy={isPending}>
+      <Card className={cn('overflow-hidden transition-opacity', isPending && 'opacity-60')}>
+        <CardContent className="p-3 sm:p-4">
+          <div className="mb-3 flex items-center justify-between gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              onClick={() => navigateToMonth(-1)}
+              disabled={isPending}
+              aria-label={t('previousMonth')}
+            >
+              <ChevronLeft className="size-5" />
+            </Button>
+            <div className="min-w-0 text-center">
+              <div className="truncate text-lg font-semibold capitalize">{monthLabel}</div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2 text-xs"
+                onClick={goToToday}
+                disabled={isPending}
+              >
+                {t('today')}
+              </Button>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              onClick={() => navigateToMonth(1)}
+              disabled={isPending}
+              aria-label={t('nextMonth')}
+            >
+              <ChevronRight className="size-5" />
+            </Button>
+          </div>
+
+          <div className="grid grid-cols-7 text-center" role="grid" aria-label={monthLabel}>
+            {weekdayLabels.map((label, index) => (
+              <div
+                key={`${label}-${index}`}
+                className="pb-2 text-xs font-medium uppercase text-muted-foreground"
+                role="columnheader"
+              >
+                {label}
+              </div>
+            ))}
+            {cells.map((cell, index) => {
+              if (!cell.dateKey || !cell.dayNumber) {
+                return <div key={`blank-${index}`} className="aspect-square min-h-11" aria-hidden />;
+              }
+
+              const daySessions = sessionsByDate.get(cell.dateKey) ?? [];
+              const isToday = cell.dateKey === todayKey;
+              const isSelected = cell.dateKey === selectedDate;
+              const dateLabel = format.dateTime(dateKeyToLocalDate(cell.dateKey), {
+                weekday: 'long',
+                day: 'numeric',
+                month: 'long',
+                year: 'numeric',
+              });
+              const accessibleLabel = daySessions.length
+                ? `${dateLabel}, ${t('workoutCount', { count: daySessions.length })}`
+                : dateLabel;
+
+              return (
+                <button
+                  key={cell.dateKey}
+                  type="button"
+                  role="gridcell"
+                  aria-label={accessibleLabel}
+                  aria-selected={isSelected}
+                  onClick={() => selectDay(cell.dateKey!)}
+                  className={cn(
+                    'relative flex aspect-square min-h-11 flex-col items-center justify-center rounded-lg border border-transparent text-sm transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                    isToday && 'border-primary font-semibold',
+                    isSelected && 'bg-primary text-primary-foreground hover:bg-primary/90',
+                  )}
+                >
+                  <span>{cell.dayNumber}</span>
+                  {daySessions.length > 0 && (
+                    <span
+                      className={cn(
+                        'mt-0.5 flex min-h-3 min-w-3 items-center justify-center rounded-full bg-primary px-1 text-[9px] font-bold leading-3 text-primary-foreground',
+                        isSelected && 'bg-primary-foreground text-primary',
+                      )}
+                      aria-hidden
+                    >
+                      {daySessions.length > 1 ? daySessions.length : ''}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </CardContent>
+      </Card>
+
+      <section className="flex flex-col gap-2" aria-labelledby="selected-day-heading">
+        <div className="flex items-center gap-2">
+          <CalendarDays className="size-5 text-muted-foreground" />
+          <h2 id="selected-day-heading" className="text-lg font-semibold capitalize">
+            {selectedDateLabel}
+          </h2>
+        </div>
+
+        {selectedSessions.length === 0 ? (
+          <Card>
+            <CardContent className="py-6 text-center text-sm text-muted-foreground">
+              {t('noSessions')}
+            </CardContent>
+          </Card>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {selectedSessions.map((session) => {
+              const returnParams = new URLSearchParams({ month: monthKey, day: selectedDate });
+              if (selectedProgramId) returnParams.set('programId', selectedProgramId);
+              return (
+                <li key={session.id}>
+                  <Link
+                    href={`/history/${session.id}?${returnParams.toString()}`}
+                    className="block"
+                  >
+                    <Card className="transition-colors hover:bg-accent/40">
+                      <CardContent className="flex items-center justify-between gap-3 p-4">
+                        <div className="min-w-0 flex-1">
+                          <p className="truncate text-base font-medium">{session.title}</p>
+                          <p className="mt-0.5 text-xs text-muted-foreground">
+                            {format.dateTime(new Date(session.startedAt), {
+                              hour: '2-digit',
+                              minute: '2-digit',
+                            })}
+                          </p>
+                          <div className="mt-2 flex flex-wrap gap-1.5 text-xs">
+                            {session.programName && (
+                              <Badge variant="secondary">{session.programName}</Badge>
+                            )}
+                            {session.cardioDistanceLabel && (
+                              <Badge variant="outline">{session.cardioDistanceLabel}</Badge>
+                            )}
+                            {session.cardioDurationLabel && (
+                              <Badge variant="outline">{session.cardioDurationLabel}</Badge>
+                            )}
+                            {session.cardioHeartRateLabel && (
+                              <Badge variant="outline">{session.cardioHeartRateLabel}</Badge>
+                            )}
+                            {!session.cardioDurationLabel && (
+                              <>
+                                <Badge variant="outline">
+                                  {common('counts.sets', { count: session.workingSets })}
+                                </Badge>
+                                {session.volumeLabel && (
+                                  <Badge variant="outline">{session.volumeLabel}</Badge>
+                                )}
+                                {session.durationLabel && (
+                                  <Badge variant="outline">{session.durationLabel}</Badge>
+                                )}
+                              </>
+                            )}
+                          </div>
+                        </div>
+                        <ChevronRight className="size-5 shrink-0 text-muted-foreground" />
+                      </CardContent>
+                    </Card>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function dateKeyToLocalDate(dateKey: string): Date {
+  const [year, month, day] = dateKey.split('-').map(Number);
+  if (year === undefined || month === undefined || day === undefined) {
+    throw new Error(`Invalid date key: ${dateKey}`);
+  }
+  return new Date(year, month - 1, day, 12);
+}

--- a/components/history/history-filters.tsx
+++ b/components/history/history-filters.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTransition } from 'react';
-import { useFormatter, useTranslations } from 'next-intl';
+import { useTranslations } from 'next-intl';
 import { Download, Filter, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
@@ -17,39 +17,23 @@ import { useTrainingName } from '@/components/shared/use-training-name';
 interface Props {
   programs: { id: string; name: string }[];
   selectedProgramId?: string;
-  selectedMonth?: string; // YYYY-MM
-}
-
-// Generates the last 12 months (including the current month) in YYYY-MM format.
-function recentMonths(formatLabel: (date: Date) => string): { value: string; label: string }[] {
-  const now = new Date();
-  const out: { value: string; label: string }[] = [];
-  for (let i = 0; i < 12; i++) {
-    const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
-    const value = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
-    out.push({ value, label: formatLabel(d) });
-  }
-  return out;
+  selectedMonth: string;
 }
 
 export function HistoryFilters({ programs, selectedProgramId, selectedMonth }: Props) {
   const t = useTranslations('history.filters');
   const trainingName = useTrainingName();
-  const format = useFormatter();
   const router = useRouter();
   const search = useSearchParams();
   const [isPending, startTransition] = useTransition();
-  const months = recentMonths((date) => format.dateTime(date, { month: 'long', year: 'numeric' }));
-  const hasFilter = !!(selectedProgramId || selectedMonth);
 
-  function update(key: 'programId' | 'month', value: string | undefined) {
+  function updateProgram(value: string | undefined) {
     const params = new URLSearchParams(search.toString());
-    if (value) params.set(key, value);
-    else params.delete(key);
-    const qs = params.toString();
-    startTransition(() => {
-      router.push(qs ? `/history?${qs}` : '/history');
-    });
+    if (value) params.set('programId', value);
+    else params.delete('programId');
+    params.set('month', selectedMonth);
+    params.delete('day');
+    startTransition(() => router.push(`/history?${params.toString()}`));
   }
 
   return (
@@ -61,43 +45,26 @@ export function HistoryFilters({ programs, selectedProgramId, selectedMonth }: P
 
       <Select
         value={selectedProgramId ?? 'all'}
-        onValueChange={(v) => update('programId', v === 'all' ? undefined : v)}
+        onValueChange={(value) => updateProgram(value === 'all' ? undefined : value)}
       >
-        <SelectTrigger className="h-9 w-auto min-w-[10rem]">
+        <SelectTrigger className="h-9 w-auto min-w-[10rem]" disabled={isPending}>
           <SelectValue placeholder={t('program')} />
         </SelectTrigger>
         <SelectContent>
           <SelectItem value="all">{t('allPrograms')}</SelectItem>
-          {programs.map((p) => (
-            <SelectItem key={p.id} value={p.id}>
-              {trainingName(p.name)}
+          {programs.map((program) => (
+            <SelectItem key={program.id} value={program.id}>
+              {trainingName(program.name)}
             </SelectItem>
           ))}
         </SelectContent>
       </Select>
 
-      <Select
-        value={selectedMonth ?? 'all'}
-        onValueChange={(v) => update('month', v === 'all' ? undefined : v)}
-      >
-        <SelectTrigger className="h-9 w-auto min-w-[9rem]">
-          <SelectValue placeholder={t('month')} />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">{t('allMonths')}</SelectItem>
-          {months.map((m) => (
-            <SelectItem key={m.value} value={m.value}>
-              {m.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-
-      {hasFilter && (
+      {selectedProgramId && (
         <Button
           variant="ghost"
           size="sm"
-          onClick={() => startTransition(() => router.push('/history'))}
+          onClick={() => updateProgram(undefined)}
           disabled={isPending}
         >
           <X className="size-4" />
@@ -115,10 +82,8 @@ export function HistoryFilters({ programs, selectedProgramId, selectedMonth }: P
   );
 }
 
-function buildCsvHref(programId?: string, month?: string): string {
-  const params = new URLSearchParams();
+function buildCsvHref(programId: string | undefined, month: string): string {
+  const params = new URLSearchParams({ month });
   if (programId) params.set('programId', programId);
-  if (month) params.set('month', month);
-  const qs = params.toString();
-  return qs ? `/api/history/csv?${qs}` : '/api/history/csv';
+  return `/api/history/csv?${params.toString()}`;
 }

--- a/lib/history-calendar.test.ts
+++ b/lib/history-calendar.test.ts
@@ -11,7 +11,7 @@ import {
 
 describe('history calendar helpers', () => {
   it('parses, formats and shifts month keys across year boundaries', () => {
-    expect(parseMonthKey('2026-09', new Date('2000-01-01T00:00:00Z'))).toEqual({
+    expect(parseMonthKey('2026-09', new Date('2000-01-01T00:00:00Z'), 'UTC')).toEqual({
       year: 2026,
       monthIndex: 8,
     });
@@ -43,9 +43,21 @@ describe('history calendar helpers', () => {
     expect(dateKeyInTimeZone(instant, 'America/Los_Angeles')).toBe('2026-08-31');
   });
 
-  it('validates calendar day keys without accepting partial values', () => {
+  it('validates real calendar day keys including leap years', () => {
     expect(isDateKey('2026-09-12')).toBe(true);
+    expect(isDateKey('2024-02-29')).toBe(true);
+    expect(isDateKey('2026-02-29')).toBe(false);
+    expect(isDateKey('2026-13-01')).toBe(false);
+    expect(isDateKey('2026-04-31')).toBe(false);
     expect(isDateKey('2026-9-12')).toBe(false);
     expect(isDateKey(undefined)).toBe(false);
+  });
+
+  it('uses the explicit timezone for the fallback month', () => {
+    const fallback = new Date('2026-09-01T00:30:00.000Z');
+    expect(parseMonthKey(undefined, fallback, 'America/Los_Angeles')).toEqual({
+      year: 2026,
+      monthIndex: 7,
+    });
   });
 });

--- a/lib/history-calendar.test.ts
+++ b/lib/history-calendar.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildMonthGrid,
+  dateKeyInTimeZone,
+  formatMonthKey,
+  getMonthQueryRange,
+  isDateKey,
+  parseMonthKey,
+  shiftCalendarMonth,
+} from './history-calendar';
+
+describe('history calendar helpers', () => {
+  it('parses, formats and shifts month keys across year boundaries', () => {
+    expect(parseMonthKey('2026-09', new Date('2000-01-01T00:00:00Z'))).toEqual({
+      year: 2026,
+      monthIndex: 8,
+    });
+    expect(formatMonthKey({ year: 2026, monthIndex: 8 })).toBe('2026-09');
+    expect(shiftCalendarMonth({ year: 2026, monthIndex: 11 }, 1)).toEqual({
+      year: 2027,
+      monthIndex: 0,
+    });
+  });
+
+  it('builds a fixed six-week grid with the requested week start', () => {
+    const mondayGrid = buildMonthGrid({ year: 2026, monthIndex: 8 }, 1);
+    expect(mondayGrid).toHaveLength(42);
+    expect(mondayGrid[0]).toEqual({ dateKey: null, dayNumber: null });
+    expect(mondayGrid[1]).toEqual({ dateKey: '2026-09-01', dayNumber: 1 });
+    expect(mondayGrid[30]).toEqual({ dateKey: '2026-09-30', dayNumber: 30 });
+    expect(mondayGrid[31]).toEqual({ dateKey: null, dayNumber: null });
+  });
+
+  it('pads the server query so client-local month boundaries are not dropped', () => {
+    const range = getMonthQueryRange({ year: 2026, monthIndex: 8 });
+    expect(range.gte.toISOString()).toBe('2026-08-30T12:00:00.000Z');
+    expect(range.lt.toISOString()).toBe('2026-10-02T12:00:00.000Z');
+  });
+
+  it('resolves date keys in an explicit timezone', () => {
+    const instant = new Date('2026-09-01T00:30:00.000Z');
+    expect(dateKeyInTimeZone(instant, 'UTC')).toBe('2026-09-01');
+    expect(dateKeyInTimeZone(instant, 'America/Los_Angeles')).toBe('2026-08-31');
+  });
+
+  it('validates calendar day keys without accepting partial values', () => {
+    expect(isDateKey('2026-09-12')).toBe(true);
+    expect(isDateKey('2026-9-12')).toBe(false);
+    expect(isDateKey(undefined)).toBe(false);
+  });
+});

--- a/lib/history-calendar.ts
+++ b/lib/history-calendar.ts
@@ -16,7 +16,11 @@ export function formatMonthKey(month: CalendarMonth): string {
   return `${month.year}-${String(month.monthIndex + 1).padStart(2, '0')}`;
 }
 
-export function parseMonthKey(value: string | undefined, fallback = new Date()): CalendarMonth {
+export function parseMonthKey(
+  value: string | undefined,
+  fallback = new Date(),
+  timeZone?: string,
+): CalendarMonth {
   const match = value?.match(MONTH_PATTERN);
   if (match) {
     const year = Number(match[1]);
@@ -26,7 +30,11 @@ export function parseMonthKey(value: string | undefined, fallback = new Date()):
     }
   }
 
-  return { year: fallback.getFullYear(), monthIndex: fallback.getMonth() };
+  const fallbackDateKey = dateKeyInTimeZone(fallback, timeZone);
+  return {
+    year: Number(fallbackDateKey.slice(0, 4)),
+    monthIndex: Number(fallbackDateKey.slice(5, 7)) - 1,
+  };
 }
 
 export function shiftCalendarMonth(month: CalendarMonth, delta: number): CalendarMonth {
@@ -89,5 +97,11 @@ export function dateKeyInTimeZone(value: Date | string, timeZone?: string): stri
 }
 
 export function isDateKey(value: string | undefined): value is string {
-  return Boolean(value && DATE_KEY_PATTERN.test(value));
+  if (!value || !DATE_KEY_PATTERN.test(value)) return false;
+  const year = Number(value.slice(0, 4));
+  const month = Number(value.slice(5, 7));
+  const day = Number(value.slice(8, 10));
+  if (year < 1970 || year > 9999 || month < 1 || month > 12 || day < 1) return false;
+  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  return day <= daysInMonth;
 }

--- a/lib/history-calendar.ts
+++ b/lib/history-calendar.ts
@@ -1,0 +1,93 @@
+export interface CalendarMonth {
+  year: number;
+  monthIndex: number;
+}
+
+export interface CalendarDayCell {
+  dateKey: string | null;
+  dayNumber: number | null;
+}
+
+const MONTH_PATTERN = /^(\d{4})-(\d{2})$/;
+const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const QUERY_PADDING_MS = 36 * 60 * 60 * 1000;
+
+export function formatMonthKey(month: CalendarMonth): string {
+  return `${month.year}-${String(month.monthIndex + 1).padStart(2, '0')}`;
+}
+
+export function parseMonthKey(value: string | undefined, fallback = new Date()): CalendarMonth {
+  const match = value?.match(MONTH_PATTERN);
+  if (match) {
+    const year = Number(match[1]);
+    const monthIndex = Number(match[2]) - 1;
+    if (year >= 1970 && year <= 9999 && monthIndex >= 0 && monthIndex <= 11) {
+      return { year, monthIndex };
+    }
+  }
+
+  return { year: fallback.getFullYear(), monthIndex: fallback.getMonth() };
+}
+
+export function shiftCalendarMonth(month: CalendarMonth, delta: number): CalendarMonth {
+  const shifted = new Date(Date.UTC(month.year, month.monthIndex + delta, 1));
+  return { year: shifted.getUTCFullYear(), monthIndex: shifted.getUTCMonth() };
+}
+
+export function buildMonthGrid(
+  month: CalendarMonth,
+  weekStartsOn: 0 | 1,
+): CalendarDayCell[] {
+  const firstWeekday = new Date(Date.UTC(month.year, month.monthIndex, 1)).getUTCDay();
+  const leadingCells = (firstWeekday - weekStartsOn + 7) % 7;
+  const daysInMonth = new Date(Date.UTC(month.year, month.monthIndex + 1, 0)).getUTCDate();
+  const cells: CalendarDayCell[] = [];
+
+  for (let index = 0; index < 42; index += 1) {
+    const dayNumber = index - leadingCells + 1;
+    if (dayNumber < 1 || dayNumber > daysInMonth) {
+      cells.push({ dateKey: null, dayNumber: null });
+      continue;
+    }
+
+    cells.push({
+      dateKey: `${month.year}-${String(month.monthIndex + 1).padStart(2, '0')}-${String(dayNumber).padStart(2, '0')}`,
+      dayNumber,
+    });
+  }
+
+  return cells;
+}
+
+export function getMonthQueryRange(month: CalendarMonth): { gte: Date; lt: Date } {
+  const start = Date.UTC(month.year, month.monthIndex, 1);
+  const end = Date.UTC(month.year, month.monthIndex + 1, 1);
+  return {
+    gte: new Date(start - QUERY_PADDING_MS),
+    lt: new Date(end + QUERY_PADDING_MS),
+  };
+}
+
+export function dateKeyInTimeZone(value: Date | string, timeZone?: string): string {
+  const date = typeof value === 'string' ? new Date(value) : value;
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    ...(timeZone ? { timeZone } : {}),
+  });
+  const parts = formatter.formatToParts(date);
+  const year = parts.find((part) => part.type === 'year')?.value;
+  const month = parts.find((part) => part.type === 'month')?.value;
+  const day = parts.find((part) => part.type === 'day')?.value;
+
+  if (!year || !month || !day) {
+    throw new Error('Unable to resolve a calendar date.');
+  }
+
+  return `${year}-${month}-${day}`;
+}
+
+export function isDateKey(value: string | undefined): value is string {
+  return Boolean(value && DATE_KEY_PATTERN.test(value));
+}

--- a/messages/en/history.ts
+++ b/messages/en/history.ts
@@ -18,6 +18,13 @@ export const history = {
     clear: 'Clear',
     csvTitle: 'Download the CSV of sets for the active filters',
   },
+  calendar: {
+    previousMonth: 'Previous month',
+    nextMonth: 'Next month',
+    today: 'Today',
+    workoutCount: '{count, plural, one {# workout} other {# workouts}}',
+    noSessions: 'No completed workouts on this date.',
+  },
   detail: {
     downloadTcx: 'Download .tcx',
     sets: 'Sets',

--- a/messages/fr/history.ts
+++ b/messages/fr/history.ts
@@ -21,6 +21,13 @@ export const history = {
     clear: 'Effacer',
     csvTitle: 'Télécharger le CSV des séries pour les filtres actifs',
   },
+  calendar: {
+    previousMonth: 'Mois précédent',
+    nextMonth: 'Mois suivant',
+    today: 'Aujourd’hui',
+    workoutCount: '{count, plural, one {# séance} other {# séances}}',
+    noSessions: 'Aucune séance terminée à cette date.',
+  },
   detail: {
     downloadTcx: 'Télécharger le .tcx',
     sets: 'Séries',

--- a/messages/ru/history.ts
+++ b/messages/ru/history.ts
@@ -21,6 +21,14 @@ export const history = {
     clear: 'Сбросить',
     csvTitle: 'Скачать CSV подходов с учётом активных фильтров',
   },
+  calendar: {
+    previousMonth: 'Предыдущий месяц',
+    nextMonth: 'Следующий месяц',
+    today: 'Сегодня',
+    workoutCount:
+      '{count, plural, one {# тренировка} few {# тренировки} many {# тренировок} other {# тренировки}}',
+    noSessions: 'В этот день завершённых тренировок нет.',
+  },
   detail: {
     downloadTcx: 'Скачать .tcx',
     sets: 'Подходы',

--- a/tests/e2e/fit-import.spec.ts
+++ b/tests/e2e/fit-import.spec.ts
@@ -55,7 +55,7 @@ test('a lifter can import multiple FIT activities at once', async ({ page }) => 
 
   await page.goto('/history?month=2025-12&day=2025-12-01');
   await expect(page.getByRole('heading', { name: /December 1, 2025/i })).toBeVisible();
-  await expect(page.getByText('Biking')).toBeVisible();
+  await expect(page.getByText('Cycling')).toBeVisible();
 
   // The records run (April 10) shows a heart-rate-over-time chart (#254).
   await page.goto('/history?month=2026-04&day=2026-04-10');

--- a/tests/e2e/fit-import.spec.ts
+++ b/tests/e2e/fit-import.spec.ts
@@ -49,12 +49,17 @@ test('a lifter can import multiple FIT activities at once', async ({ page }) => 
   await page.getByRole('button', { name: /import 3 sessions/i }).click();
   await expect(page.getByTestId('import-preview')).not.toBeVisible();
 
-  await page.goto('/history');
-  await expect(page.getByText('March 15, 2026')).toBeVisible();
-  await expect(page.getByText('December 01, 2025')).toBeVisible();
+  await page.goto('/history?month=2026-03&day=2026-03-15');
+  await expect(page.getByRole('heading', { name: /March 15, 2026/i })).toBeVisible();
+  await expect(page.getByText('Running')).toBeVisible();
+
+  await page.goto('/history?month=2025-12&day=2025-12-01');
+  await expect(page.getByRole('heading', { name: /December 1, 2025/i })).toBeVisible();
+  await expect(page.getByText('Biking')).toBeVisible();
 
   // The records run (April 10) shows a heart-rate-over-time chart (#254).
-  await page.getByRole('link', { name: /April 10, 2026/ }).click();
+  await page.goto('/history?month=2026-04&day=2026-04-10');
+  await page.getByRole('link', { name: /Running/ }).click();
   await expect(page.getByRole('heading', { name: 'Running' })).toBeVisible();
   await expect(page.getByTestId('activity-track-chart')).toBeVisible();
 });

--- a/tests/e2e/gpx-import.spec.ts
+++ b/tests/e2e/gpx-import.spec.ts
@@ -60,8 +60,8 @@ test('a lifter can import a GPX activity as a cardio session', async ({ page }) 
   await page.getByRole('button', { name: /confirm import/i }).click();
   await expect(page.getByTestId('import-preview')).not.toBeVisible();
 
-  await page.goto('/history');
-  await expect(page.getByText('May 21, 2026')).toBeVisible();
+  await page.goto('/history?month=2026-05&day=2026-05-21');
+  await expect(page.getByRole('heading', { name: /May 21, 2026/i })).toBeVisible();
   // The history list renders the imported activity as a cardio session (name +
   // HR), not an empty "Free session - 0 kg vol" row.
   await expect(page.getByText('Running')).toBeVisible();
@@ -70,7 +70,7 @@ test('a lifter can import a GPX activity as a cardio session', async ({ page }) 
 
   // The session detail shows the cardio set with its average heart rate, plus
   // the heart-rate-over-time chart built from the trackpoints (issue #259).
-  await page.getByRole('link', { name: /May 21, 2026/ }).click();
+  await page.getByRole('link', { name: /Running/ }).click();
   await expect(page.getByRole('heading', { name: 'Running' })).toBeVisible();
   await expect(page.getByText('155 bpm')).toBeVisible();
   await expect(page.getByTestId('activity-track-chart')).toBeVisible();

--- a/tests/e2e/gymcoach-import.spec.ts
+++ b/tests/e2e/gymcoach-import.spec.ts
@@ -57,7 +57,7 @@ test('a lifter can preview and confirm a GymCoach CSV import', async ({ page }) 
   await page.getByRole('button', { name: /confirm import/i }).click();
   await expect(page.getByTestId('import-preview')).not.toBeVisible();
 
-  await page.goto('/history');
-  await expect(page.getByText('May 02, 2026')).toBeVisible();
+  await page.goto('/history?month=2026-05&day=2026-05-02');
+  await expect(page.getByRole('heading', { name: /May 2, 2026/i })).toBeVisible();
   await expect(page.getByText('2 sets')).toBeVisible();
 });

--- a/tests/e2e/hevy-import.spec.ts
+++ b/tests/e2e/hevy-import.spec.ts
@@ -56,7 +56,7 @@ test('a lifter can preview and confirm a Hevy CSV import', async ({ page }) => {
   await page.getByRole('button', { name: /confirm import/i }).click();
   await expect(page.getByTestId('import-preview')).not.toBeVisible();
 
-  await page.goto('/history');
-  await expect(page.getByText('May 02, 2026')).toBeVisible();
+  await page.goto('/history?month=2026-05&day=2026-05-02');
+  await expect(page.getByRole('heading', { name: /May 2, 2026/i })).toBeVisible();
   await expect(page.getByText('2 sets')).toBeVisible();
 });

--- a/tests/e2e/import.spec.ts
+++ b/tests/e2e/import.spec.ts
@@ -45,7 +45,7 @@ test('a lifter can preview and confirm a Strong CSV import', async ({ page }) =>
   await page.getByRole('button', { name: /confirm import/i }).click();
   await expect(page.getByTestId('import-preview')).not.toBeVisible();
 
-  await page.goto('/history');
-  await expect(page.getByText('May 02, 2026')).toBeVisible();
+  await page.goto('/history?month=2026-05&day=2026-05-02');
+  await expect(page.getByRole('heading', { name: /May 2, 2026/i })).toBeVisible();
   await expect(page.getByText('2 sets')).toBeVisible();
 });

--- a/tests/e2e/tcx-import.spec.ts
+++ b/tests/e2e/tcx-import.spec.ts
@@ -74,6 +74,6 @@ test('a lifter can import a TCX activity as a cardio session', async ({ page }) 
   // the heart-rate-over-time chart built from the trackpoints (issue #259).
   await page.getByRole('link', { name: /Running/ }).click();
   await expect(page.getByRole('heading', { name: 'Running' })).toBeVisible();
-  await expect(page.getByText('152 bpm')).toBeVisible();
+  await expect(page.getByRole('cell', { name: '152 bpm' })).toBeVisible();
   await expect(page.getByTestId('activity-track-chart')).toBeVisible();
 });

--- a/tests/e2e/tcx-import.spec.ts
+++ b/tests/e2e/tcx-import.spec.ts
@@ -62,8 +62,8 @@ test('a lifter can import a TCX activity as a cardio session', async ({ page }) 
   await page.getByRole('button', { name: /confirm import/i }).click();
   await expect(page.getByTestId('import-preview')).not.toBeVisible();
 
-  await page.goto('/history');
-  await expect(page.getByText('May 20, 2026')).toBeVisible();
+  await page.goto('/history?month=2026-05&day=2026-05-20');
+  await expect(page.getByRole('heading', { name: /May 20, 2026/i })).toBeVisible();
   // The history list renders it as a cardio activity (name + HR), not an empty
   // "Free session" row.
   await expect(page.getByText('Running')).toBeVisible();
@@ -72,7 +72,7 @@ test('a lifter can import a TCX activity as a cardio session', async ({ page }) 
 
   // The session detail shows the cardio set with its average heart rate, plus
   // the heart-rate-over-time chart built from the trackpoints (issue #259).
-  await page.getByRole('link', { name: /May 20, 2026/ }).click();
+  await page.getByRole('link', { name: /Running/ }).click();
   await expect(page.getByRole('heading', { name: 'Running' })).toBeVisible();
   await expect(page.getByText('152 bpm')).toBeVisible();
   await expect(page.getByTestId('activity-track-chart')).toBeVisible();


### PR DESCRIPTION
## Motivation

Workout history is currently a reverse-chronological list. This adds a month calendar so completed training days are visible at a glance and a user can inspect the sessions for a specific date without leaving the history view.

## What changed

- replace the history list with a six-week month calendar and per-day session counts
- keep program filtering while month navigation lives in the calendar header
- show the selected day's sessions with the existing strength/cardio summary data
- preserve month/day/program context in session links
- add EN/FR/RU calendar copy
- add helper and component regression tests for month boundaries, workout-day marking, day selection, and month navigation

## Tests

- `npx vitest run lib/history-calendar.test.ts components/history/history-calendar.test.tsx` - 8/8 passed
- `npm run typecheck` - passed
- `npm run lint` - passed (existing unrelated `lib/import/gpx.ts` unused-function warning remains)
- `bash scripts/verify.sh` on Linux/ext4 with Node 22.22.1 - 108 test files / 1039 tests passed, production build passed

The Windows/NTFS full-gate run hit only the repository's existing progress-photo path/mode assumptions; the same candidate passed the complete gate on Linux/ext4.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced the session list with a month-based workout calendar.
  * Added month navigation, a “Today” action, workout-day indicators, and daily session details.
  * Added session metrics including sets, volume, duration, cardio distance, and heart rate.
  * Preserved active filters while navigating months and viewing session details.
  * Added English, French, and Russian calendar translations.

* **Bug Fixes**
  * Improved calendar date handling across time zones and month boundaries.

* **Tests**
  * Added coverage for calendar navigation, filtering, date selection, and calendar utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->