### PR TITLE
fix: keep settings locale hydration stable

### DIFF
--- a/components/settings/mcp-section.test.tsx
+++ b/components/settings/mcp-section.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { McpSection } from './mcp-section';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('McpSection', () => {
+  it('formats the last-used date through the app formatter', () => {
+    const browserDateFormatter = vi
+      .spyOn(Date.prototype, 'toLocaleDateString')
+      .mockImplementation(() => {
+        throw new Error('Browser-default date formatting must not run during hydration.');
+      });
+
+    render(
+      <McpSection
+        initialTokens={[
+          {
+            id: 'token-1',
+            name: 'ChatGPT',
+            tokenPrefix: 'gmc_test',
+            canWrite: true,
+            createdAt: '2026-01-01T00:00:00.000Z',
+            lastUsedAt: '2026-01-02T23:30:00.000Z',
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText(/used 01\/02\/2026/u)).toBeInTheDocument();
+    expect(browserDateFormatter).not.toHaveBeenCalled();
+  });
+});

--- a/components/settings/mcp-section.tsx
+++ b/components/settings/mcp-section.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { useTranslations } from 'next-intl';
+import { useFormatter, useTranslations } from 'next-intl';
 import { Copy, KeyRound, Loader2, Plug, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
@@ -24,6 +24,7 @@ interface Props {
 
 export function McpSection({ initialTokens }: Props) {
   const t = useTranslations('settings.mcp');
+  const format = useFormatter();
   const [tokens, setTokens] = useState(initialTokens);
   const [name, setName] = useState('ChatGPT');
   // Least privilege: new connections start read-only; the user opts in to write.
@@ -146,7 +147,13 @@ export function McpSection({ initialTokens }: Props) {
                   <p className="text-xs text-muted-foreground">
                     {token.canWrite ? t('readWrite') : t('readOnly')}
                     {token.lastUsedAt
-                      ? ` · ${t('lastUsed', { date: new Date(token.lastUsedAt).toLocaleDateString() })}`
+                      ? ` · ${t('lastUsed', {
+                          date: format.dateTime(new Date(token.lastUsedAt), {
+                            day: '2-digit',
+                            month: '2-digit',
+                            year: 'numeric',
+                          }),
+                        })}`
                       : ''}
                   </p>
                 </div>


### PR DESCRIPTION
## Motivation
The MCP settings list currently formats last-used dates with Date.toLocaleDateString(), which depends on the browser default locale and can produce server/client locale differences during hydration.

## What changed
- format MCP token last-used dates with next-intl useFormatter() instead of the browser default locale
- use an explicit day/month/year date shape so the rendered value follows the active app locale deterministically
- add a regression test that fails if Date.toLocaleDateString() is used during rendering

## Tests
- focused McpSection test: 1/1 passed
- full Linux/ext4 gate: 107 unit files / 1032 tests; 32 integration files / 298 tests; Playwright 19/19; lint, typecheck, and production build passed