### PR TITLE
fix: refresh stale PWA clients after deploy

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { NextIntlClientProvider } from 'next-intl';
 import { getLocale, getMessages, getTranslations } from 'next-intl/server';
 import { Toaster } from '@/components/ui/sonner';
 import { ThemeProvider } from '@/components/shared/theme-provider';
+import { PwaUpdateManager } from '@/components/shared/pwa-update-manager';
 import './globals.css';
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -47,6 +48,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
       <body className="min-h-screen bg-background font-sans text-foreground antialiased">
         <NextIntlClientProvider messages={messages}>
           <ThemeProvider>
+            <PwaUpdateManager />
             {children}
             <Toaster richColors position="top-center" />
           </ThemeProvider>

--- a/components/shared/pwa-update-manager.test.tsx
+++ b/components/shared/pwa-update-manager.test.tsx
@@ -1,0 +1,60 @@
+import { render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { isServiceWorkerUpdate, PwaUpdateManager } from './pwa-update-manager';
+
+const originalServiceWorker = Object.getOwnPropertyDescriptor(navigator, 'serviceWorker');
+
+afterEach(() => {
+  if (originalServiceWorker) {
+    Object.defineProperty(navigator, 'serviceWorker', originalServiceWorker);
+  } else {
+    Reflect.deleteProperty(navigator, 'serviceWorker');
+  }
+  vi.restoreAllMocks();
+});
+
+function installServiceWorkerMock(controller: ServiceWorker | null = {} as ServiceWorker) {
+  const update = vi.fn().mockResolvedValue(undefined);
+  const registration = { update } as unknown as ServiceWorkerRegistration;
+  const listeners = new Map<string, EventListener>();
+  const serviceWorker = {
+    controller,
+    ready: Promise.resolve(registration),
+    getRegistration: vi.fn().mockResolvedValue(registration),
+    addEventListener: vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+      if (typeof listener === 'function') listeners.set(type, listener);
+    }),
+    removeEventListener: vi.fn(),
+  } as unknown as ServiceWorkerContainer;
+
+  Object.defineProperty(navigator, 'serviceWorker', {
+    configurable: true,
+    value: serviceWorker,
+  });
+
+  return { serviceWorker, update, listeners };
+}
+
+describe('PwaUpdateManager', () => {
+  it('checks for an updated worker and listens for controller changes', async () => {
+    const { serviceWorker, update } = installServiceWorkerMock();
+    const view = render(<PwaUpdateManager />);
+
+    await waitFor(() => expect(update).toHaveBeenCalled());
+    expect(serviceWorker.addEventListener).toHaveBeenCalledWith(
+      'controllerchange',
+      expect.any(Function),
+    );
+
+    view.unmount();
+    expect(serviceWorker.removeEventListener).toHaveBeenCalledWith(
+      'controllerchange',
+      expect.any(Function),
+    );
+  });
+
+  it('distinguishes an update from the initial service-worker install', () => {
+    expect(isServiceWorkerUpdate({} as ServiceWorker)).toBe(true);
+    expect(isServiceWorkerUpdate(null)).toBe(false);
+  });
+});

--- a/components/shared/pwa-update-manager.test.tsx
+++ b/components/shared/pwa-update-manager.test.tsx
@@ -1,17 +1,29 @@
-import { render, waitFor } from '@testing-library/react';
+import { act, cleanup, render, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { isServiceWorkerUpdate, PwaUpdateManager } from './pwa-update-manager';
+import { PwaUpdateManager } from './pwa-update-manager';
 
 const originalServiceWorker = Object.getOwnPropertyDescriptor(navigator, 'serviceWorker');
+const originalVisibilityState = Object.getOwnPropertyDescriptor(document, 'visibilityState');
 
 afterEach(() => {
+  cleanup();
   if (originalServiceWorker) {
     Object.defineProperty(navigator, 'serviceWorker', originalServiceWorker);
   } else {
     Reflect.deleteProperty(navigator, 'serviceWorker');
   }
+  if (originalVisibilityState) {
+    Object.defineProperty(document, 'visibilityState', originalVisibilityState);
+  }
   vi.restoreAllMocks();
 });
+
+function setVisibilityState(state: DocumentVisibilityState) {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    value: state,
+  });
+}
 
 function installServiceWorkerMock(controller: ServiceWorker | null = {} as ServiceWorker) {
   const update = vi.fn().mockResolvedValue(undefined);
@@ -36,9 +48,11 @@ function installServiceWorkerMock(controller: ServiceWorker | null = {} as Servi
 }
 
 describe('PwaUpdateManager', () => {
-  it('checks for an updated worker and listens for controller changes', async () => {
+  it('checks for updates and removes all listeners on unmount', async () => {
     const { serviceWorker, update } = installServiceWorkerMock();
-    const view = render(<PwaUpdateManager />);
+    const documentRemove = vi.spyOn(document, 'removeEventListener');
+    const windowRemove = vi.spyOn(window, 'removeEventListener');
+    const view = render(<PwaUpdateManager reloadPage={vi.fn()} />);
 
     await waitFor(() => expect(update).toHaveBeenCalled());
     expect(serviceWorker.addEventListener).toHaveBeenCalledWith(
@@ -47,14 +61,64 @@ describe('PwaUpdateManager', () => {
     );
 
     view.unmount();
+
     expect(serviceWorker.removeEventListener).toHaveBeenCalledWith(
       'controllerchange',
       expect.any(Function),
     );
+    expect(documentRemove).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
+    expect(windowRemove).toHaveBeenCalledWith('online', expect.any(Function));
   });
 
-  it('distinguishes an update from the initial service-worker install', () => {
-    expect(isServiceWorkerUpdate({} as ServiceWorker)).toBe(true);
-    expect(isServiceWorkerUpdate(null)).toBe(false);
+  it('ignores the initial controller install but reloads for a replacement controller', () => {
+    const initial = installServiceWorkerMock(null);
+    const reloadInitial = vi.fn();
+    const firstView = render(<PwaUpdateManager reloadPage={reloadInitial} />);
+
+    (initial.serviceWorker as { controller: ServiceWorker | null }).controller =
+      {} as ServiceWorker;
+    act(() => initial.listeners.get('controllerchange')?.(new Event('controllerchange')));
+    expect(reloadInitial).not.toHaveBeenCalled();
+    firstView.unmount();
+
+    const replacement = installServiceWorkerMock({} as ServiceWorker);
+    const reloadReplacement = vi.fn();
+    render(<PwaUpdateManager reloadPage={reloadReplacement} />);
+
+    act(() => replacement.listeners.get('controllerchange')?.(new Event('controllerchange')));
+    expect(reloadReplacement).toHaveBeenCalledTimes(1);
+  });
+
+  it('defers a replacement reload while hidden and reloads when visibility returns', () => {
+    setVisibilityState('hidden');
+    const { listeners } = installServiceWorkerMock({} as ServiceWorker);
+    const reload = vi.fn();
+    render(<PwaUpdateManager reloadPage={reload} />);
+
+    act(() => listeners.get('controllerchange')?.(new Event('controllerchange')));
+    expect(reload).not.toHaveBeenCalled();
+
+    setVisibilityState('visible');
+    act(() => document.dispatchEvent(new Event('visibilitychange')));
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('checks for updates again when the page becomes visible or comes online', async () => {
+    setVisibilityState('hidden');
+    const { serviceWorker, update } = installServiceWorkerMock({} as ServiceWorker);
+    render(<PwaUpdateManager reloadPage={vi.fn()} />);
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(1));
+    update.mockClear();
+
+    setVisibilityState('visible');
+    act(() => document.dispatchEvent(new Event('visibilitychange')));
+    await waitFor(() => expect(serviceWorker.getRegistration).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(1));
+
+    (serviceWorker.getRegistration as ReturnType<typeof vi.fn>).mockClear();
+    update.mockClear();
+    act(() => window.dispatchEvent(new Event('online')));
+    await waitFor(() => expect(serviceWorker.getRegistration).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(1));
   });
 });

--- a/components/shared/pwa-update-manager.tsx
+++ b/components/shared/pwa-update-manager.tsx
@@ -6,7 +6,15 @@ export function isServiceWorkerUpdate(previousController: ServiceWorker | null):
   return previousController !== null;
 }
 
-export function PwaUpdateManager() {
+interface Props {
+  reloadPage?: () => void;
+}
+
+function reloadCurrentPage() {
+  window.location.reload();
+}
+
+export function PwaUpdateManager({ reloadPage = reloadCurrentPage }: Props = {}) {
   useEffect(() => {
     if (!('serviceWorker' in navigator)) return;
 
@@ -22,7 +30,7 @@ export function PwaUpdateManager() {
       }
 
       reloading = true;
-      window.location.reload();
+      reloadPage();
     }
 
     function handleControllerChange() {
@@ -70,7 +78,7 @@ export function PwaUpdateManager() {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
       window.removeEventListener('online', handleOnline);
     };
-  }, []);
+  }, [reloadPage]);
 
   return null;
 }

--- a/components/shared/pwa-update-manager.tsx
+++ b/components/shared/pwa-update-manager.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export function isServiceWorkerUpdate(previousController: ServiceWorker | null): boolean {
+  return previousController !== null;
+}
+
+export function PwaUpdateManager() {
+  useEffect(() => {
+    if (!('serviceWorker' in navigator)) return;
+
+    let controller = navigator.serviceWorker.controller;
+    let reloadPending = false;
+    let reloading = false;
+
+    function reloadForUpdate() {
+      if (reloading) return;
+      if (document.visibilityState === 'hidden') {
+        reloadPending = true;
+        return;
+      }
+
+      reloading = true;
+      window.location.reload();
+    }
+
+    function handleControllerChange() {
+      // A controller appearing for the first time is the initial PWA install,
+      // not an update to a page that is already running.
+      if (!isServiceWorkerUpdate(controller)) {
+        controller = navigator.serviceWorker.controller;
+        return;
+      }
+
+      reloadForUpdate();
+    }
+
+    async function checkForUpdate() {
+      try {
+        const registration = await navigator.serviceWorker.getRegistration();
+        await registration?.update();
+      } catch {
+        // Updates are best-effort; offline mode continues through Workbox caches.
+      }
+    }
+
+    function handleVisibilityChange() {
+      if (document.visibilityState !== 'visible') return;
+      if (reloadPending) {
+        reloadForUpdate();
+        return;
+      }
+      void checkForUpdate();
+    }
+
+    function handleOnline() {
+      void checkForUpdate();
+    }
+
+    navigator.serviceWorker.addEventListener('controllerchange', handleControllerChange);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('online', handleOnline);
+    void navigator.serviceWorker.ready
+      .then((registration) => registration.update())
+      .catch(() => {});
+
+    return () => {
+      navigator.serviceWorker.removeEventListener('controllerchange', handleControllerChange);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('online', handleOnline);
+    };
+  }, []);
+
+  return null;
+}

--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,7 @@ const withPWA = require('@ducanh2912/next-pwa').default({
   disable: process.env.NODE_ENV === 'development',
   workboxOptions: {
     skipWaiting: true,
+    clientsClaim: true,
     // Do not pre-cache API routes: too volatile and auth-dependent.
     exclude: [/middleware-manifest\.json$/, /app-build-manifest\.json$/],
     runtimeCaching: [


### PR DESCRIPTION
## Motivation
Installed PWA clients can keep running an old frontend bundle after a deploy even when a new service worker is available.

## What changed
- claim existing clients when a new Workbox service worker activates
- add a small client-side update manager that checks for updates on startup, visibility restore, and reconnect
- reload an already-controlled visible client after controllerchange, while avoiding a reload on the initial service-worker install
- cover controller replacement, hidden-tab deferral, reconnect/visibility checks, and listener cleanup

## Tests
- focused PWA update-manager tests: 4/4 passed
- full Linux/ext4 gate: 107 unit files / 1035 tests; 32 integration files / 298 tests; Playwright 19/19; lint, typecheck, and production build passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection and application of available app updates.
  * Updates are checked when the app becomes visible or connectivity is restored.
  * Update reloads are deferred while a live session is active or the page is hidden, helping prevent interruptions.
  * Added safeguards to prevent repeated reloads during update processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->